### PR TITLE
Fix pipe-operator compatibility issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        extra-conf: "extra-experimental-features = pipe-operators"
     - name: "Set Matrix"
       id: set-matrix
       run: |
@@ -33,8 +31,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        extra-conf: "extra-experimental-features = pipe-operators"
     - run: |
         nix build '.#millVersions.${{ matrix.version }}'
 
@@ -43,8 +39,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        extra-conf: "extra-experimental-features = pipe-operators"
     - name: Integration test
       run: |
         nix build '.#ci-test' --max-jobs auto

--- a/nix/mill-build.nix
+++ b/nix/mill-build.nix
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         let
           v = finalAttrs.version;
         in
-        if (major v) == "1" || ((majorMinor v) == "0.12" && (patch v |> toInt) >= 14) then
+        if (major v) == "1" || ((majorMinor v) == "0.12" && (toInt (patch v)) >= 14) then
           "mill-dist${suffix}-${finalAttrs.version}.exe"
         else
           "mill-dist-${finalAttrs.version}.jar";


### PR DESCRIPTION
## Summary

This PR fixes the pipe-operator compatibility issue reported in #27.

The codebase was using Nix's experimental `pipe-operators` feature, which caused compatibility issues for users without this experimental feature enabled.

## Changes

- **nix/mill-build.nix**: Replaced `patch v |> toInt` with `toInt (patch v)` - using standard function application syntax
- **.github/workflows/ci.yml**: Removed `extra-experimental-features = pipe-operators` configuration from all CI jobs

## Testing

All CI jobs should pass without requiring experimental Nix features.

## Related Issue

Fixes #27