### PR TITLE
Skip CI on direct master pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   gen-build-matrix:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Summary
Add condition to skip CI workflow when pushing directly to master branch.

## Changes
- Added `if: github.event_name == 'pull_request'` condition to the `gen-build-matrix` job
- CI will now only run on pull requests, not on direct pushes to master

## Benefits
- Prevents duplicate CI runs when merging PRs
- Prevents CI runs when rebasing master
- Saves CI resources and reduces noise