### PR TITLE
Fix mill-wrapper to handle read-only sources gracefully

### DIFF
--- a/.github/integration/chisel-lock.nix
+++ b/.github/integration/chisel-lock.nix
@@ -6318,6 +6318,16 @@ in
     installPath = "https/repo1.maven.org/maven2/com/google/code/gson/gson-parent/2.13.2";
   };
 
+  "io.get-coursier.jvm.indices_index-linux-amd64-0.0.4-125-77e06d" = fetchMaven {
+    name = "io.get-coursier.jvm.indices_index-linux-amd64-0.0.4-125-77e06d";
+    urls = [
+      "https://repo1.maven.org/maven2/io/get-coursier/jvm/indices/index-linux-amd64/0.0.4-125-77e06d/index-linux-amd64-0.0.4-125-77e06d.jar"
+      "https://repo1.maven.org/maven2/io/get-coursier/jvm/indices/index-linux-amd64/0.0.4-125-77e06d/index-linux-amd64-0.0.4-125-77e06d.pom"
+    ];
+    hash = "sha256-C4EJNuRO4o1LUqOuaXYdvrv4ndGRDmRipabBoqDm7WA=";
+    installPath = "https/repo1.maven.org/maven2/io/get-coursier/jvm/indices/index-linux-amd64/0.0.4-125-77e06d";
+  };
+
   "io.github.alexarchambault.native-terminal_native-terminal-no-ffm-0.0.9.1" = fetchMaven {
     name = "io.github.alexarchambault.native-terminal_native-terminal-no-ffm-0.0.9.1";
     urls = [
@@ -6574,4 +6584,4 @@ in
   };
 
 }
-# Project Source Hash:sha256-TU3AlrbWcps6zYbfLD677jfZ/UcBO1M9FcG1nb98Nhk=
+# Cache Identifier:sha256-TU3AlrbWcps6zYbfLD677jfZ/UcBO1M9FcG1nb98Nhk=@Mill Build Tool version 1.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - name: Integration test
       run: |
+        # Run bump to regenerate lock file
+        nix run '.#ci-test.bump'
+
+        # Check that chisel-lock.nix is not modified (forces dependency review)
+        if ! git diff --exit-code .github/integration/chisel-lock.nix; then
+          echo "Error: chisel-lock.nix has been modified by bump"
+          echo "Please review dependency changes and commit the updated lock file"
+          exit 1
+        fi
+
         # First build
         nix build '.#ci-test' --max-jobs auto
         FIRST_HASH="$(nix hash path --sri --algo sha256 --mode nar "$(realpath ./result)")"

--- a/mif/src/Mif.scala
+++ b/mif/src/Mif.scala
@@ -159,12 +159,18 @@ object MillIvyFetcher {
       case Array(hash, millVer) => Some((hash, millVer))
       case _                    => None
 
-  private def getMillVersion(projectDir: os.Path): String =
-    ProcessRunner
-      .run(Seq("mill", "--version"), cwd = projectDir)
-      .out
-      .linesIterator
-      .next()
+  private def getMillVersion(projectDir: os.Path): String = {
+    val tempDir = os.temp.dir(prefix = s"${projectDir.last}_version_check_")
+    try {
+      ProcessRunner
+        .run(Seq("mill", "--version"), cwd = tempDir)
+        .out
+        .linesIterator
+        .next()
+    } finally {
+      os.remove.all(tempDir)
+    }
+  }
 
   def main(args: Array[String]): Unit =
     ParserForMethods(this).runOrExit(args.toSeq)

--- a/nix/mill-wrapper.sh
+++ b/nix/mill-wrapper.sh
@@ -9,8 +9,22 @@ readonly VERSION_FILE=".mill-jvm-version"
 FORCE_SYSTEM_JRE="${FORCE_SYSTEM_JRE:-}"
 
 modified_file=""
+skipped_readonly=""
+
+isWritable() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    [[ -w "$file" ]]
+  else
+    [[ -w "$(dirname "$file")" ]]
+  fi
+}
 
 patchHeader() {
+  if ! isWritable "$MILL_FILE"; then
+    skipped_readonly="$MILL_FILE"
+    return
+  fi
   tmp=$(mktemp)
   echo "//| mill-jvm-version: system" > "$tmp"
   cat "$MILL_FILE" >> "$tmp"
@@ -27,8 +41,12 @@ elif [[ -f "$MILL_FILE" ]]; then
     fi
   fi
 elif [[ ! -f "$VERSION_FILE" ]]; then
-  echo "system" > "$VERSION_FILE"
-  modified_file="$VERSION_FILE"
+  if isWritable "$VERSION_FILE"; then
+    echo "system" > "$VERSION_FILE"
+    modified_file="$VERSION_FILE"
+  else
+    skipped_readonly="$VERSION_FILE"
+  fi
 fi
 
 if [[ -n "$modified_file" ]]; then
@@ -36,6 +54,13 @@ if [[ -n "$modified_file" ]]; then
 >> [mill-wrapper] Modified: $modified_file
 >> [mill-wrapper] Note: This modification exists because you are using a patched version of mill
 >> [mill-wrapper] so that mill can use the system JDK instead of its vendor version.
+EOF
+fi
+
+if [[ -n "$skipped_readonly" ]]; then
+  cat >&2 <<EOF
+>> [mill-wrapper] Warning: Skipped modifying $skipped_readonly (read-only)
+>> [mill-wrapper] Mill will use its default JVM version instead of system JRE
 EOF
 fi
 


### PR DESCRIPTION
Fixes Permission Denied errors when running on read-only sources (e.g., Nix store paths) by checking writability before modifying build.mill or .mill-jvm-version files. Skips modifications gracefully and continues execution.