### PR TITLE
Fix broken symlinks and add Nix minimum version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "Generic devshell setup";
 
+  nixConfig.minimumVersion = "2.28";
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts = {

--- a/mif/src/Prepare.scala
+++ b/mif/src/Prepare.scala
@@ -14,7 +14,7 @@ class WorkdirInfo(projectPath: os.Path, deleteOnExit: Boolean) {
   def copyFix(
       from: os.Path,
       to: os.Path,
-      followLinks: Boolean = true,
+      followLinks: Boolean = false,
       replaceExisting: Boolean = false,
       copyAttributes: Boolean = false,
       createFolders: Boolean = false,

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ into small pieces.
 
 ## Requirements
 
+* Nix >= 2.28
 * mill 1.1.0
 
 ## Usage


### PR DESCRIPTION
Summary of changes:
- Fix #30:  Add Nix minimum version requirement (2.28) to flake.nix and README
- Fix #31: Change followLinks default to false to handle broken symlinks gracefully