### PR TITLE
Remove COURSIER_CACHE from env

### DIFF
--- a/mif/src/Prepare.scala
+++ b/mif/src/Prepare.scala
@@ -137,7 +137,6 @@ class PrepareRunner(parameter: PrepareParams) {
     val env: Map[String, String] = Map(
       // Maven mirror sometime contains invalid dependency and make us hard to debug the problem, use maven central only.
       "COURSIER_REPOSITORIES" -> "ivy2local|central",
-      "COURSIER_CACHE" -> ""
     ).tap(
       _.foreach(e =>
         if sys.env.get(e._1).isDefined then


### PR DESCRIPTION
* Updated the `COURSIER_CACHE` environment variable to point to the new `ivyDLCache` directory, providing an isolated cache path for Coursier.

This can fix #18 