### PR TITLE
Add Maven relay

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+    types: [ "opened", "synchronize", "reopened", "ready_for_review" ]
 
 permissions:
   contents: read
 
 jobs:
   format-check:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,7 +21,7 @@ jobs:
       run: nix fmt -- --ci
 
   gen-build-matrix:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -32,6 +34,7 @@ jobs:
         nix eval --json ".#millVersions.allVersions" | nix run '.#jq' -- -rc '"matrix=" + ({version: .} | tostring)' > "$GITHUB_OUTPUT"
 
   build-mill-versions:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     needs: [gen-build-matrix]
     runs-on: ubuntu-latest
     strategy:
@@ -45,7 +48,7 @@ jobs:
         result/bin/mill --version
 
   integration-test:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/mif.yml
+++ b/.github/workflows/mif.yml
@@ -1,0 +1,21 @@
+name: MIF
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+    types: [ "opened", "synchronize", "reopened", "ready_for_review" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - name: Run MIF tests
+      run: nix develop --command mill mif.test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ result
 .metals/
 .bloop/
 chisel/
+.direnv/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = "3.7.15"
-runner.dialect = scala213
+runner.dialect = scala3
 fileOverride {
   "glob:**/mif/src/**" {
      runner.dialect = scala3

--- a/build.mill
+++ b/build.mill
@@ -14,11 +14,26 @@ trait MIFModule extends ScalaModule with ScalafmtModule with PublishModule {
   val mainargs = mvn"com.lihaoyi::mainargs:0.5.0"
   val oslib    = mvn"com.lihaoyi::os-lib:0.10.0"
   val upickle  = mvn"com.lihaoyi::upickle:3.3.1"
+  val cask     = mvn"com.lihaoyi::cask:0.11.3"
+  val requests = mvn"com.lihaoyi::requests:0.9.2"
+  val scalasql = mvn"com.lihaoyi::scalasql:0.3.1"
+  val sqlite   = mvn"org.xerial:sqlite-jdbc:3.46.1.0"
+  val slf4jNop = mvn"org.slf4j:slf4j-nop:2.0.13"
   val coursier = mvn"io.get-coursier:coursier_2.13:2.1.25-M3"
 
   def scalaVersion     = "3.6.4"
   def scalacOptions    = Seq("-new-syntax", "-deprecation")
-  override def mvnDeps = Seq(mainargs, oslib, upickle, coursier)
+  override def mvnDeps = Seq(
+    mainargs,
+    oslib,
+    upickle,
+    cask,
+    requests,
+    scalasql,
+    sqlite,
+    slf4jNop,
+    coursier
+  )
 
   def pomSettings = PomSettings(
     description = "MIF is a project to help you generate Nix lock from a Mill project",

--- a/docs/cask-0.11.3.md
+++ b/docs/cask-0.11.3.md
@@ -1,0 +1,2405 @@
+# Cask 0.11.3 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `509` non-private declaration signatures from `26` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::cask:0.11.3`
+- Upstream docs: https://com-lihaoyi.github.io/cask/
+- Source artifacts included:
+  - `com.lihaoyi:cask_3:0.11.3`
+
+## Common imports
+
+```scala
+import cask.*
+```
+
+## Usage notes
+
+Lightweight HTTP routing framework used by the Maven relay server. APIs include route annotations, `Routes`, `Main`, `Request`, `Response`, static files, forms, JSON, and websockets.
+
+```scala
+object App extends cask.Main:
+  override def host: String = "127.0.0.1"
+  override def port: Int = 8081
+
+  @cask.get("/")
+  def hello() = cask.Response("ok\n", statusCode = 200)
+
+  @cask.route("/api", methods = Seq("get", "head"))
+  def api(request: cask.Request) =
+    cask.Response(s"method=${request.exchange.getRequestMethod}\n")
+
+  initialize()
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:cask_3:0.11.3`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/cask_3/0.11.3/cask_3-0.11.3-sources.jar
+
+#### `cask/decorators/compress.scala`
+
+```scala
+class compress extends cask.RawDecorator
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate) = ...
+```
+
+#### `cask/endpoints/FormEndpoint.scala`
+
+```scala
+sealed trait FormReader[T] extends ArgReader[Seq[FormEntry], T, Request]
+```
+
+```scala
+object FormReader
+```
+
+```scala
+implicit def paramFormReader[T: QueryParamReader]: FormReader[T] = ...
+```
+
+```scala
+implicit def formEntryReader: FormReader[FormEntry] = ...
+```
+
+```scala
+implicit def formEntriesReader: FormReader[Seq[FormEntry]] = ...
+```
+
+```scala
+implicit def formValueReader: FormReader[FormValue] = ...
+```
+
+```scala
+implicit def formValuesReader: FormReader[Seq[FormValue]] = ...
+```
+
+```scala
+implicit def formFileReader: FormReader[FormFile] = ...
+```
+
+```scala
+implicit def formFilesReader: FormReader[Seq[FormFile]] = ...
+```
+
+```scala
+class postForm(val path: String, override val subpath: Boolean = false)
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+def wrapFunction(ctx: Request,
+                       delegate: Delegate): Result[Response.Raw] = ...
+```
+
+```scala
+def wrapPathSegment(s: String): Seq[FormEntry] = ...
+```
+
+#### `cask/endpoints/JsonEndpoint.scala`
+
+```scala
+sealed trait JsReader[T] extends ArgReader[ujson.Value, T, cask.model.Request]
+```
+
+```scala
+object JsReader
+```
+
+```scala
+implicit def defaultJsReader[T: upickle.default.Reader]: JsReader[T] = ...
+```
+
+```scala
+implicit def paramReader[T: ParamReader]: JsReader[T] = ...
+```
+
+```scala
+trait JsonData extends Response.Data
+```
+
+```scala
+object JsonData extends DataCompanion[JsonData]
+```
+
+```scala
+implicit class JsonDataImpl[T: upickle.default.Writer](t: T) extends JsonData
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+def write(out: OutputStream) = ...
+```
+
+```scala
+class postJsonCached(path: String, subpath: Boolean = false) extends postJsonBase(path, subpath, true)
+```
+
+```scala
+class postJson(path: String, subpath: Boolean = false) extends postJsonBase(path, subpath, false)
+```
+
+```scala
+abstract class postJsonBase(val path: String, override val subpath: Boolean = false, cacheBody: Boolean = false)
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate): Result[Response.Raw] = ...
+```
+
+```scala
+def wrapPathSegment(s: String): ujson.Value = ...
+```
+
+```scala
+class getJson(val path: String, override val subpath: Boolean = false)
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate): Result[Response.Raw] = ...
+```
+
+```scala
+def wrapPathSegment(s: String) = ...
+```
+
+#### `cask/endpoints/ParamReader.scala`
+
+```scala
+abstract class ParamReader[T] extends ArgReader[Unit, T, cask.model.Request]
+```
+
+```scala
+def arity: Int
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Unit): T
+```
+
+```scala
+object ParamReader
+```
+
+```scala
+class NilParam[T](f: (Request, String) => T) extends ParamReader[T]
+```
+
+```scala
+def arity = ...
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Unit): T = ...
+```
+
+```scala
+implicit object HttpExchangeParam extends NilParam[HttpServerExchange]((ctx, label) => ctx.exchange)
+```
+
+```scala
+implicit object FormDataParam extends NilParam[FormData]((ctx, label) =>
+    FormParserFactory.builder().build().createParser(ctx.exchange).parseBlocking()
+  )
+```
+
+```scala
+implicit object RequestParam extends NilParam[Request]((ctx, label) => ctx)
+```
+
+```scala
+implicit object CookieParam extends NilParam[Cookie]((ctx, label) =>
+    Cookie.fromUndertow(ctx.exchange.getRequestCookies().get(label))
+  )
+```
+
+```scala
+implicit object QueryParams extends ParamReader[cask.model.QueryParams]
+```
+
+```scala
+def arity: Int = ...
+```
+
+```scala
+override def unknownQueryParams = ...
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Unit) = ...
+```
+
+```scala
+implicit object RemainingPathSegments extends ParamReader[cask.model.RemainingPathSegments]
+```
+
+```scala
+def arity: Int = ...
+```
+
+```scala
+override def remainingPathSegments = ...
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Unit) = ...
+```
+
+#### `cask/endpoints/StaticEndpoints.scala`
+
+```scala
+object StaticUtil
+```
+
+```scala
+def makePathAndContentType(t: String, ctx: Request) = ...
+```
+
+```scala
+class staticFiles(val path: String, headers: Seq[(String, String)] = Nil) extends HttpEndpoint[String, Seq[String]]
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+override def subpath = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate) = ...
+```
+
+```scala
+def wrapPathSegment(s: String): Seq[String] = ...
+```
+
+```scala
+class staticResources(val path: String,
+                      resourceRoot: ClassLoader = classOf[staticResources].getClassLoader,
+                      headers: Seq[(String, String)] = Nil)
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+override def subpath = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate) = ...
+```
+
+```scala
+def wrapPathSegment(s: String): Seq[String] = ...
+```
+
+#### `cask/endpoints/WebEndpoints.scala`
+
+```scala
+trait WebEndpoint extends HttpEndpoint[Response.Raw, Seq[String]]
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+def wrapFunction(ctx: Request,
+                       delegate: Delegate): Result[Response.Raw] = ...
+```
+
+```scala
+def wrapPathSegment(s: String) = ...
+```
+
+```scala
+object WebEndpoint
+```
+
+```scala
+def buildMapFromQueryParams(ctx: Request) = ...
+```
+
+```scala
+class get(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+class post(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+class put(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+class patch(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+class delete(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+class route(val path: String, val methods: Seq[String], override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+class options(val path: String, override val subpath: Boolean = false) extends WebEndpoint
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+abstract class QueryParamReader[T]
+  extends ArgReader[Seq[String], T, cask.model.Request]
+```
+
+```scala
+def arity: Int
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Seq[String]): T
+```
+
+```scala
+object QueryParamReader
+```
+
+```scala
+class SimpleParam[T](f: String => T) extends QueryParamReader[T]
+```
+
+```scala
+def arity = ...
+```
+
+```scala
+def read(ctx: cask.model.Request, label: String, v: Seq[String]): T = ...
+```
+
+```scala
+implicit object StringParam extends SimpleParam[String](x => x)
+```
+
+```scala
+implicit object BooleanParam extends SimpleParam[Boolean](_.toBoolean)
+```
+
+```scala
+implicit object ByteParam extends SimpleParam[Byte](_.toByte)
+```
+
+```scala
+implicit object ShortParam extends SimpleParam[Short](_.toShort)
+```
+
+```scala
+implicit object IntParam extends SimpleParam[Int](_.toInt)
+```
+
+```scala
+implicit object LongParam extends SimpleParam[Long](_.toLong)
+```
+
+```scala
+implicit object DoubleParam extends SimpleParam[Double](_.toDouble)
+```
+
+```scala
+implicit object FloatParam extends SimpleParam[Float](_.toFloat)
+```
+
+```scala
+implicit def SeqParam[T: QueryParamReader]: QueryParamReader[Seq[T]] = ...
+```
+
+```scala
+implicit def OptionParam[T: QueryParamReader]: QueryParamReader[Option[T]] = ...
+```
+
+```scala
+implicit def paramReader[T: ParamReader]: QueryParamReader[T] = ...
+```
+
+#### `cask/endpoints/WebSocketEndpoint.scala`
+
+```scala
+sealed trait WebsocketResult
+```
+
+```scala
+object WebsocketResult
+```
+
+```scala
+implicit class Response[T](value0: cask.model.Response[T])
+```
+
+```scala
+def value = ...
+```
+
+```scala
+implicit class Listener(val value: WebSocketConnectionCallback) extends WebsocketResult
+```
+
+```scala
+class websocket(val path: String, override val subpath: Boolean = false)
+```
+
+```scala
+val methods = ...
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+```scala
+type OuterReturned = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate) = ...
+```
+
+```scala
+def wrapPathSegment(s: String): Seq[String] = ...
+```
+
+```scala
+case class WsHandler(f: WsChannelActor => castor.Actor[Ws.Event])
+```
+
+```scala
+class WsChannelActor(channel: WebSocketChannel)
+```
+
+```scala
+case class WsActor(handle: PartialFunction[Ws.Event, Unit])
+```
+
+#### `cask/internal/Conversion.scala`
+
+```scala
+@implicitNotFound("Cannot return ${T} as a ${V}")
+class Conversion[T, V](val f: T => V)
+```
+
+```scala
+object Conversion
+```
+
+```scala
+implicit def create[T, V](implicit f: T => V): Conversion[T, V] = ...
+```
+
+#### `cask/internal/DispatchTrie.scala`
+
+```scala
+object DispatchTrie
+```
+
+```scala
+def construct[T, V](index: Int,
+                      inputs: collection.Seq[(collection.IndexedSeq[String], T, Boolean)])
+```
+
+```scala
+def validateGroup[T, V](terminals: collection.Seq[(collection.Seq[String], T, Boolean, V)],
+                          continuations: mutable.Map[String, mutable.Buffer[(collection.IndexedSeq[String], T, Boolean, V)]]) = ...
+```
+
+```scala
+def renderPath(p: collection.Seq[String]) = ...
+```
+
+> A simple Trie that can be compiled from a list of endpoints, to allow
+> endpoint lookup in O(length-of-request-path) time. Lookup returns the
+> [[T]] this trie contains, as well as a map of bound wildcards (path
+> segments starting with `:`) and any remaining un-used path segments
+> (only when `current._2 == true`, indicating this route allows trailing
+> segments)
+> current = (value, captures subpaths, argument names)
+
+```scala
+case class DispatchTrie[T](
+  current: Option[(T, Boolean, Vector[String])],
+  staticChildren: Map[String, DispatchTrie[T]],
+  dynamicChildren: Option[DispatchTrie[T]]
+)
+```
+
+```scala
+final def lookup(remainingInput: List[String],
+                   bindings: Vector[String])
+```
+
+```scala
+def map[V](f: T => V): DispatchTrie[V] = ...
+```
+
+#### `cask/internal/ThreadBlockingHandler.scala`
+
+> A handler that dispatches the request to the given handler using the given executor.
+
+```scala
+final class ThreadBlockingHandler(executor: Executor, handler: HttpHandler) extends HttpHandler
+```
+
+```scala
+def handleRequest(exchange: HttpServerExchange): Unit = ...
+```
+
+#### `cask/internal/Util.scala`
+
+```scala
+object Util
+```
+
+> Create a virtual thread executor with the given executor as the scheduler.
+
+```scala
+def createVirtualThreadExecutor(executor: Executor): Option[ExecutorService] = ...
+```
+
+> Create a default cask virtual thread executor if possible.
+
+```scala
+def createDefaultCaskVirtualThreadExecutor: Option[ExecutorService] = ...
+```
+
+> Try to get the default virtual thread scheduler, or null if not supported.
+
+```scala
+def getDefaultVirtualThreadScheduler: Option[ForkJoinPool] = ...
+```
+
+```scala
+def createNewThreadPerTaskExecutor(threadFactory: ThreadFactory): ExecutorService = ...
+```
+
+> Create a dedicated forkjoin based scheduler for the virtual thread.
+> NOTE: you can use other threads pool as scheduler too, this method just integrated the `CarrierThreadFactory`
+> when creating the ForkJoinPool.
+
+```scala
+def createForkJoinPoolBasedScheduler(parallelism: Int,
+                                       corePoolSize: Int,
+                                       maximumPoolSize: Int,
+                                       keepAliveTime: Int,
+                                       timeUnit: TimeUnit): Executor = ...
+```
+
+> Create a virtual thread factory with a executor, the executor will be used as the scheduler of
+> virtual thread.
+>
+> The executor should run task on platform threads.
+>
+> returns null if not supported.
+
+```scala
+def createVirtualThreadFactory(prefix: String,
+                                 executor: Executor): ThreadFactory = ...
+```
+
+```scala
+def firstFutureOf[T](futures: Seq[Future[T]])(implicit ec: ExecutionContext) = ...
+```
+
+> Convert a string to a C&P-able literal. Basically
+> copied verbatim from the uPickle source code.
+
+```scala
+def literalize(s: IndexedSeq[Char], unicode: Boolean = true) = ...
+```
+
+```scala
+def transferTo(in: InputStream, out: OutputStream) = ...
+```
+
+```scala
+def pluralize(s: String, n: Int) = ...
+```
+
+> Splits a string into path segments; automatically removes all
+> leading/trailing slashes, and ignores empty path segments.
+>
+> Written imperatively for performance since it's used all over the place.
+
+```scala
+def splitPath(p: String): collection.IndexedSeq[String] = ...
+```
+
+```scala
+def stackTraceString(e: Throwable) = ...
+```
+
+```scala
+def softWrap(s: String, leftOffset: Int, maxWidth: Int) = ...
+```
+
+```scala
+def sequenceEither[A, B, M[X] <: TraversableOnce[X]](in: M[Either[A, B]])(
+    implicit cbf: CanBuildFrom[M[Either[A, B]], B, M[B]]): Either[A, M[B]] = ...
+```
+
+#### `cask/main/ErrorMsgs.scala`
+
+```scala
+object ErrorMsgs
+```
+
+```scala
+def getLeftColWidth(items: Seq[ArgSig[_, _, _,_]]) = ...
+```
+
+```scala
+def renderArg[T](base: T,
+                   arg: ArgSig[_, T, _, _],
+                   leftOffset: Int,
+                   wrappedWidth: Int): (String, String) = ...
+```
+
+```scala
+def formatMainMethodSignature[T](base: T,
+                                   main: EntryPoint[T, _],
+                                   leftIndent: Int,
+                                   leftColWidth: Int) = ...
+```
+
+```scala
+def formatInvokeError[T](base: T, route: EntryPoint[T, _], x: Result.Error): String = ...
+```
+
+#### `cask/main/Main.scala`
+
+> A combination of [[cask.Main]] and [[cask.Routes]], ideal for small
+> one-file web applications.
+
+```scala
+class MainRoutes extends Main with Routes
+```
+
+```scala
+def allRoutes = ...
+```
+
+> Defines the main entrypoint and configuration of the Cask web application.
+>
+> You can pass in an arbitrary number of [[cask.Routes]] objects for it to
+> serve, and override various properties on [[Main]] in order to configure
+> application-wide properties.
+
+```scala
+abstract class Main
+```
+
+```scala
+def mainDecorators: Seq[Decorator[_, _, _, _]] = ...
+```
+
+```scala
+def allRoutes: Seq[Routes]
+```
+
+```scala
+def port: Int = ...
+```
+
+```scala
+def host: String = ...
+```
+
+```scala
+def verbose = ...
+```
+
+```scala
+def debugMode: Boolean = ...
+```
+
+```scala
+def createExecutionContext = ...
+```
+
+```scala
+def createActorContext = ...
+```
+
+```scala
+val executionContext = ...
+```
+
+```scala
+implicit val actorContext: castor.Context = ...
+```
+
+```scala
+implicit def log: cask.util.Logger = ...
+```
+
+```scala
+def dispatchTrie = ...
+```
+
+```scala
+def defaultHandler: HttpHandler = ...
+```
+
+```scala
+def handleNotFound(req: Request): Response.Raw = ...
+```
+
+```scala
+def handleMethodNotAllowed(req: Request): Response.Raw = ...
+```
+
+```scala
+def handleEndpointError(routes: Routes,
+                          metadata: EndpointMetadata[_],
+                          e: cask.router.Result.Error,
+                          req: Request): Response.Raw = ...
+```
+
+```scala
+def main(args: Array[String]): Unit = ...
+```
+
+```scala
+object Main
+```
+
+> property key to enable virtual thread support.
+
+```scala
+val VIRTUAL_THREAD_ENABLED = ...
+```
+
+```scala
+class DefaultHandler(dispatchTrie: DispatchTrie[Map[String, (Routes, EndpointMetadata[_])]],
+                       mainDecorators: Seq[Decorator[_, _, _, _]],
+                       debugMode: Boolean,
+                       handleNotFound: Request => Response.Raw,
+                       handleMethodNotAllowed: Request => Response.Raw,
+                       handleError: (Routes, EndpointMetadata[_], Result.Error, Request) => Response.Raw)
+```
+
+```scala
+def handleRequest(exchange: HttpServerExchange): Unit = ...
+```
+
+```scala
+def defaultHandleNotFound(req: Request): Response.Raw = ...
+```
+
+```scala
+def defaultHandleMethodNotAllowed(req: Request): Response.Raw = ...
+```
+
+```scala
+def prepareDispatchTrie(allRoutes: Seq[Routes]): DispatchTrie[Map[String, (Routes, EndpointMetadata[_])]] = ...
+```
+
+```scala
+def writeResponse(exchange: HttpServerExchange, response: Response.Raw) = ...
+```
+
+```scala
+def defaultHandleError(routes: Routes,
+                         metadata: EndpointMetadata[_],
+                         e: Result.Error,
+                         debugMode: Boolean,
+                         req: Request)
+```
+
+```scala
+def silenceJboss(): Unit = ...
+```
+
+#### `cask/main/Routes.scala`
+
+```scala
+trait Routes
+```
+
+```scala
+def decorators = ...
+```
+
+```scala
+def caskMetadata = ...
+```
+
+#### `cask/model/Params.scala`
+
+```scala
+case class QueryParams(value: Map[String, collection.Seq[String]])
+```
+
+```scala
+case class RemainingPathSegments(value: Seq[String])
+```
+
+```scala
+case class Request(exchange: HttpServerExchange, remainingPathSegments: Seq[String], boundPathSegments: Map[String, String])
+```
+
+```scala
+object Cookie
+```
+
+```scala
+def fromUndertow(from: io.undertow.server.handlers.Cookie): Cookie = ...
+```
+
+```scala
+def toUndertow(from: Cookie): io.undertow.server.handlers.Cookie = ...
+```
+
+```scala
+case class Cookie(name: String,
+                  value: String,
+                  comment: String = null,
+                  domain: String = null,
+                  expires: java.time.Instant = null,
+                  maxAge: Integer = null,
+                  path: String = null,
+                  version: Int = 1,
+                  discard: Boolean = false,
+                  httpOnly: Boolean = false,
+                  secure: Boolean = false,
+                  sameSite: String = "Lax")
+```
+
+```scala
+sealed trait FormEntry
+```
+
+```scala
+def valueOrFileName: String
+```
+
+```scala
+def headers: io.undertow.util.HeaderMap
+```
+
+```scala
+def asFile: Option[FormFile] = ...
+```
+
+```scala
+object FormEntry
+```
+
+```scala
+def fromUndertow(from: io.undertow.server.handlers.form.FormData.FormValue): FormEntry = ...
+```
+
+```scala
+case class FormValue(value: String,
+                     headers: io.undertow.util.HeaderMap) extends FormEntry
+```
+
+```scala
+def valueOrFileName = ...
+```
+
+```scala
+case class FormFile(fileName: String,
+                    filePath: Option[java.nio.file.Path],
+                    headers: io.undertow.util.HeaderMap) extends FormEntry
+```
+
+```scala
+def valueOrFileName = ...
+```
+
+```scala
+case class EmptyFormEntry()
+```
+
+#### `cask/model/Response.scala`
+
+> The basic response returned by a HTTP endpoint.
+>
+> Note that [[data]] by default can take in a wide range of types: strings,
+> bytes, uPickle JSON-convertable types or arbitrary input streams. You can
+> also construct your own implementations of `Response.Data`.
+
+```scala
+case class Response[+T](
+  data: T,
+  statusCode: Int,
+  headers: Seq[(String, String)],
+  cookies: Seq[Cookie]
+)
+```
+
+```scala
+def map[V](f: T => V) = ...
+```
+
+```scala
+object Response
+```
+
+```scala
+type Raw = ...
+```
+
+```scala
+def apply[T](data: T,
+               statusCode: Int = 200,
+               headers: Seq[(String, String)] = Nil,
+               cookies: Seq[Cookie] = Nil) = ...
+```
+
+```scala
+trait Data
+```
+
+```scala
+def write(out: OutputStream): Unit
+```
+
+```scala
+def headers: Seq[(String, String)]
+```
+
+```scala
+trait DataCompanion[V]
+```
+
+```scala
+implicit def dataResponse[T](t: T)(implicit c: T => V): Response[V] = ...
+```
+
+```scala
+implicit def dataResponse2[T](t: Response[T])(implicit c: T => V): Response[V] = ...
+```
+
+```scala
+object Data extends DataCompanion[Data]
+```
+
+```scala
+implicit class UnitData(s: Unit) extends Data
+```
+
+```scala
+def write(out: OutputStream) = ...
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+implicit class WritableData[T](s: T)(implicit f: T => geny.Writable) extends Data
+```
+
+```scala
+val writable = ...
+```
+
+```scala
+def write(out: OutputStream) = ...
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+implicit class NumericData[T: Numeric](s: T) extends Data
+```
+
+```scala
+def write(out: OutputStream) = ...
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+implicit class BooleanData(s: Boolean) extends Data
+```
+
+```scala
+def write(out: OutputStream) = ...
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+object Redirect
+```
+
+```scala
+def apply(url: String) = ...
+```
+
+```scala
+object Abort
+```
+
+```scala
+def apply(code: Int) = ...
+```
+
+```scala
+object StaticFile
+```
+
+```scala
+def apply(path: String, headers: Seq[(String, String)]) = ...
+```
+
+```scala
+object StaticResource
+```
+
+```scala
+def apply(path: String, resourceRoot: ClassLoader, headers: Seq[(String, String)]) = ...
+```
+
+#### `cask/model/Status.scala`
+
+```scala
+sealed trait Status
+```
+
+```scala
+val code: Int
+```
+
+```scala
+val reason: String
+```
+
+```scala
+object Status
+```
+
+```scala
+val codesToStatus: Map[Int, Status] = ...
+```
+
+```scala
+val statusToCodes: Map[String, Int] = ...
+```
+
+```scala
+case class Unknown(code: Int, reason: String) extends Status
+```
+
+```scala
+case object Continue extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object SwitchingProtocols extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object OK extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Created extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Accepted extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NonAuthoritativeInformation extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NoContent extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object ResetContent extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object PartialContent extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object MultipleChoices extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object MovedPermanently extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Found extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object SeeOther extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NotModified extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object UseProxy extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object TemporaryRedirect extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object PermanentRedirect extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object BadRequest extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Unauthorized extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object PaymentRequired extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Forbidden extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NotFound extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object MethodNotAllowed extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NotAcceptable extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object ProxyAuthenticationRequired extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object RequestTimeout extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Conflict extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Gone extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object LengthRequired extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object PreconditionFailed extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object RequestEntityTooLarge extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object RequestURITooLong extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object UnsupportedMediaType extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object RequestedRangeNotSatisfiable extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object ExpectationFailed extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object Teapot extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object EnhanceYourCalm extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object TooManyRequests extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object UnavailableForLegalReasons extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object InternalServerError extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object NotImplemented extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object BadGateway extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object ServiceUnavailable extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object GatewayTimeout extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+```scala
+case object HTTPVersionNotSupported extends Status
+```
+
+```scala
+val code = ...
+```
+
+```scala
+val reason: String = ...
+```
+
+#### `cask/package.scala`
+
+```scala
+package object cask
+```
+
+```scala
+type Response[T] = ...
+```
+
+```scala
+val Response = ...
+```
+
+```scala
+val Abort = ...
+```
+
+```scala
+val Redirect = ...
+```
+
+```scala
+val StaticFile = ...
+```
+
+```scala
+val StaticResource = ...
+```
+
+```scala
+type FormEntry = ...
+```
+
+```scala
+val FormEntry = ...
+```
+
+```scala
+type FormValue = ...
+```
+
+```scala
+val FormValue = ...
+```
+
+```scala
+type FormFile = ...
+```
+
+```scala
+val FormFile = ...
+```
+
+```scala
+type Cookie = ...
+```
+
+```scala
+val Cookie = ...
+```
+
+```scala
+type Request = ...
+```
+
+```scala
+val Request = ...
+```
+
+```scala
+type QueryParams = ...
+```
+
+```scala
+val QueryParams = ...
+```
+
+```scala
+type RemainingPathSegments = ...
+```
+
+```scala
+val RemainingPathSegments = ...
+```
+
+```scala
+type websocket = ...
+```
+
+```scala
+val WebsocketResult = ...
+```
+
+```scala
+type WebsocketResult = ...
+```
+
+```scala
+type get = ...
+```
+
+```scala
+type post = ...
+```
+
+```scala
+type put = ...
+```
+
+```scala
+type delete = ...
+```
+
+```scala
+type patch = ...
+```
+
+```scala
+type route = ...
+```
+
+```scala
+type staticFiles = ...
+```
+
+```scala
+type staticResources = ...
+```
+
+```scala
+type postJson = ...
+```
+
+```scala
+type postJsonCached = ...
+```
+
+```scala
+type getJson = ...
+```
+
+```scala
+type postForm = ...
+```
+
+```scala
+type options = ...
+```
+
+```scala
+type MainRoutes = ...
+```
+
+```scala
+type Routes = ...
+```
+
+```scala
+type Main = ...
+```
+
+```scala
+type RawDecorator = ...
+```
+
+```scala
+type HttpEndpoint[InnerReturned, Input] = ...
+```
+
+```scala
+type WsHandler = ...
+```
+
+```scala
+val WsHandler = ...
+```
+
+```scala
+type WsActor = ...
+```
+
+```scala
+val WsActor = ...
+```
+
+```scala
+type WsChannelActor = ...
+```
+
+```scala
+type WsClient = ...
+```
+
+```scala
+val WsClient = ...
+```
+
+```scala
+val Ws = ...
+```
+
+```scala
+type Logger = ...
+```
+
+```scala
+val Logger = ...
+```
+
+#### `cask/router/Decorators.scala`
+
+> A [[Decorator]] allows you to annotate a function to wrap it, via
+> `wrapFunction`. You can use this to perform additional validation before or
+> after the function runs, provide an additional parameter list of params,
+> open/commit/rollback database transactions before/after the function runs,
+> or even retrying the wrapped function if it fails.
+>
+> Calls to the wrapped function are done on the `delegate` parameter passed
+> to `wrapFunction`, which takes a `Map` representing any additional argument
+> lists (if any).
+
+```scala
+trait Decorator[OuterReturned, InnerReturned, Input, InputContext] extends scala.annotation.Annotation
+```
+
+```scala
+final type InputTypeAlias = ...
+```
+
+```scala
+type InputParser[T] <: ArgReader[Input, T, InputContext]
+```
+
+```scala
+final type Delegate = ...
+```
+
+```scala
+def wrapFunction(ctx: Request, delegate: Delegate): Result[OuterReturned]
+```
+
+```scala
+def getParamParser[T](implicit p: InputParser[T]) = ...
+```
+
+```scala
+object Decorator
+```
+
+> A stack of [[Decorator]]s is invoked recursively: each decorator's `wrapFunction`
+> is invoked around the invocation of all inner decorators, with the inner-most
+> decorator finally invoking the route's [[EntryPoint.invoke]] function.
+>
+> Each decorator (and the final `Endpoint`) contributes a dictionary of name-value
+> bindings, which are eventually all passed to [[EntryPoint.invoke]]. Each decorator's
+> dictionary corresponds to a different argument list on [[EntryPoint.invoke]]. The
+> bindings passed from the router are aggregated with those from the `EndPoint` and
+> used as the first argument list.
+
+```scala
+def invoke[T](ctx: Request,
+                endpoint: Endpoint[_, _, _, _],
+                entryPoint: EntryPoint[T, _],
+                routes: T,
+                remainingDecorators: List[Decorator[_, _, _, _]],
+                inputContexts: List[Any],
+                bindings: List[Map[String, Any]]): Result[Any] = ...
+```
+
+> A [[RawDecorator]] is a decorator that operates on the raw request and
+> response stream, before and after the primary [[Endpoint]] does it's job.
+
+```scala
+trait RawDecorator extends Decorator[Response.Raw, Response.Raw, Any, Request]
+```
+
+```scala
+type InputParser[T] = ...
+```
+
+> An [[HttpEndpoint]] that may return something else than a HTTP response, e.g.
+> a websocket endpoint which may instead return a websocket event handler
+
+```scala
+trait Endpoint[OuterReturned, InnerReturned, Input, InputContext]
+  extends Decorator[OuterReturned, InnerReturned, Input, InputContext]
+```
+
+> What is the path that this particular endpoint matches?
+
+```scala
+val path: String
+```
+
+> Which HTTP methods does this endpoint support? POST? GET? PUT? Or some
+> combination of those?
+
+```scala
+val methods: Seq[String]
+```
+
+> Whether or not this endpoint allows matching on sub-paths: does
+> `@endpoint("/foo")` capture the path "/foo/bar/baz"? Useful to e.g. have
+> an endpoint match URLs with paths in a filesystem (real or virtual) to
+> serve files
+
+```scala
+def subpath: Boolean = ...
+```
+
+```scala
+def convertToResultType[T](t: T)
+```
+
+> [[HttpEndpoint]]s are unique among decorators in that they alone can bind
+> path segments to parameters, e.g. binding `/hello/:world` to `(world: Int)`.
+> In order to do so, we need to box up the path segment strings into an
+> [[Input]] so they can later be parsed by [[getParamParser]] into an
+> instance of the appropriate type.
+
+```scala
+def wrapPathSegment(s: String): Input
+```
+
+> Annotates a Cask endpoint that returns a HTTP [[Response]]; similar to a
+> [[RawDecorator]] but with additional metadata and capabilities.
+
+```scala
+trait HttpEndpoint[InnerReturned, Input] extends Endpoint[Response.Raw, InnerReturned, Input, Request]
+```
+
+```scala
+class NoOpParser[Input, T, InputContext] extends ArgReader[Input, T, InputContext]
+```
+
+```scala
+def arity = ...
+```
+
+```scala
+def read(ctx: InputContext, label: String, input: Input) = ...
+```
+
+```scala
+object NoOpParser
+```
+
+```scala
+implicit def instance[Input, T, InputContext]: NoOpParser[Input, T, InputContext] = ...
+```
+
+```scala
+implicit def instanceAny[T, InputContext]: NoOpParser[Any, T, InputContext] = ...
+```
+
+```scala
+implicit def instanceAnyRequest[T]: NoOpParser[Any, T, Request] = ...
+```
+
+#### `cask/router/EndpointMetadata.scala`
+
+```scala
+case class EndpointMetadata[T](decorators: Seq[Decorator[_, _, _, _]],
+                               endpoint: Endpoint[_, _, _, _],
+                               entryPoint: EntryPoint[T, _])
+```
+
+```scala
+object EndpointMetadata
+```
+
+```scala
+def seqify1(d: Decorator[_, _, _, _]) = ...
+```
+
+```scala
+def seqify2[T1]
+             (d1: Decorator[T1, _, _, _])
+```
+
+```scala
+def seqify3[T1, T2]
+             (d1: Decorator[T1, _, _, _])
+```
+
+```scala
+def seqify4[T1, T2, T3]
+             (d1: Decorator[T1, _, _, _])
+```
+
+```scala
+def seqify5[T1, T2, T3, T4]
+             (d1: Decorator[T1, _, _, _])
+```
+
+```scala
+def seqify6[T1, T2, T3, T4, T5]
+             (d1: Decorator[T1, _, _, _])
+```
+
+#### `cask/router/EntryPoint.scala`
+
+> What is known about a single endpoint for our routes. It has a [[name]],
+> [[argSignatures]] for each argument, and a macro-generated [[invoke0]]
+> that performs all the necessary argument parsing and de-serialization.
+>
+> Realistically, you will probably spend most of your time calling [[invoke]]
+> instead, which provides a nicer API to call it that mimmicks the API of
+> calling a Scala method.
+
+```scala
+case class EntryPoint[T, C](name: String,
+                            argSignatures: Seq[Seq[ArgSig[_, T, _, C]]],
+                            doc: Option[String],
+                            invoke0: (T, Seq[C], Seq[Map[String, Any]], Seq[Seq[ArgSig[Any, _, _, C]]]) => Result[Any])
+```
+
+```scala
+val firstArgs = ...
+```
+
+```scala
+def invoke(target: T,
+             ctxs: Seq[C],
+             paramLists: Seq[Map[String, Any]]): Result[Any] = ...
+```
+
+#### `cask/router/Macros.scala`
+
+```scala
+object Macros
+```
+
+> Check that decorator inner and outer return types match.
+>
+> This replicates EndpointMetadata.seqify, but in a macro where error
+> positions can be controlled.
+
+```scala
+def checkDecorators(using Quotes)(decorators: List[Expr[Decorator[_, _, _, _]]]): Boolean = ...
+```
+
+> Lookup default values for a method's parameters.
+
+```scala
+def getDefaultParams(using Quotes)(method: quotes.reflect.Symbol): Map[quotes.reflect.Symbol, Expr[Any]] = ...
+```
+
+> Summon the reader for a parameter.
+
+```scala
+def summonReader(using Quotes)(
+    decorator: Expr[Decorator[_,_,_,_]],
+    param: quotes.reflect.Symbol
+  ): Expr[ArgReader[_, _, _]] = ...
+```
+
+> Call a method given by its symbol.
+>
+> E.g.
+>
+> assuming:
+>
+> def foo(x: Int, y: String)(z: Int)
+>
+> val argss: List[List[Any]] = ???
+>
+> then:
+>
+> call(<symbol of foo>, '{argss})
+>
+> will expand to:
+>
+> foo(argss(0)(0), argss(0)(1))(argss(1)(0))
+
+```scala
+def call(using Quotes)(
+    method: quotes.reflect.Symbol,
+    argss: Expr[Seq[Seq[Any]]]
+  ): Expr[_] = ...
+```
+
+> Convert a result to an HTTP response
+>
+> Note: essentially, all this method does is summon a `cask.internal.Conversion`
+> and provide a helpful error message if it cannot be found. In this case,
+> one could wonder why we do the implicit summoning in this macro, rather than
+> emit "regular" code which does the summoning. The reason is to provide
+> helpful error messages with correct positions. We can control the position
+> in the macro, but if the error were to come from the expanded code the position
+> would be completely off.
+
+```scala
+def convertToResponse(using Quotes)(
+    method: quotes.reflect.Symbol,
+    endpoint: Expr[Endpoint[_, _, _, _]],
+    result: Expr[Any]
+  ): Expr[Any] = ...
+```
+
+> The type of paramters displayed in error messages
+
+```scala
+def friendlyName(using Quotes)(param: quotes.reflect.ValDef): String = ...
+```
+
+```scala
+def extractMethod[Cls: Type](using q: Quotes)(
+    method: quotes.reflect.Symbol,
+    decorators: List[Expr[Decorator[_, _, _, _]]], // these must also include the endpoint
+    endpoint: Expr[Endpoint[_, _, _, _]]
+  ): Expr[EntryPoint[Cls, Any]] = ...
+```
+
+#### `cask/router/Misc.scala`
+
+```scala
+class doc(s: String) extends StaticAnnotation
+```
+
+> Models what is known by the router about a single argument: that it has
+> a [[name]], a human-readable [[typeString]] describing what the type is
+> (just for logging and reading, not a replacement for a `TypeTag`) and
+> possible a function that can compute its default value
+
+```scala
+case class ArgSig[I, -T, +V, -C](name: String,
+                                 typeString: String,
+                                 doc: Option[String],
+                                 default: Option[T => V])
+```
+
+```scala
+trait ArgReader[I, +T, -C]
+```
+
+```scala
+def arity: Int
+```
+
+```scala
+def unknownQueryParams: Boolean = ...
+```
+
+```scala
+def remainingPathSegments: Boolean = ...
+```
+
+```scala
+def read(ctx: C, label: String, input: I): T
+```
+
+#### `cask/router/Result.scala`
+
+> Represents what comes out of an attempt to invoke an [[EntryPoint]].
+> Could succeed with a value, but could fail in many different ways.
+
+```scala
+sealed trait Result[+T]
+```
+
+```scala
+def map[V](f: T => V): Result[V]
+```
+
+```scala
+def transform[V](f: PartialFunction[Any, V]): Result[V]
+```
+
+```scala
+object Result
+```
+
+> Invoking the [[EntryPoint]] was totally successful, and returned a
+> result
+
+```scala
+case class Success[T](value: T) extends Result[T]
+```
+
+```scala
+def map[V](f: T => V) = ...
+```
+
+```scala
+def transform[V](f: PartialFunction[Any, V]) = ...
+```
+
+> Invoking the [[EntryPoint]] was not successful
+
+```scala
+sealed trait Error extends Result[Nothing]
+```
+
+```scala
+def map[V](f: Nothing => V) = ...
+```
+
+```scala
+def transform[V](f: PartialFunction[Any, V]) = ...
+```
+
+```scala
+object Error
+```
+
+> Invoking the [[EntryPoint]] failed with an exception while executing
+> code within it.
+
+```scala
+case class Exception(t: Throwable) extends Error
+```
+
+> Invoking the [[EntryPoint]] failed because the arguments provided
+> did not line up with the arguments expected
+
+```scala
+case class MismatchedArguments(missing: Seq[ArgSig[_, _, _, _]],
+                                   unknown: Seq[String]) extends Error
+```
+
+> Invoking the [[EntryPoint]] failed because there were problems
+> deserializing/parsing individual arguments
+
+```scala
+case class InvalidArguments(values: Seq[ParamError]) extends Error
+```
+
+```scala
+sealed trait ParamError
+```
+
+```scala
+object ParamError
+```
+
+> Something went wrong trying to de-serialize the input parameter;
+> the thrown exception is stored in [[ex]]
+
+```scala
+case class Invalid(arg: ArgSig[_, _, _, _], value: String, ex: Throwable) extends ParamError
+```
+
+> Something went wrong trying to evaluate the default value
+> for this input parameter
+
+```scala
+case class DefaultFailed(arg: ArgSig[_, _, _, _], ex: Throwable) extends ParamError
+```
+
+#### `cask/router/RoutesEndpointMetadata.scala`
+
+```scala
+case class RoutesEndpointsMetadata[T](value: Seq[EndpointMetadata[T]])
+```
+
+```scala
+object RoutesEndpointsMetadata
+```
+
+```scala
+inline given initialize[T]: RoutesEndpointsMetadata[T] = ...
+```
+
+```scala
+def setRoutesImpl[T: Type](setter: Expr[RoutesEndpointsMetadata[T] => Unit])(using Quotes): Expr[Unit] = ...
+```
+
+```scala
+def initializeImpl[T: Type](using q: Quotes): Expr[RoutesEndpointsMetadata[T]] = ...
+```
+
+#### `cask/router/Runtime.scala`
+
+```scala
+object Runtime
+```
+
+```scala
+def tryEither[T](t: => T, error: Throwable => Result.ParamError) = ...
+```
+
+```scala
+def validate(args: Seq[Either[Seq[Result.ParamError], Any]]): Result[Seq[Any]] = ...
+```
+
+```scala
+def validateLists(argss: Seq[Seq[Either[Seq[Result.ParamError], Any]]]): Result[Seq[Seq[Any]]] = ...
+```
+
+```scala
+def makeReadCall[I, C](dict: Map[String, I],
+                         ctx: C,
+                         default: => Option[Any],
+                         arg: ArgSig[I, _, _, C]) = ...
+```
+

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -1,0 +1,31 @@
+# Coding Guideline
+
+## Error handling
+
+Treat Java and throwing library APIs like unsafe foreign APIs.
+
+The mental model should be similar to writing a C API wrapper in Rust:
+
+- The Java or throwing library API is the unsafe C boundary.
+- The Scala code we write is the safe Rust-side API.
+- Boundary wrappers convert exceptions into typed values.
+- Normal project code composes those typed values instead of throwing.
+
+Rules:
+
+1. Only use `try` / `catch` at a Java or throwing-library boundary that we cannot control.
+2. Wrap those calls in small functions that convert failures into `Either` or another explicit type.
+3. Functions defined in this project should not throw for expected failures.
+4. Project-owned control flow should use `Either`, `Option`, or another type-level representation.
+5. Avoid `throw` in our own code. If an error must reach the CLI, return `Left(...)` up to the command boundary and let the top-level command decide how to report it.
+
+Example shape:
+
+```scala
+def callJavaApi(): Either[String, Result] =
+  try Right(javaLibrary.call())
+  catch case NonFatal(e) => Left(e.getMessage)
+
+def projectFunction(): Either[String, Output] =
+  callJavaApi().map(convertResult)
+```

--- a/docs/coursier-2.1.25-M3.md
+++ b/docs/coursier-2.1.25-M3.md
@@ -1,0 +1,7636 @@
+# Coursier 2.1.25-M3 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `1412` non-private declaration signatures from `163` source files.
+
+## Coordinates
+- Direct dependency: `io.get-coursier:coursier_2.13:2.1.25-M3`
+- Upstream docs: https://get-coursier.io/docs/api
+- Source artifacts included:
+  - `io.get-coursier:coursier_2.13:2.1.25-M3`
+  - `io.get-coursier:coursier-core_2.13:2.1.25-M3`
+  - `io.get-coursier:coursier-cache_2.13:2.1.25-M3`
+  - `io.get-coursier:coursier-proxy-setup:2.1.25-M3`
+  - `io.get-coursier:dependency_2.13:0.3.2`
+
+## Common imports
+
+```scala
+import coursier.*
+import coursier.cache.FileCache
+```
+
+## Usage notes
+
+Dependency resolution/fetching library. This doc includes the high-level `coursier` module plus core/cache/proxy/dependency source artifacts that expose `Fetch`, `Dependency`, `Module`, `Repositories`, `FileCache`, and Maven repository APIs.
+
+```scala
+import coursier.*
+import coursier.cache.FileCache
+
+val dep = Dependency(
+  Module(Organization("com.lihaoyi"), ModuleName("os-lib_3"), Map.empty),
+  VersionConstraint("0.10.0")
+)
+
+val result = Fetch()
+  .addDependencies(dep)
+  .withRepositories(Seq(Repositories.central))
+  .withCache(FileCache().withLocation((os.pwd / ".mif" / "coursier-cache").toIO))
+  .runResult()
+```
+
+## API signatures from upstream source
+
+### `io.get-coursier:coursier_2.13:2.1.25-M3`
+
+Source: https://repo1.maven.org/maven2/io/get-coursier/coursier_2.13/2.1.25-M3/coursier_2.13-2.1.25-M3-sources.jar
+
+#### `coursier/Artifacts.scala`
+
+```scala
+object Artifacts
+```
+
+```scala
+def apply(): Artifacts[Task] = ...
+```
+
+```scala
+implicit class ArtifactsTaskOps(private val artifacts: Artifacts[Task]) extends AnyVal
+```
+
+```scala
+def future()(implicit
+      ec: ExecutionContext = artifacts.cache.ec
+    ): Future[Seq[(Artifact, File)]] = ...
+```
+
+```scala
+def either()(implicit
+      ec: ExecutionContext = artifacts.cache.ec
+    ): Either[FetchError, Seq[(Artifact, File)]] = ...
+```
+
+```scala
+def run()(implicit ec: ExecutionContext = artifacts.cache.ec): Seq[(Artifact, File)] = ...
+```
+
+```scala
+def futureResult()(implicit ec: ExecutionContext = artifacts.cache.ec): Future[Result] = ...
+```
+
+```scala
+def eitherResult()(implicit
+      ec: ExecutionContext = artifacts.cache.ec
+    ): Either[FetchError, Result] = ...
+```
+
+```scala
+def runResult()(implicit ec: ExecutionContext = artifacts.cache.ec): Result = ...
+```
+
+```scala
+def defaultTypes(
+    classifiers: Set[Classifier] = Set.empty,
+    mainArtifactsOpt: Option[Boolean] = None
+  ): Set[Type] = ...
+```
+
+```scala
+  @deprecated("Use artifacts0 instead", "2.1.25")
+def artifacts(
+    resolution: Resolution,
+    classifiers: Set[Classifier],
+    mainArtifactsOpt: Option[Boolean],
+    artifactTypesOpt: Option[Set[Type]],
+    classpathOrder: Boolean
+  ): Seq[(Dependency, Publication, Artifact)] = ...
+```
+
+```scala
+def artifacts0(
+    resolution: Resolution,
+    classifiers: Set[Classifier],
+    mainArtifactsOpt: Option[Boolean],
+    artifactTypesOpt: Option[Set[Type]],
+    classpathOrder: Boolean
+  ): Seq[(Dependency, Either[VariantPublication, Publication], Artifact)] = ...
+```
+
+#### `coursier/Fetch.scala`
+
+```scala
+object Fetch
+```
+
+```scala
+def apply(): Fetch[Task] = ...
+```
+
+```scala
+def apply[F[_]](cache: Cache[F])(implicit S: Sync[F]): Fetch[F] = ...
+```
+
+```scala
+implicit class FetchTaskOps(private val fetch: Fetch[Task]) extends AnyVal
+```
+
+```scala
+def futureResult()(implicit ec: ExecutionContext = fetch.resolve.cache.ec): Future[Result] = ...
+```
+
+```scala
+def future()(implicit ec: ExecutionContext = fetch.resolve.cache.ec): Future[Seq[File]] = ...
+```
+
+```scala
+def eitherResult()(implicit
+      ec: ExecutionContext = fetch.resolve.cache.ec
+    ): Either[CoursierError, Result] = ...
+```
+
+```scala
+def either()(implicit
+      ec: ExecutionContext = fetch.resolve.cache.ec
+    ): Either[CoursierError, Seq[File]] = ...
+```
+
+```scala
+def runResult()(implicit ec: ExecutionContext = fetch.resolve.cache.ec): Result = ...
+```
+
+```scala
+def run()(implicit ec: ExecutionContext = fetch.resolve.cache.ec): Seq[File] = ...
+```
+
+#### `coursier/LocalRepositories.scala`
+
+```scala
+object LocalRepositories
+```
+
+```scala
+lazy val ivy2Local = ...
+```
+
+> These repositories aren't guaranteed to always work fine with coursier (they sometimes have
+> only the metadata of some dependencies, and coursier isn't fine with that - coursier requires
+> both the metadata and the JARs to be in the same repo) see
+> https://github.com/coursier/coursier/pull/868#issuecomment-398779799
+
+```scala
+object Dangerous
+```
+
+```scala
+lazy val maven2Local = ...
+```
+
+```scala
+lazy val ivy2Cache = ...
+```
+
+#### `coursier/PlatformResolve.scala`
+
+```scala
+abstract class PlatformResolve
+```
+
+```scala
+type Path = ...
+```
+
+```scala
+def defaultConfFiles: Seq[Path] = ...
+```
+
+```scala
+def defaultMirrorConfFiles: Seq[MirrorConfFile] = ...
+```
+
+```scala
+def confFileMirrors(confFile: Path): Seq[Mirror] = ...
+```
+
+```scala
+def confFileRepositories(confFile: Path): Option[Seq[Repository]] = ...
+```
+
+```scala
+lazy val defaultRepositories: Seq[Repository] = ...
+```
+
+```scala
+def proxySetup(): Unit = ...
+```
+
+#### `coursier/error/FetchError.scala`
+
+```scala
+sealed abstract class FetchError(message: String, cause: Throwable = null)
+```
+
+```scala
+object FetchError
+```
+
+```scala
+final class DownloadingArtifacts(val errors: Seq[(Artifact, ArtifactError)]) extends FetchError(
+    "Error fetching artifacts:" + System.lineSeparator() +
+      errors.map { case (a, e) =>
+        s"${a.url}: ${e.describe}" + System.lineSeparator()
+      }.mkString,
+    errors.headOption.map(_._2).orNull
+  )
+```
+
+#### `coursier/internal/Defaults.scala`
+
+```scala
+object Defaults
+```
+
+```scala
+def scalaVersion: String = ...
+```
+
+```scala
+def scalaVersionConstraint: VersionConstraint = ...
+```
+
+#### `coursier/internal/FetchCache.scala`
+
+```scala
+object FetchCache
+```
+
+#### `coursier/internal/InMemoryCachingFetcher.scala`
+
+> For benchmarking purposes
+
+```scala
+final class InMemoryCachingFetcher[F[_]](underlying: Repository.Fetch[F])(implicit S: Sync[F])
+```
+
+```scala
+def onlyCache(): Unit = ...
+```
+
+```scala
+def fromCache(url: String): String = ...
+```
+
+```scala
+def fetcher: Repository.Fetch[F] = ...
+```
+
+#### `coursier/internal/PlatformMirrorConfFile.scala`
+
+```scala
+abstract class PlatformMirrorConfFile
+```
+
+```scala
+def path: String
+```
+
+```scala
+def optional: Boolean
+```
+
+```scala
+def mirrors(): Seq[Mirror] = ...
+```
+
+#### `coursier/internal/PlatformRepositoryParser.scala`
+
+```scala
+abstract class PlatformRepositoryParser
+```
+
+```scala
+def repository(input: String): Either[String, Repository] = ...
+```
+
+```scala
+def repository(input: String, maybeFile: Boolean): Either[String, Repository] = ...
+```
+
+#### `coursier/util/InMemoryRepository.scala`
+
+```scala
+object InMemoryRepository
+```
+
+```scala
+def forDependencies(dependencies: (Dependency, String)*): InMemoryRepository = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a cache", "2.0.0-RC3")
+def exists(
+    url: URL,
+    localArtifactsShouldBeCached: Boolean
+  ): Boolean = ...
+```
+
+```scala
+def exists(
+    url: URL,
+    localArtifactsShouldBeCached: Boolean,
+    cacheOpt: Option[FileCache[Nothing]]
+  ): Boolean = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a cache", "2.0.0-RC3")
+def apply(
+    fallbacks: Map[(Module, String), (URL, Boolean)]
+  ): InMemoryRepository = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a cache", "2.0.0-RC3")
+def apply(
+    fallbacks: Map[(Module, String), (URL, Boolean)],
+    localArtifactsShouldBeCached: Boolean
+  ): InMemoryRepository = ...
+```
+
+```scala
+def create[F[_]](
+    fallbacks: Map[(Module, Version0), (URL, Boolean)],
+    cache: FileCache[F]
+  ): InMemoryRepository = ...
+```
+
+```scala
+  @deprecated("Use create instead", "2.1.25")
+def apply[F[_]](
+    fallbacks: Map[(Module, String), (URL, Boolean)],
+    cache: FileCache[F]
+  ): InMemoryRepository = ...
+```
+
+```scala
+def apply(
+    fallbacks0: Map[(Module, String), (URL, Boolean)],
+    localArtifactsShouldBeCached: Boolean,
+    cacheOpt: Option[FileCache[Nothing]]
+  ): InMemoryRepository = ...
+```
+
+#### `scala/coursier/Repositories.scala`
+
+```scala
+object Repositories
+```
+
+```scala
+def central: MavenRepository = ...
+```
+
+```scala
+def sonatype(name: String): MavenRepository = ...
+```
+
+```scala
+def sonatypeS01(name: String): MavenRepository = ...
+```
+
+```scala
+def bintray(id: String): MavenRepository = ...
+```
+
+```scala
+def bintray(owner: String, repo: String): MavenRepository = ...
+```
+
+```scala
+def bintrayIvy(id: String): IvyRepository = ...
+```
+
+```scala
+def typesafe(id: String): MavenRepository = ...
+```
+
+```scala
+def typesafeIvy(id: String): IvyRepository = ...
+```
+
+```scala
+def sbtPlugin(id: String): IvyRepository = ...
+```
+
+```scala
+def sbtMaven(id: String): MavenRepository = ...
+```
+
+```scala
+def scalaIntegration: MavenRepository = ...
+```
+
+```scala
+def jitpack: MavenRepository = ...
+```
+
+```scala
+def clojars: MavenRepository = ...
+```
+
+```scala
+def jcenter: MavenRepository = ...
+```
+
+```scala
+def google: MavenRepository = ...
+```
+
+```scala
+def centralGcs: MavenRepository = ...
+```
+
+```scala
+def centralGcsEu: MavenRepository = ...
+```
+
+```scala
+def centralGcsAsia: MavenRepository = ...
+```
+
+```scala
+def apache(id: String): MavenRepository = ...
+```
+
+#### `scala/coursier/Resolve.scala`
+
+```scala
+object Resolve extends PlatformResolve
+```
+
+```scala
+def apply(): Resolve[Task] = ...
+```
+
+```scala
+implicit class ResolveTaskOps(private val resolve: Resolve[Task]) extends AnyVal
+```
+
+```scala
+def future()(implicit ec: ExecutionContext = resolve.cache.ec): Future[Resolution] = ...
+```
+
+```scala
+def either()(implicit
+      ec: ExecutionContext = resolve.cache.ec
+    ): Either[ResolutionError, Resolution] = ...
+```
+
+```scala
+def futureEither()(implicit
+      ec: ExecutionContext = resolve.cache.ec
+    ): Future[Either[ResolutionError, Resolution]] = ...
+```
+
+```scala
+def run()(implicit ec: ExecutionContext = resolve.cache.ec): Resolution = ...
+```
+
+```scala
+def validate(res: Resolution): ValidationNel[ResolutionError, Unit] = ...
+```
+
+#### `scala/coursier/Versions.scala`
+
+```scala
+object Versions
+```
+
+```scala
+def apply(): Versions[Task] = ...
+```
+
+```scala
+implicit class VersionsTaskOps(private val versions: Versions[Task]) extends AnyVal
+```
+
+```scala
+def futureResult()(implicit ec: ExecutionContext = versions.cache.ec): Future[Result] = ...
+```
+
+```scala
+def future()(implicit
+      ec: ExecutionContext = versions.cache.ec
+    ): Future[coursier.core.Versions] = ...
+```
+
+```scala
+def eitherResult()(implicit
+      ec: ExecutionContext = versions.cache.ec
+    ): Either[CoursierError, Result] = ...
+```
+
+```scala
+def either()(implicit
+      ec: ExecutionContext = versions.cache.ec
+    ): Either[CoursierError, coursier.core.Versions] = ...
+```
+
+```scala
+def runResult()(implicit ec: ExecutionContext = versions.cache.ec): Result = ...
+```
+
+```scala
+def run()(implicit ec: ExecutionContext = versions.cache.ec): coursier.core.Versions = ...
+```
+
+#### `scala/coursier/complete/Complete.scala`
+
+```scala
+object Complete
+```
+
+```scala
+def apply(): Complete[Task] = ...
+```
+
+```scala
+def scalaBinaryVersion(scalaVersion: String): String = ...
+```
+
+#### `scala/coursier/error/CoursierError.scala`
+
+```scala
+abstract class CoursierError(message: String, cause: Throwable = null)
+```
+
+#### `scala/coursier/error/ResolutionError.scala`
+
+```scala
+sealed abstract class ResolutionError(
+  val resolution: Resolution,
+  message: String,
+  cause: Throwable = null
+) extends CoursierError(message, cause)
+```
+
+```scala
+def errors: Seq[ResolutionError.Simple]
+```
+
+```scala
+object ResolutionError
+```
+
+```scala
+final class MaximumIterationReached(resolution: Resolution) extends Simple(
+    resolution,
+    "Maximum number of iterations reached"
+  )
+```
+
+```scala
+final class CantDownloadModule(
+    resolution: Resolution,
+    val module: Module,
+    val versionConstraint: VersionConstraint,
+    val perRepositoryErrors: Seq[String]
+  ) extends Simple(
+    resolution,
+    s"Error downloading $module:${versionConstraint.asString}" + System.lineSeparator() +
+      perRepositoryErrors
+        .map { err =>
+          "  " + err.replace(System.lineSeparator(), "  " + System.lineSeparator())
+        }
+        .mkString(System.lineSeparator())
+  )
+```
+
+```scala
+    @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def this(
+      resolution: Resolution,
+      module: Module,
+      version: String,
+      perRepositoryErrors: Seq[String]
+    ) = ...
+```
+
+```scala
+    @deprecated("Use version0 instead", "2.1.25")
+def version: String = ...
+```
+
+```scala
+final class ConflictingDependencies(
+    resolution: Resolution,
+    val dependencies: Set[Dependency]
+  ) extends Simple(resolution, conflictingDependenciesErrorMessage(resolution))
+```
+
+```scala
+sealed abstract class Simple(resolution: Resolution, message: String, cause: Throwable = null)
+```
+
+```scala
+def errors: Seq[ResolutionError.Simple] = ...
+```
+
+```scala
+final class Several(val head: Simple, val tail: Seq[Simple]) extends ResolutionError(
+    head.resolution,
+    (head +: tail).map(_.getMessage).mkString(System.lineSeparator())
+  )
+```
+
+```scala
+def errors: Seq[ResolutionError.Simple] = ...
+```
+
+```scala
+def from(head: ResolutionError, tail: ResolutionError*): ResolutionError = ...
+```
+
+```scala
+abstract class UnsatisfiableRule(
+    resolution: Resolution,
+    val rule: Rule,
+    val conflict: UnsatisfiedRule,
+    message: String
+  ) extends Simple(resolution, message, conflict)
+```
+
+#### `scala/coursier/error/conflict/StrictRule.scala`
+
+```scala
+final class StrictRule(
+  resolution: Resolution,
+  rule: Rule,
+  conflict: UnsatisfiedRule
+) extends UnsatisfiableRule(
+  resolution,
+  rule,
+  conflict,
+  s"Rule $rule not satisfied: $conflict"
+)
+```
+
+#### `scala/coursier/error/conflict/UnsatisfiedRule.scala`
+
+```scala
+abstract class UnsatisfiedRule(
+  val rule: Rule,
+  message: String,
+  cause: Throwable = null
+) extends Exception(s"Unsatisfied rule ${rule.repr}: $message", cause)
+```
+
+#### `scala/coursier/internal/SharedRepositoryParser.scala`
+
+```scala
+object SharedRepositoryParser
+```
+
+```scala
+def repository(s: String): Either[String, Repository] = ...
+```
+
+#### `scala/coursier/internal/Typelevel.scala`
+
+```scala
+object Typelevel
+```
+
+```scala
+val mainLineOrg = ...
+```
+
+```scala
+val typelevelOrg = ...
+```
+
+```scala
+val modules = ...
+```
+
+```scala
+def swap(module: Module): Module = ...
+```
+
+```scala
+val swap: Dependency = ...
+```
+
+#### `scala/coursier/package.scala`
+
+> Mainly pulls definitions from coursier.core, sometimes with default arguments.
+
+```scala
+package object coursier
+```
+
+```scala
+type Organization = ...
+```
+
+```scala
+val Organization = ...
+```
+
+```scala
+type ModuleName = ...
+```
+
+```scala
+val ModuleName = ...
+```
+
+```scala
+type Dependency = ...
+```
+
+```scala
+object Dependency
+```
+
+```scala
+def apply(
+      module: Module,
+      version: VersionConstraint0
+    ): Dependency = ...
+```
+
+```scala
+    @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def apply(
+      module: Module,
+      version: String
+    ): Dependency = ...
+```
+
+```scala
+type VersionConstraint = ...
+```
+
+```scala
+val VersionConstraint = ...
+```
+
+```scala
+type Variant = ...
+```
+
+```scala
+val Variant = ...
+```
+
+```scala
+type VariantSelector = ...
+```
+
+```scala
+val VariantSelector = ...
+```
+
+```scala
+type BomDependency = ...
+```
+
+```scala
+val BomDependency = ...
+```
+
+```scala
+type Attributes = ...
+```
+
+```scala
+object Attributes extends Serializable
+```
+
+```scala
+def apply(
+      `type`: Type = Type.empty,
+      classifier: Classifier = Classifier.empty
+    ): Attributes = ...
+```
+
+```scala
+type Project = ...
+```
+
+```scala
+val Project = ...
+```
+
+```scala
+type Info = ...
+```
+
+```scala
+val Info = ...
+```
+
+```scala
+type Profile = ...
+```
+
+```scala
+val Profile = ...
+```
+
+```scala
+type Module = ...
+```
+
+```scala
+object Module extends Serializable
+```
+
+```scala
+def apply(
+      organization: Organization,
+      name: ModuleName,
+      attributes: Map[String, String] = Map.empty
+    ): Module = ...
+```
+
+```scala
+type ModuleVersion = ...
+```
+
+```scala
+type ProjectCache = ...
+```
+
+```scala
+type Repository = ...
+```
+
+```scala
+val Repository = ...
+```
+
+```scala
+type MavenRepository = ...
+```
+
+```scala
+val MavenRepository = ...
+```
+
+```scala
+type Resolution = ...
+```
+
+```scala
+object Resolution
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+def apply(): Resolution = ...
+```
+
+```scala
+def apply(dependencies: Seq[Dependency]): Resolution = ...
+```
+
+```scala
+def defaultTypes: Set[Type] = ...
+```
+
+```scala
+def enableDependencyOverridesDefault = ...
+```
+
+```scala
+type Classifier = ...
+```
+
+```scala
+val Classifier = ...
+```
+
+```scala
+type Type = ...
+```
+
+```scala
+val Type = ...
+```
+
+```scala
+type ResolutionProcess = ...
+```
+
+```scala
+val ResolutionProcess = ...
+```
+
+```scala
+implicit class ResolutionExtensions(val underlying: Resolution) extends AnyVal
+```
+
+```scala
+def process: ResolutionProcess = ...
+```
+
+```scala
+implicit def organizationString(sc: StringContext): SafeOrganization = ...
+```
+
+```scala
+implicit def moduleNameString(sc: StringContext): SafeModuleName = ...
+```
+
+```scala
+implicit def moduleString(sc: StringContext): SafeModule = ...
+```
+
+```scala
+implicit def moduleExclString(sc: StringContext): SafeModuleExclusionMatcher = ...
+```
+
+```scala
+implicit def moduleInclString(sc: StringContext): SafeModuleInclusionMatcher = ...
+```
+
+```scala
+implicit def dependencyString(sc: StringContext): SafeDependency = ...
+```
+
+```scala
+implicit def mavenRepositoryString(sc: StringContext): SafeMavenRepository = ...
+```
+
+```scala
+implicit def ivyRepositoryString(sc: StringContext): SafeIvyRepository = ...
+```
+
+#### `scala/coursier/params/MavenMirror.scala`
+
+```scala
+object MavenMirror
+```
+
+```scala
+def apply(to: String, first: String, others: String*): MavenMirror = ...
+```
+
+#### `scala/coursier/params/Mirror.scala`
+
+```scala
+abstract class Mirror extends Serializable
+```
+
+```scala
+def matches(repo: Repository): Option[Repository]
+```
+
+```scala
+object Mirror
+```
+
+```scala
+def replace(repositories: Seq[Repository], mirrors: Seq[Mirror]): Seq[Repository] = ...
+```
+
+```scala
+def parse(input: String): Either[String, Mirror] = ...
+```
+
+#### `scala/coursier/params/TreeMirror.scala`
+
+```scala
+object TreeMirror
+```
+
+```scala
+def apply(to: String, first: String, others: String*): TreeMirror = ...
+```
+
+#### `scala/coursier/params/rule/AlwaysFail.scala`
+
+```scala
+object AlwaysFail
+```
+
+```scala
+final class Nope(override val rule: AlwaysFail) extends UnsatisfiedRule(rule, "nope")
+```
+
+```scala
+final class NopityNope(resolution: Resolution, rule: AlwaysFail, conflict: Nope)
+```
+
+#### `scala/coursier/params/rule/DontBumpRootDependencies.scala`
+
+```scala
+object DontBumpRootDependencies
+```
+
+```scala
+def apply(): DontBumpRootDependencies = ...
+```
+
+```scala
+final class BumpedRootDependencies(
+    val bumpedRootDependencies: Seq[(Dependency, String)],
+    override val rule: DontBumpRootDependencies
+  ) extends UnsatisfiedRule(
+        rule,
+        s"Some root dependency versions were bumped: " +
+          bumpedRootDependencies.map(d => s"${d._1.module}:${d._1.versionConstraint.asString}")
+            .toVector
+            .sorted
+            .mkString(", ")
+      )
+```
+
+```scala
+final class CantForceRootDependencyVersions(
+    resolution: Resolution,
+    cantBump: Map[Module, VersionConstraint],
+    conflict: BumpedRootDependencies,
+    override val rule: DontBumpRootDependencies
+  ) extends UnsatisfiableRule(
+        resolution,
+        rule,
+        conflict, {
+          val mods = cantBump
+            .toVector
+            .map {
+              case (k, v) =>
+                s"$k ($v)"
+            }
+            .sorted
+            .mkString(", ")
+          // FIXME More detailed message? (say why it can't be forced)
+          s"Can't force version of modules $mods"
+        }
+      )
+```
+
+#### `scala/coursier/params/rule/Rule.scala`
+
+```scala
+abstract class Rule extends Product with Serializable
+```
+
+```scala
+type C <: UnsatisfiedRule
+```
+
+```scala
+def check(res: Resolution): Option[C]
+```
+
+```scala
+def tryResolve(res: Resolution, conflict: C): Either[UnsatisfiableRule, Resolution]
+```
+
+```scala
+def enforce(
+    res: Resolution,
+    ruleRes: RuleResolution
+  ): Either[UnsatisfiableRule, Either[UnsatisfiedRule, Option[Resolution]]] = ...
+```
+
+```scala
+def repr: String = ...
+```
+
+#### `scala/coursier/params/rule/RuleResolution.scala`
+
+```scala
+sealed abstract class RuleResolution extends Product with Serializable
+```
+
+```scala
+def isWarn: Boolean = ...
+```
+
+```scala
+object RuleResolution
+```
+
+```scala
+case object TryResolve extends RuleResolution
+```
+
+```scala
+case object Warn       extends RuleResolution
+```
+
+```scala
+case object Fail       extends RuleResolution
+```
+
+#### `scala/coursier/params/rule/SameVersion.scala`
+
+```scala
+object SameVersion
+```
+
+```scala
+def apply(module: Module, other: Module*): SameVersion = ...
+```
+
+```scala
+final class SameVersionConflict(
+    override val rule: SameVersion,
+    val modules: Set[Module],
+    val foundVersions: Set[VersionConstraint]
+  ) extends UnsatisfiedRule(
+        rule,
+        s"Found versions ${foundVersions.toVector.sorted.map(_.asString).mkString(", ")} " +
+          s"for ${modules.toVector.map(_.toString).sorted.mkString(", ")}"
+      )
+```
+
+```scala
+final class CantForceSameVersion(
+    resolution: Resolution,
+    override val rule: SameVersion,
+    modules: Set[Module],
+    version: Version,
+    conflict: SameVersionConflict
+  ) extends UnsatisfiableRule(
+        resolution,
+        rule,
+        conflict,
+        // FIXME More detailed message? (say why it can't be forced)
+        s"Can't force version ${version.asString} for modules ${modules.toVector.map(_.toString).mkString(", ")}"
+      )
+```
+
+```scala
+    @deprecated("Use the override accepting a coursier.version.Version instead", "2.1.25")
+def this(
+      resolution: Resolution,
+      rule: SameVersion,
+      modules: Set[Module],
+      version: String,
+      conflict: SameVersionConflict
+    ) = ...
+```
+
+#### `scala/coursier/params/rule/Strict.scala`
+
+```scala
+object Strict
+```
+
+```scala
+final class EvictedDependencies(
+    override val rule: Strict,
+    val evicted: Seq[Conflicted]
+  ) extends UnsatisfiedRule(
+        rule,
+        s"Found evicted dependencies:" + System.lineSeparator() +
+          evicted.map(_.repr + System.lineSeparator()).mkString
+      )
+```
+
+```scala
+final class UnsatisfiableRule(
+    resolution: Resolution,
+    override val rule: Strict,
+    override val conflict: EvictedDependencies
+  ) extends coursier.error.ResolutionError.UnsatisfiableRule(
+        resolution,
+        rule,
+        conflict,
+        conflict.getMessage
+      )
+```
+
+#### `scala/coursier/parse/DependencyParser.scala`
+
+> These are not meant to be used by coursier users. Better coursier/dependency based parsers to
+> come.
+
+```scala
+object DependencyParser
+```
+
+```scala
+def dependency(
+    input: String,
+    defaultScalaVersion: String
+  ): Either[String, Dependency] = ...
+```
+
+```scala
+def dependency(
+    input: String,
+    defaultScalaVersion: String,
+    defaultConfiguration: Configuration
+  ): Either[String, Dependency] = ...
+```
+
+```scala
+def dependencies(
+    inputs: Seq[String],
+    defaultScalaVersion: String
+  ): ValidationNel[String, Seq[Dependency]] = ...
+```
+
+```scala
+def dependencies(
+    inputs: Seq[String],
+    defaultScalaVersion: String,
+    defaultConfiguration: Configuration
+  ): ValidationNel[String, Seq[Dependency]] = ...
+```
+
+```scala
+def javaOrScalaDependencies(
+    inputs: Seq[String]
+  ): ValidationNel[String, Seq[JavaOrScalaDependency]] = ...
+```
+
+```scala
+def javaOrScalaDependencies(
+    inputs: Seq[String],
+    defaultConfiguration: Configuration
+  ): ValidationNel[String, Seq[JavaOrScalaDependency]] = ...
+```
+
+> Parses coordinates like org:name:version possibly with attributes, like
+> org:name;attr1=val1;attr2=val2:version
+
+```scala
+def moduleVersion0(
+    input: String,
+    defaultScalaVersion: String
+  ): Either[String, (Module, VersionConstraint)] = ...
+```
+
+```scala
+  @deprecated("Use moduleVersion0 instead", "2.1.25")
+def moduleVersion(
+    input: String,
+    defaultScalaVersion: String
+  ): Either[String, (Module, String)] = ...
+```
+
+```scala
+def moduleVersions0(
+    inputs: Seq[String],
+    defaultScalaVersion: String
+  ): ValidationNel[String, Seq[(Module, VersionConstraint)]] = ...
+```
+
+```scala
+  @deprecated("Use moduleVersions0 instead", "2.1.25")
+def moduleVersions(
+    inputs: Seq[String],
+    defaultScalaVersion: String
+  ): ValidationNel[String, Seq[(Module, String)]] = ...
+```
+
+```scala
+def dependencyParams(
+    input: String,
+    defaultScalaVersion: String
+  ): Either[String, (Dependency, Map[String, String])] = ...
+```
+
+```scala
+def javaOrScalaDependencyParams(
+    input: String
+  ): Either[String, (JavaOrScalaDependency, Map[String, String])] = ...
+```
+
+> Parses coordinates like org:name:version with attributes, like
+> org:name:version,attr1=val1,attr2=val2 and a configuration, like org:name:version:config or
+> org:name:version:config,attr1=val1,attr2=val2
+>
+> Currently only the "classifier" and "url attributes are used, and others throw errors.
+
+```scala
+def javaOrScalaDependencyParams(
+    input: String,
+    defaultConfiguration: Configuration
+  ): Either[String, (JavaOrScalaDependency, Map[String, String])] = ...
+```
+
+> Parses coordinates like org:name:version with attributes, like
+> org:name:version,attr1=val1,attr2=val2 and a configuration, like org:name:version:config or
+> org:name:version:config,attr1=val1,attr2=val2
+>
+> Currently only the "classifier", "type", "extension", and "url attributes are used, and others
+> throw errors.
+
+```scala
+def dependencyParams(
+    input: String,
+    defaultScalaVersion: String,
+    defaultConfiguration: Configuration
+  ): Either[String, (Dependency, Map[String, String])] = ...
+```
+
+```scala
+def dependenciesParams(
+    inputs: Seq[String],
+    defaultConfiguration: Configuration,
+    defaultScalaVersion: String
+  ): ValidationNel[String, Seq[(Dependency, Map[String, String])]] = ...
+```
+
+```scala
+def javaOrScalaDependenciesParams(
+    inputs: Seq[String]
+  ): ValidationNel[String, Seq[(JavaOrScalaDependency, Map[String, String])]] = ...
+```
+
+```scala
+def javaOrScalaDependenciesParams(
+    inputs: Seq[String],
+    defaultConfiguration: Configuration
+  ): ValidationNel[String, Seq[(JavaOrScalaDependency, Map[String, String])]] = ...
+```
+
+#### `scala/coursier/parse/JavaOrScalaDependency.scala`
+
+```scala
+sealed abstract class JavaOrScalaDependency extends Product with Serializable
+```
+
+```scala
+def module: JavaOrScalaModule
+```
+
+```scala
+def versionConstraint: VersionConstraint
+```
+
+```scala
+def exclude: Set[JavaOrScalaModule]
+```
+
+```scala
+def addExclude(excl: JavaOrScalaModule*): JavaOrScalaDependency
+```
+
+```scala
+def dependency(scalaBinaryVersion: String, scalaVersion: String, platformName: String): Dependency
+```
+
+```scala
+def withPlatform(platformSuffix: String): JavaOrScalaDependency
+```
+
+```scala
+def withUnderlyingDependency(f: Dependency => Dependency): JavaOrScalaDependency
+```
+
+```scala
+final def dependency(scalaVersion: String): Dependency = ...
+```
+
+```scala
+  @deprecated("Use versionConstraint instead", "2.1.25")
+def version: String = ...
+```
+
+```scala
+object JavaOrScalaDependency
+```
+
+```scala
+def apply(mod: JavaOrScalaModule, dep: Dependency): JavaOrScalaDependency = ...
+```
+
+```scala
+def leftOverUserParams(dep: dependency.AnyDependency): Seq[(String, Option[String])] = ...
+```
+
+```scala
+  @deprecated("Use from0 instead", "2.1.25")
+def from(dep: dependency.AnyDependency): Either[String, JavaOrScalaDependency] = ...
+```
+
+```scala
+def from0(dep: dependency.AnyDependency)
+```
+
+#### `scala/coursier/parse/JavaOrScalaModule.scala`
+
+```scala
+sealed abstract class JavaOrScalaModule extends Product with Serializable
+```
+
+```scala
+def attributes: Map[String, String]
+```
+
+```scala
+def module(scalaBinaryVersion: String, scalaVersion: String): Module
+```
+
+```scala
+final def module(scalaVersion: String): Module = ...
+```
+
+```scala
+object JavaOrScalaModule
+```
+
+```scala
+def scalaBinaryVersion(scalaVersion: String): String = ...
+```
+
+#### `scala/coursier/parse/JsonRuleParser.scala`
+
+```scala
+class JsonRuleParser(
+  defaultScalaVersion: String,
+  defaultRuleResolution: RuleResolution
+)
+```
+
+```scala
+def parseRule(s: String): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def parseRule(b: Array[Byte]): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def parseRules(s: String): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+```scala
+def parseRules(b: Array[Byte]): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+```scala
+object JsonRuleParser
+```
+
+```scala
+def parseRule(
+    s: String,
+    defaultScalaVersion: String,
+    defaultRuleResolution: RuleResolution = RuleResolution.TryResolve
+  ): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def parseRule(
+    content: Array[Byte],
+    defaultScalaVersion: String,
+    defaultRuleResolution: RuleResolution
+  ): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def parseRule(
+    content: Array[Byte],
+    defaultScalaVersion: String
+  ): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def parseRules(
+    s: String,
+    defaultScalaVersion: String,
+    defaultRuleResolution: RuleResolution = RuleResolution.TryResolve
+  ): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+```scala
+def parseRules(
+    content: Array[Byte],
+    defaultScalaVersion: String,
+    defaultRuleResolution: RuleResolution
+  ): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+```scala
+def parseRules(
+    content: Array[Byte],
+    defaultScalaVersion: String
+  ): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+#### `scala/coursier/parse/ModuleParser.scala`
+
+```scala
+object ModuleParser
+```
+
+> Parses a module like org:name possibly with attributes, like org:name;attr1=val1;attr2=val2
+>
+> Two semi-columns after the org part is interpreted as a scala module. E.g. if the scala
+> version is 2.11., org::name is equivalent to org:name_2.11.
+
+```scala
+def javaOrScalaModule(s: String): Either[String, JavaOrScalaModule] = ...
+```
+
+> Parses a module like org:name possibly with attributes, like org:name;attr1=val1;attr2=val2
+>
+> Two semi-columns after the org part is interpreted as a scala module. E.g. if
+> `defaultScalaVersion` is `"2.11.x"`, org::name is equivalent to org:name_2.11.
+
+```scala
+def module(s: String, defaultScalaVersion: String): Either[String, Module] = ...
+```
+
+```scala
+def javaOrScalaModules(
+    inputs: Seq[String]
+  ): ValidationNel[String, Seq[JavaOrScalaModule]] = ...
+```
+
+```scala
+def modules(
+    inputs: Seq[String],
+    defaultScalaVersion: String
+  ): ValidationNel[String, Seq[Module]] = ...
+```
+
+#### `scala/coursier/parse/RawJson.scala`
+
+```scala
+final case class RawJson(value: Array[Byte])
+```
+
+```scala
+override lazy val hashCode: Int = ...
+```
+
+```scala
+override def equals(obj: Any): Boolean = ...
+```
+
+```scala
+override def toString: String = ...
+```
+
+```scala
+object RawJson
+```
+
+```scala
+implicit val codec: JsonValueCodec[RawJson] = ...
+```
+
+```scala
+val emptyObj: RawJson = ...
+```
+
+#### `scala/coursier/parse/ReconciliationParser.scala`
+
+```scala
+object ReconciliationParser
+```
+
+```scala
+def reconciliation0(
+    input: Seq[String],
+    scalaVersionOrDefault: String
+  ): ValidationNel[String, Seq[(ModuleMatchers, ConstraintReconciliation)]] = ...
+```
+
+```scala
+  @deprecated("Use reconciliation0 instead", "2.1.25")
+def reconciliation(
+    input: Seq[String],
+    scalaVersionOrDefault: String
+  ): ValidationNel[String, Seq[(ModuleMatchers, coursier.core.Reconciliation)]] = ...
+```
+
+#### `scala/coursier/parse/RepositoryParser.scala`
+
+```scala
+object RepositoryParser extends PlatformRepositoryParser
+```
+
+```scala
+def repositories(inputs: Seq[String]): ValidationNel[String, Seq[Repository]] = ...
+```
+
+#### `scala/coursier/parse/RuleParser.scala`
+
+```scala
+object RuleParser
+```
+
+```scala
+def rule(input: String): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def rule(
+    input: String,
+    defaultResolution: RuleResolution
+  ): Either[String, (Rule, RuleResolution)] = ...
+```
+
+```scala
+def rules(input: String): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+```scala
+def rules(
+    input: String,
+    defaultResolution: RuleResolution
+  ): Either[String, Seq[(Rule, RuleResolution)]] = ...
+```
+
+#### `scala/coursier/util/ModuleMatcher.scala`
+
+```scala
+object ModuleMatcher
+```
+
+```scala
+def apply(
+    org: Organization,
+    name: ModuleName,
+    attributes: Map[String, String] = Map.empty
+  ): ModuleMatcher = ...
+```
+
+```scala
+def all: ModuleMatcher = ...
+```
+
+#### `scala/coursier/util/ModuleMatchers.scala`
+
+```scala
+object ModuleMatchers
+```
+
+```scala
+def all: ModuleMatchers = ...
+```
+
+```scala
+def only(mod: Module): ModuleMatchers = ...
+```
+
+```scala
+def only(mod: ModuleMatcher): ModuleMatchers = ...
+```
+
+```scala
+def only(org: Organization, name: ModuleName): ModuleMatchers = ...
+```
+
+#### `scala/coursier/util/StringInterpolators.scala`
+
+```scala
+object StringInterpolators
+```
+
+```scala
+implicit class SafeOrganization(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def org(args: Any*): Organization = ...
+```
+
+```scala
+implicit class SafeModuleName(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def name(args: Any*): ModuleName = ...
+```
+
+```scala
+implicit class SafeModule(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def mod(args: Any*): Module = ...
+```
+
+```scala
+implicit class SafeModuleExclusionMatcher(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def excl(args: Any*): ModuleMatchers = ...
+```
+
+```scala
+implicit class SafeModuleInclusionMatcher(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def incl(args: Any*): ModuleMatchers = ...
+```
+
+```scala
+implicit class SafeDependency(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def dep(args: Any*): Dependency = ...
+```
+
+```scala
+implicit class SafeMavenRepository(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def mvn(args: Any*): MavenRepository = ...
+```
+
+```scala
+implicit class SafeIvyRepository(val sc: StringContext) extends AnyVal
+```
+
+```scala
+def ivy(args: Any*): IvyRepository = ...
+```
+
+```scala
+def safeOrganization(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Organization] = ...
+```
+
+```scala
+def safeModuleName(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[ModuleName] = ...
+```
+
+```scala
+def safeModule(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Module] = ...
+```
+
+```scala
+def safeModuleExclusionMatcher(
+    c: blackbox.Context
+  )(
+    args: c.Expr[Any]*
+  ): c.Expr[ModuleMatchers] = ...
+```
+
+```scala
+def safeModuleInclusionMatcher(
+    c: blackbox.Context
+  )(
+    args: c.Expr[Any]*
+  ): c.Expr[ModuleMatchers] = ...
+```
+
+```scala
+def safeDependency(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Dependency] = ...
+```
+
+```scala
+def safeMavenRepository(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[MavenRepository] = ...
+```
+
+```scala
+def safeIvyRepository(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[IvyRepository] = ...
+```
+
+### `io.get-coursier:coursier-core_2.13:2.1.25-M3`
+
+Source: https://repo1.maven.org/maven2/io/get-coursier/coursier-core_2.13/2.1.25-M3/coursier-core_2.13-2.1.25-M3-sources.jar
+
+#### `Properties.scala`
+
+> Build-time constants. Generated from mill.
+
+```scala
+object Properties
+```
+
+```scala
+def version = ...
+```
+
+```scala
+def commitHash = ...
+```
+
+#### `coursier/core/compatibility/Entities.scala`
+
+```scala
+object Entities
+```
+
+```scala
+val entities = ...
+```
+
+```scala
+lazy val map = ...
+```
+
+#### `coursier/core/compatibility/package.scala`
+
+```scala
+package object compatibility
+```
+
+```scala
+implicit class RichChar(val c: Char) extends AnyVal
+```
+
+```scala
+def letterOrDigit = ...
+```
+
+```scala
+def letter = ...
+```
+
+```scala
+def xmlPreprocess(s: String): String = ...
+```
+
+```scala
+def xmlParseSax(str: String, handler: SaxHandler): handler.type = ...
+```
+
+```scala
+def xmlParseDom(s: String): Either[String, Xml.Node] = ...
+```
+
+```scala
+def xmlFromElem(elem: Elem): Xml.Node = ...
+```
+
+```scala
+def xmlParse(s: String): Either[String, Xml.Node] = ...
+```
+
+```scala
+def encodeURIComponent(s: String): String = ...
+```
+
+```scala
+def regexLookbehind: String = ...
+```
+
+```scala
+def coloredOutput: Boolean = ...
+```
+
+```scala
+def hasConsole: Boolean = ...
+```
+
+#### `coursier/maven/WritePom.scala`
+
+```scala
+object WritePom
+```
+
+```scala
+def project(proj: Project, packaging: Option[String]) = ...
+```
+
+#### `scala/coursier/core/Activation.scala`
+
+```scala
+object Activation
+```
+
+```scala
+object Os
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+def families(name: String, pathSep: String): Set[String] = ...
+```
+
+```scala
+def fromProperties(properties: Map[String, String]): Os = ...
+```
+
+```scala
+val empty = ...
+```
+
+#### `scala/coursier/core/BomDependency.scala`
+
+```scala
+object BomDependency
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    config: Configuration,
+    forceOverrideVersions: Boolean
+  ): BomDependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    config: Configuration
+  ): BomDependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String
+  ): BomDependency = ...
+```
+
+#### `scala/coursier/core/Definitions.scala`
+
+```scala
+final case class Organization(value: String) extends AnyVal
+```
+
+```scala
+def map(f: String => String): Organization = ...
+```
+
+```scala
+object Organization
+```
+
+```scala
+implicit val ordering: Ordering[Organization] = ...
+```
+
+```scala
+final case class ModuleName(value: String) extends AnyVal
+```
+
+```scala
+def map(f: String => String): ModuleName = ...
+```
+
+```scala
+object ModuleName
+```
+
+```scala
+implicit val ordering: Ordering[ModuleName] = ...
+```
+
+```scala
+object Module
+```
+
+```scala
+def apply(organization: Organization, name: ModuleName, attributes: Map[String, String]): Module = ...
+```
+
+```scala
+final case class Type(value: String) extends AnyVal
+```
+
+```scala
+def isEmpty: Boolean = ...
+```
+
+```scala
+def nonEmpty: Boolean = ...
+```
+
+```scala
+def map(f: String => String): Type = ...
+```
+
+```scala
+def asExtension: Extension = ...
+```
+
+```scala
+object Type
+```
+
+```scala
+implicit val ordering: Ordering[Type] = ...
+```
+
+```scala
+val jar = ...
+```
+
+```scala
+val testJar = ...
+```
+
+```scala
+val bundle = ...
+```
+
+```scala
+val doc = ...
+```
+
+```scala
+val source = ...
+```
+
+```scala
+val javadoc = ...
+```
+
+```scala
+val javaSource = ...
+```
+
+```scala
+val ivy = ...
+```
+
+```scala
+val pom = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+val all = ...
+```
+
+```scala
+object Exotic
+```
+
+```scala
+val mavenPlugin = ...
+```
+
+```scala
+val eclipsePlugin = ...
+```
+
+```scala
+val hk2 = ...
+```
+
+```scala
+val orbit = ...
+```
+
+```scala
+val scalaJar = ...
+```
+
+```scala
+val klib = ...
+```
+
+```scala
+val aar = ...
+```
+
+```scala
+final case class Classifier(value: String) extends AnyVal
+```
+
+```scala
+def isEmpty: Boolean = ...
+```
+
+```scala
+def nonEmpty: Boolean = ...
+```
+
+```scala
+def map(f: String => String): Classifier = ...
+```
+
+```scala
+object Classifier
+```
+
+```scala
+implicit val ordering: Ordering[Classifier] = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+val tests = ...
+```
+
+```scala
+val javadoc = ...
+```
+
+```scala
+val sources = ...
+```
+
+```scala
+final case class Extension(value: String) extends AnyVal
+```
+
+```scala
+def isEmpty: Boolean = ...
+```
+
+```scala
+def map(f: String => String): Extension = ...
+```
+
+```scala
+def asType: Type = ...
+```
+
+```scala
+object Extension
+```
+
+```scala
+implicit val ordering: Ordering[Extension] = ...
+```
+
+```scala
+val jar = ...
+```
+
+```scala
+val pom = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+final case class Configuration(value: String) extends AnyVal
+```
+
+```scala
+def isEmpty: Boolean = ...
+```
+
+```scala
+def nonEmpty: Boolean = ...
+```
+
+```scala
+def -->(target: Configuration): Configuration = ...
+```
+
+```scala
+def map(f: String => String): Configuration = ...
+```
+
+```scala
+object Configuration
+```
+
+```scala
+implicit val ordering: Ordering[Configuration] = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+val compile = ...
+```
+
+```scala
+val runtime = ...
+```
+
+```scala
+val test = ...
+```
+
+```scala
+val default = ...
+```
+
+```scala
+val defaultCompile = ...
+```
+
+```scala
+val defaultRuntime = ...
+```
+
+```scala
+val provided = ...
+```
+
+```scala
+val `import` = ...
+```
+
+```scala
+val optional = ...
+```
+
+```scala
+val all = ...
+```
+
+```scala
+def join(confs: Configuration*): Configuration = ...
+```
+
+```scala
+object Attributes
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+object Project
+```
+
+```scala
+  @deprecated("Use the override accepting Version-s instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    dependencies: Seq[(Configuration, Dependency)],
+    configurations: Map[Configuration, Seq[Configuration]],
+    parent: Option[(Module, String)],
+    dependencyManagement: Seq[(Configuration, Dependency)],
+    properties: Seq[(String, String)],
+    profiles: Seq[Profile],
+    versions: Option[Versions],
+    snapshotVersioning: Option[SnapshotVersioning],
+    packagingOpt: Option[Type],
+    relocated: Boolean,
+    actualVersionOpt: Option[String],
+    publications: Seq[(Configuration, Publication)],
+    info: Info
+  ): Project = ...
+```
+
+```scala
+  @deprecated("Use the override accepting Version-s instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    dependencies: Seq[(Configuration, Dependency)],
+    configurations: Map[Configuration, Seq[Configuration]],
+    parent: Option[(Module, String)],
+    dependencyManagement: Seq[(Configuration, Dependency)],
+    properties: Seq[(String, String)],
+    profiles: Seq[Profile],
+    versions: Option[Versions],
+    snapshotVersioning: Option[SnapshotVersioning],
+    packagingOpt: Option[Type],
+    relocated: Boolean,
+    actualVersionOpt: Option[String],
+    publications: Seq[(Configuration, Publication)],
+    info: Info,
+    overrides: Overrides
+  ): Project = ...
+```
+
+```scala
+object Info
+```
+
+```scala
+def apply(
+    description: String,
+    homePage: String,
+    licenses: Seq[(String, Option[String])],
+    developers: Seq[Info.Developer],
+    publication: Option[Versions.DateTime],
+    scm: Option[Info.Scm]
+  ): Info = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+extension: Extension,
+```
+
+```scala
+extension: Extension,
+```
+
+```scala
+extension,
+```
+
+```scala
+object SnapshotVersion
+```
+
+```scala
+  @deprecated("Use the override accepting a Version instead", "2.1.25")
+def apply(
+    classifier: Classifier,
+    extension: Extension,
+    value: String,
+    updated: Option[Versions.DateTime]
+  ): SnapshotVersion = ...
+```
+
+```scala
+object SnapshotVersioning
+```
+
+```scala
+  @deprecated("Use the override accepting Version-s instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    latest: String,
+    release: String,
+    timestamp: String,
+    buildNumber: Option[Int],
+    localCopy: Option[Boolean],
+    lastUpdated: Option[Versions.DateTime],
+    snapshotVersions: Seq[SnapshotVersion]
+  ): SnapshotVersioning = ...
+```
+
+```scala
+object Publication
+```
+
+```scala
+def apply(name: String, `type`: Type, ext: Extension, classifier: Classifier): Publication = ...
+```
+
+```scala
+val empty: Publication = ...
+```
+
+```scala
+trait ArtifactSource
+```
+
+```scala
+def artifacts(
+    dependency: Dependency,
+    project: Project,
+    overrideClassifiers: Option[Seq[Classifier]]
+  ): Seq[(Publication, Artifact)]
+```
+
+```scala
+object ArtifactSource
+```
+
+```scala
+trait ModuleBased
+```
+
+```scala
+def moduleArtifacts(
+      dependency: Dependency,
+      project: Project
+    ): Seq[(VariantPublication, Artifact)]
+```
+
+#### `scala/coursier/core/Dependency.scala`
+
+```scala
+object Dependency
+```
+
+```scala
+def apply(
+    module: Module,
+    versionConstraint: VersionConstraint0,
+    variantSelector: VariantSelector,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)],
+    bomDependencies: Seq[BomDependency],
+    overridesMap: Overrides
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)],
+    bomDependencies: Seq[BomDependency],
+    overridesMap: Overrides
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0,
+    variantSelector: VariantSelector,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)],
+    bomDependencies: Seq[BomDependency]
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)],
+    bomDependencies: Seq[BomDependency]
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0,
+    variantSelector: VariantSelector,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)]
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map,
+    boms: Seq[(Module, String)]
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0,
+    variantSelector: VariantSelector,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean,
+    overrides: DependencyManagement.Map
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0,
+    variantSelector: VariantSelector,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    minimizedExclusions: MinimizedExclusions,
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    versionConstraint: VersionConstraint0,
+    variantSelector: VariantSelector,
+    exclusions: Set[(Organization, ModuleName)],
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    exclusions: Set[(Organization, ModuleName)],
+    publication: Publication,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String
+  ): Dependency = ...
+```
+
+```scala
+def apply(
+    module: Module,
+    version: VersionConstraint0,
+    variantSelector: VariantSelector,
+    exclusions: Set[(Organization, ModuleName)],
+    attributes: Attributes,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    configuration: Configuration,
+    exclusions: Set[(Organization, ModuleName)],
+    attributes: Attributes,
+    optional: Boolean,
+    transitive: Boolean
+  ): Dependency = ...
+```
+
+```scala
+def mavenPrefix(module: Module, attributes: Attributes): String = ...
+```
+
+#### `scala/coursier/core/DependencyManagement.scala`
+
+```scala
+object DependencyManagement
+```
+
+```scala
+type Map = ...
+```
+
+```scala
+type GenericMap = ...
+```
+
+```scala
+object Key
+```
+
+```scala
+def from(dep: Dependency): Key = ...
+```
+
+```scala
+object Values
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+def from(config: Configuration, dep: Dependency): Values = ...
+```
+
+```scala
+    @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def apply(
+      config: Configuration,
+      version: String,
+      minimizedExclusions: MinimizedExclusions,
+      optional: Boolean
+    ): Values = ...
+```
+
+```scala
+def entry(config: Configuration, dep: Dependency): (Key, Values) = ...
+```
+
+> Converts a sequence of dependency management entries to a dependency management map
+>
+> The map having at most one value per key, rather than possibly several in the sequence
+>
+> This composes the values together, keeping the version of the first one, and adding their
+> exclusions if `composeValues` is true (the default). In particular, this respects the order of
+> values in the incoming sequence, and makes sure the values in the initial map go before those
+> of the sequence.
+
+```scala
+def add(
+    initialMap: Map,
+    entries: Seq[(Key, Values)],
+    composeValues: Boolean = true
+  ): Map = ...
+```
+
+```scala
+def addAll(
+    initialMap: Map,
+    entries: Seq[GenericMap],
+    composeValues: Boolean = true
+  ): GenericMap = ...
+```
+
+```scala
+def addDependencies(
+    map: Map,
+    deps: Seq[(Configuration, Dependency)],
+    composeValues: Boolean = true
+  ): Map = ...
+```
+
+#### `scala/coursier/core/DependencySet.scala`
+
+```scala
+object DependencySet
+```
+
+```scala
+val empty = ...
+```
+
+#### `scala/coursier/core/Exclusions.scala`
+
+```scala
+object Exclusions
+```
+
+```scala
+def partition(
+    exclusions: Set[(Organization, ModuleName)]
+  ): (Boolean, Set[Organization], Set[ModuleName], Set[(Organization, ModuleName)]) = ...
+```
+
+```scala
+def apply(exclusions: Set[(Organization, ModuleName)]): (Organization, ModuleName) = ...
+```
+
+```scala
+def minimize(exclusions: Set[(Organization, ModuleName)]): Set[(Organization, ModuleName)] = ...
+```
+
+```scala
+val allOrganizations = ...
+```
+
+```scala
+val allNames = ...
+```
+
+```scala
+val zero = ...
+```
+
+```scala
+val one = ...
+```
+
+```scala
+def join(
+    x: Set[(Organization, ModuleName)],
+    y: Set[(Organization, ModuleName)]
+  ): Set[(Organization, ModuleName)] = ...
+```
+
+```scala
+def meet(
+    x: Set[(Organization, ModuleName)],
+    y: Set[(Organization, ModuleName)]
+  ): Set[(Organization, ModuleName)] = ...
+```
+
+#### `scala/coursier/core/Latest.scala`
+
+```scala
+@deprecated("Use coursier.version.Latest instead", "2.1.25")
+sealed abstract class Latest(val name: String) extends Product with Serializable
+```
+
+```scala
+@deprecated("Use coursier.version.Latest instead", "2.1.25")
+object Latest
+```
+
+```scala
+case object Integration extends Latest("integration")
+```
+
+```scala
+case object Release     extends Latest("release")
+```
+
+```scala
+case object Stable      extends Latest("stable")
+```
+
+```scala
+def apply(s: String): Option[Latest] = ...
+```
+
+#### `scala/coursier/core/MinimizedExclusions.scala`
+
+> This file defines a special-purpose structure for exclusions that has the following
+> properties/goals:
+> - The exclusion data is always minimized (minimized meaning overlapping rules are removed)
+> - The data structure is split into various cases, optimizing common cases for join/meet
+> - The hashcode is cached, such that recalculating the hashcode for these exclusions is cached.
+
+```scala
+object MinimizedExclusions
+```
+
+```scala
+val zero = ...
+```
+
+```scala
+val one = ...
+```
+
+```scala
+sealed abstract class ExclusionData extends Product with Serializable
+```
+
+```scala
+def apply(org: Organization, module: ModuleName): Boolean
+```
+
+```scala
+def join(other: ExclusionData): ExclusionData
+```
+
+```scala
+def meet(other: ExclusionData): ExclusionData
+```
+
+```scala
+def partitioned()
+```
+
+```scala
+def map(f: String => String): ExclusionData
+```
+
+```scala
+def size(): Int
+```
+
+```scala
+def subsetOf(other: ExclusionData): Boolean
+```
+
+```scala
+def toSet(): Set[(Organization, ModuleName)]
+```
+
+```scala
+def hasProperties: Boolean
+```
+
+```scala
+case object ExcludeNone extends ExclusionData
+```
+
+```scala
+override def apply(org: Organization, module: ModuleName): Boolean = ...
+```
+
+```scala
+override def join(other: ExclusionData): ExclusionData = ...
+```
+
+```scala
+override def meet(other: ExclusionData): ExclusionData = ...
+```
+
+```scala
+override def partitioned()
+```
+
+```scala
+override def map(f: String => String): ExclusionData = ...
+```
+
+```scala
+override def size(): Int = ...
+```
+
+```scala
+override def subsetOf(other: ExclusionData): Boolean = ...
+```
+
+```scala
+override def toSet(): Set[(Organization, ModuleName)] = ...
+```
+
+```scala
+def hasProperties: Boolean = ...
+```
+
+```scala
+case object ExcludeAll extends ExclusionData
+```
+
+```scala
+override def apply(org: Organization, module: ModuleName): Boolean = ...
+```
+
+```scala
+override def join(other: ExclusionData): ExclusionData = ...
+```
+
+```scala
+override def meet(other: ExclusionData): ExclusionData = ...
+```
+
+```scala
+override def partitioned()
+```
+
+```scala
+override def map(f: String => String): ExclusionData = ...
+```
+
+```scala
+override def size(): Int = ...
+```
+
+```scala
+override def subsetOf(other: ExclusionData): Boolean = ...
+```
+
+```scala
+override def toSet(): Set[(Organization, ModuleName)] = ...
+```
+
+```scala
+def hasProperties: Boolean = ...
+```
+
+```scala
+def apply(exclusions: Set[(Organization, ModuleName)]): MinimizedExclusions = ...
+```
+
+#### `scala/coursier/core/Orders.scala`
+
+```scala
+object Orders
+```
+
+```scala
+  @deprecated("Will likely be removed at some point in future versions", "2.0.0-RC3")
+trait PartialOrdering[T] extends scala.math.PartialOrdering[T]
+```
+
+```scala
+def lteq(x: T, y: T): Boolean = ...
+```
+
+> All configurations that each configuration extends, including the ones it extends transitively
+
+```scala
+  @deprecated("Will likely be removed at some point in future versions", "2.0.0-RC3")
+def allConfigurations(
+    configurations: Map[Configuration, Seq[Configuration]]
+  ): Map[Configuration, Set[Configuration]] = ...
+```
+
+> Configurations partial order based on configuration mapping `configurations`.
+>
+> @param configurations:
+> for each configuration, the configurations it directly extends.
+
+```scala
+  @deprecated("Will likely be removed at some point in future versions", "2.0.0-RC3")
+def configurationPartialOrder(
+    configurations: Map[Configuration, Seq[Configuration]]
+  ): PartialOrdering[Configuration] = ...
+```
+
+> Non-optional < optional
+
+```scala
+  @deprecated("Will likely be removed at some point in future versions", "2.0.0-RC3")
+val optionalPartialOrder: PartialOrdering[Boolean] = ...
+```
+
+```scala
+val exclusionsPartialOrder: PartialOrdering[Set[(Organization, ModuleName)]] = ...
+```
+
+```scala
+def minDependenciesUnsafe(
+    dependencies: Set[Dependency],
+    configs: Map[Configuration, Seq[Configuration]]
+  ): Set[Dependency] = ...
+```
+
+```scala
+def minDependencies(
+    dependencies: Set[Dependency],
+    configs: ((Module, String)) => Map[Configuration, Seq[Configuration]]
+  ): Set[Dependency] = ...
+```
+
+#### `scala/coursier/core/Overrides.scala`
+
+```scala
+sealed abstract class Overrides extends Product with Serializable
+```
+
+```scala
+def get(key: DependencyManagement.Key): Option[DependencyManagement.Values]
+```
+
+```scala
+def contains(key: DependencyManagement.Key): Boolean
+```
+
+```scala
+def isEmpty: Boolean
+```
+
+```scala
+def nonEmpty: Boolean = ...
+```
+
+```scala
+def maps: Seq[DependencyManagement.GenericMap]
+```
+
+```scala
+def flatten: DependencyManagement.GenericMap = ...
+```
+
+```scala
+def filter(f: (DependencyManagement.Key, DependencyManagement.Values) => Boolean): Overrides
+```
+
+```scala
+def map(
+    f: (
+      DependencyManagement.Key,
+      DependencyManagement.Values
+    ) => (DependencyManagement.Key, DependencyManagement.Values)
+  ): Overrides
+```
+
+```scala
+def mapMap(
+    f: DependencyManagement.GenericMap => Option[DependencyManagement.GenericMap]
+  ): Overrides
+```
+
+```scala
+def hasProperties: Boolean
+```
+
+```scala
+object Overrides
+```
+
+```scala
+def empty: Overrides = ...
+```
+
+```scala
+def apply(map: DependencyManagement.GenericMap): Overrides = ...
+```
+
+```scala
+def add(overrides: Overrides*): Overrides = ...
+```
+
+#### `scala/coursier/core/Parse.scala`
+
+```scala
+object Parse
+```
+
+```scala
+  @deprecated("Use coursier.version.VersionParse.version instead", "2.1.25")
+def version(s: String): Option[Version] = ...
+```
+
+```scala
+  @deprecated("Unused by coursier", "2.1.25")
+def ivyLatestSubRevisionInterval(s: String): Option[VersionInterval] = ...
+```
+
+```scala
+  @deprecated("Use coursier.version.VersionParse.versionInterval instead", "2.1.25")
+def versionInterval(s: String): Option[VersionInterval] = ...
+```
+
+```scala
+  @deprecated("Unused by coursier", "2.1.25")
+def multiVersionInterval(s: String): Option[VersionInterval] = ...
+```
+
+```scala
+  @deprecated("Use coursier.version.VersionParse.versionConstraint instead", "2.1.25")
+def versionConstraint(s: String): VersionConstraint = ...
+```
+
+```scala
+val fallbackConfigRegex = ...
+```
+
+```scala
+def withFallbackConfig(config: Configuration): Option[(Configuration, Configuration)] = ...
+```
+
+#### `scala/coursier/core/Reconciliation.scala`
+
+> Represents a reconciliation strategy given a dependency conflict.
+
+```scala
+@deprecated("Use coursier.version.ConstraintReconciliation instead", "2.1.25")
+sealed abstract class Reconciliation
+```
+
+> Reconcile multiple version candidate.
+>
+> Returns `None` in case of conflict.
+
+```scala
+def apply(versions: Seq[VersionConstraint0]): Option[VersionConstraint0]
+```
+
+```scala
+def reconcile(versions: Seq[VersionConstraint0]): Option[VersionConstraint0] = ...
+```
+
+```scala
+def id: String
+```
+
+```scala
+@deprecated("Use coursier.version.ConstraintReconciliation instead", "2.1.25")
+object Reconciliation
+```
+
+```scala
+case object Default extends Reconciliation
+```
+
+```scala
+def apply(versions: Seq[VersionConstraint0]): Option[VersionConstraint0] = ...
+```
+
+```scala
+def id: String = ...
+```
+
+```scala
+case object Relaxed extends Reconciliation
+```
+
+```scala
+def apply(versions: Seq[VersionConstraint0]): Option[VersionConstraint0] = ...
+```
+
+```scala
+def id: String = ...
+```
+
+> Strict version reconciliation.
+>
+> This particular instance behaves the same as [[Default]] when used by
+> [[coursier.core.Resolution]]. Actual strict conflict manager is handled by
+> `coursier.params.rule.Strict`, which is set up by `coursier.Resolve` when a strict
+> reconciliation is added to it.
+
+```scala
+case object Strict extends Reconciliation
+```
+
+```scala
+def apply(versions: Seq[VersionConstraint0]): Option[VersionConstraint0] = ...
+```
+
+```scala
+def id: String = ...
+```
+
+> Semantic versioning version reconciliation.
+>
+> This particular instance behaves the same as [[Default]] when used by
+> [[coursier.core.Resolution]]. Actual semantic versioning checks are handled by
+> `coursier.params.rule.Strict` with field `semVer = true`, which is set up by
+> `coursier.Resolve` when a SemVer reconciliation is added to it.
+
+```scala
+case object SemVer extends Reconciliation
+```
+
+```scala
+def apply(versions: Seq[VersionConstraint0]): Option[VersionConstraint0] = ...
+```
+
+```scala
+def id: String = ...
+```
+
+```scala
+def apply(input: VersionConstraint0): Option[Reconciliation] = ...
+```
+
+```scala
+def apply(input: String): Option[Reconciliation] = ...
+```
+
+#### `scala/coursier/core/Repository.scala`
+
+```scala
+trait Repository extends Serializable with ArtifactSource
+```
+
+```scala
+def repr: String = ...
+```
+
+```scala
+def find0[F[_]](
+    module: Module,
+    version: Version0,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)] = ...
+```
+
+```scala
+def find[F[_]](
+    module: Module,
+    version: String,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)]
+```
+
+```scala
+  @deprecated("Unused by coursier", "2.1.25")
+def findMaybeInterval[F[_]](
+    module: Module,
+    version: VersionConstraint0,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)] = ...
+```
+
+```scala
+  @deprecated("Unused by coursier", "2.1.25")
+def findMaybeInterval[F[_]](
+    module: Module,
+    version: String,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)] = ...
+```
+
+```scala
+def findFromVersionConstraint[F[_]](
+    module: Module,
+    versionConstraint: VersionConstraint0,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)] = ...
+```
+
+```scala
+def completeOpt[F[_]: Monad](fetch: Repository.Fetch[F]): Option[Repository.Complete[F]] = ...
+```
+
+```scala
+def versionsCheckHasModule: Boolean = ...
+```
+
+```scala
+def versions[F[_]](
+    module: Module,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (Versions, String)] = ...
+```
+
+```scala
+def versions[F[_]](
+    module: Module,
+    fetch: Repository.Fetch[F],
+    versionsCheckHasModule: Boolean
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (Versions, String)] = ...
+```
+
+```scala
+object Repository
+```
+
+```scala
+type Fetch[F[_]] = ...
+```
+
+```scala
+implicit class ArtifactExtensions(val underlying: Artifact) extends AnyVal
+```
+
+```scala
+def withDefaultChecksums: Artifact = ...
+```
+
+```scala
+def withDefaultSignature: Artifact = ...
+```
+
+```scala
+trait Complete[F[_]]
+```
+
+```scala
+def organization(prefix: String): F[Either[Throwable, Seq[String]]]
+```
+
+```scala
+def moduleName(organization: Organization, prefix: String): F[Either[Throwable, Seq[String]]]
+```
+
+```scala
+def versions(
+      module: Module,
+      prefix: String
+    ): F[Either[Throwable, Seq[Version0]]]
+```
+
+```scala
+def hasModule(module: Module)(implicit F: Monad[F]): F[Boolean] = ...
+```
+
+```scala
+final def complete(
+      input: Complete.Input
+    )(implicit
+      F: Monad[F]
+    ): F[Either[Throwable, Complete.Result]] = ...
+```
+
+```scala
+final def complete(
+      input: String,
+      scalaVersion: String,
+      scalaBinaryVersion: String
+    )(implicit
+      F: Monad[F]
+    ): F[Either[Throwable, Complete.Result]] = ...
+```
+
+```scala
+object Complete
+```
+
+```scala
+sealed abstract class Input extends Product with Serializable
+```
+
+```scala
+def input: String
+```
+
+```scala
+def from: Int
+```
+
+```scala
+object Input
+```
+
+```scala
+def parse(
+      input: String,
+      scalaVersion: String,
+      scalaBinaryVersion: String
+    ): Either[Throwable, Input] = ...
+```
+
+```scala
+    @data class Result(input: Input, completions: Seq[String])
+final class CompletingOrgException(input: String, cause: Throwable = null)
+```
+
+```scala
+final class CompletingNameException(
+      organization: Organization,
+      input: String,
+      from: Int,
+      cause: Throwable = null
+      // format: off
+    ) extends Exception(
+      s"Completing module name '${input.drop(from)}' for organization ${organization.value}",
+      cause
+    )
+```
+
+```scala
+final class CompletingVersionException(
+      module: Module,
+      input: String,
+      from: Int,
+      cause: Throwable = null
+    ) extends Exception(s"Completing version '${input.drop(from)}' for module $module", cause)
+```
+
+```scala
+final class MalformedInput(input: String)
+```
+
+```scala
+trait VersionApi extends Repository
+```
+
+```scala
+def find[F[_]](
+      module: Module,
+      version: String,
+      fetch: Repository.Fetch[F]
+    )(implicit
+      F: Monad[F]
+    ): EitherT[F, String, (ArtifactSource, Project)] = ...
+```
+
+#### `scala/coursier/core/Resolution.scala`
+
+```scala
+object Resolution
+```
+
+```scala
+type ModuleVersion = ...
+```
+
+```scala
+type ModuleVersionConstraint = ...
+```
+
+```scala
+def profileIsActive0(
+    profile: Profile,
+    properties: Map[String, String],
+    osInfo: Activation.Os,
+    jdkVersion: Option[Version0],
+    userActivations: Option[Map[String, Boolean]]
+  ): Boolean = ...
+```
+
+```scala
+  @deprecated("Use profileIsActive0 instead", "2.1.25")
+def profileIsActive(
+    profile: Profile,
+    properties: Map[String, String],
+    osInfo: Activation.Os,
+    jdkVersion: Option[String],
+    userActivations: Option[Map[String, Boolean]]
+  ): Boolean = ...
+```
+
+> Get the active profiles of `project`, using the current properties `properties`, and
+> `profileActivations` stating if a profile is active.
+
+```scala
+def profiles0(
+    project: Project,
+    properties: Map[String, String],
+    osInfo: Activation.Os,
+    jdkVersion: Option[Version0],
+    userActivations: Option[Map[String, Boolean]]
+  ): Seq[Profile] = ...
+```
+
+```scala
+  @deprecated("Use profiles0 instead", "2.1.25")
+def profiles(
+    project: Project,
+    properties: Map[String, String],
+    osInfo: Activation.Os,
+    jdkVersion: Option[String],
+    userActivations: Option[Map[String, Boolean]]
+  ): Seq[Profile] = ...
+```
+
+```scala
+def addDependencies(
+    deps: Seq[Seq[(Variant, Dependency)]]
+  ): Seq[(Variant, Dependency)] = ...
+```
+
+```scala
+def hasProps(s: String): Boolean = ...
+```
+
+```scala
+def substituteProps(s: String, properties: Map[String, String]): String = ...
+```
+
+```scala
+def substituteProps(s: String, properties: Map[String, String], trim: Boolean): String = ...
+```
+
+```scala
+def withProperties0(
+    dependencies: Seq[(Variant, Dependency)],
+    properties: Map[String, String]
+  ): Seq[(Variant, Dependency)] = ...
+```
+
+```scala
+  @deprecated("Use withProperties0 instead", "2.1.25")
+def withProperties(
+    dependencies: Seq[(Configuration, Dependency)],
+    properties: Map[String, String]
+  ): Seq[(Configuration, Dependency)] = ...
+```
+
+> Merge several dependencies, solving version constraints of duplicated modules.
+>
+> Returns the conflicted dependencies, and the merged others.
+
+```scala
+def merge0(
+    dependencies: Seq[Dependency],
+    forceVersions: Map[Module, VersionConstraint0],
+    reconciliation: Option[Module => ConstraintReconciliation],
+    preserveOrder: Boolean = false
+  ): (Seq[Dependency], Seq[Dependency], Map[Module, VersionConstraint0]) = ...
+```
+
+```scala
+  @deprecated("", "2.1.25")
+def merge(
+    dependencies: Seq[Dependency],
+    forceVersions: Map[Module, String],
+    reconciliation: Option[Module => coursier.core.Reconciliation],
+    preserveOrder: Boolean = false
+  ): (Seq[Dependency], Seq[Dependency], Map[Module, String]) = ...
+```
+
+> Applies `dependencyManagement` to `dependencies`.
+>
+> Fill empty version / scope / exclusions, for dependencies found in `dependencyManagement`.
+
+```scala
+def depsWithDependencyManagement0(
+    rawDependencies: Seq[(Variant, Dependency)],
+    properties: Map[String, String],
+    rawOverridesOpt: Option[Overrides],
+    rawDependencyManagement: Overrides,
+    forceDepMgmtVersions: Boolean,
+    keepVariant: Variant => Boolean
+  ): Seq[(Variant, Dependency)] = ...
+```
+
+```scala
+  @deprecated("Use depsWithDependencyManagement0 instead", "2.1.25")
+def depsWithDependencyManagement(
+    rawDependencies: Seq[(Configuration, Dependency)],
+    properties: Map[String, String],
+    rawOverridesOpt: Option[Overrides],
+    rawDependencyManagement: Overrides,
+    forceDepMgmtVersions: Boolean,
+    keepVariant: Variant => Boolean
+  ): Seq[(Configuration, Dependency)] = ...
+```
+
+```scala
+def depsWithDependencyManagement(
+    rawDependencies: Seq[(Configuration, Dependency)],
+    properties: Map[String, String],
+    rawOverridesOpt: Option[DependencyManagement.Map],
+    rawDependencyManagement: Seq[(Configuration, Dependency)],
+    forceDepMgmtVersions: Boolean
+  ): Seq[(Configuration, Dependency)] = ...
+```
+
+```scala
+def depsWithDependencyManagement(
+    dependencies: Seq[(Configuration, Dependency)],
+    dependencyManagement: Seq[(Configuration, Dependency)]
+  ): Seq[(Configuration, Dependency)] = ...
+```
+
+> Filters `dependencies` with `exclusions`.
+
+```scala
+def withExclusions0(
+    dependencies: Seq[(Variant, Dependency)],
+    exclusions: Set[(Organization, ModuleName)]
+  ): Seq[(Variant, Dependency)] = ...
+```
+
+```scala
+  @deprecated("Use withExclusions0 instead", "2.1.25")
+def withExclusions(
+    dependencies: Seq[(Configuration, Dependency)],
+    exclusions: Set[(Organization, ModuleName)]
+  ): Seq[(Configuration, Dependency)] = ...
+```
+
+```scala
+def actualConfiguration(
+    config: Configuration,
+    configurations: Map[Configuration, Seq[Configuration]]
+  ): Configuration = ...
+```
+
+```scala
+def actualConfiguration(
+    config: Configuration,
+    configurations: Set[Configuration]
+  ): Configuration = ...
+```
+
+```scala
+def parentConfigurations(
+    actualConfig: Configuration,
+    configurations: Map[Configuration, Seq[Configuration]]
+  ): Set[Configuration] = ...
+```
+
+```scala
+  @deprecated("Unused by coursier, should be removed in the future", "2.1.25")
+def withParentConfigurations(
+    config: Configuration,
+    configurations: Map[Configuration, Seq[Configuration]]
+  ): (Configuration, Set[Configuration]) = ...
+```
+
+```scala
+def projectProperties(project: Project): Seq[(String, String)] = ...
+```
+
+> Default dependency filter used during resolution.
+>
+> Does not follow optional dependencies.
+
+```scala
+def defaultFilter(dep: Dependency): Boolean = ...
+```
+
+```scala
+val defaultTypes = ...
+```
+
+```scala
+def overrideScalaModule(sv: VersionConstraint0): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def overrideScalaModule(sv: String): Dependency = ...
+```
+
+```scala
+def overrideScalaModule(
+    sv: VersionConstraint0,
+    scalaOrg: Organization
+  ): Dependency = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint instead", "2.1.25")
+def overrideScalaModule(
+    sv: String,
+    scalaOrg: Organization
+  ): Dependency = ...
+```
+
+> Replaces the full suffix _2.12.8 with the given Scala version.
+
+```scala
+def overrideFullSuffix(sv: String): Dependency = ...
+```
+
+```scala
+  @deprecated("Use overrideScalaModule and overrideFullSuffix instead", "2.0.17")
+def forceScalaVersion(sv: String): Dependency = ...
+```
+
+```scala
+def enableDependencyOverridesDefault: Boolean = ...
+```
+
+#### `scala/coursier/core/ResolutionProcess.scala`
+
+```scala
+sealed abstract class ResolutionProcess extends Product with Serializable
+```
+
+```scala
+def run0[F[_]](
+    fetch: ResolutionProcess.Fetch0[F],
+    maxIterations: Int = ResolutionProcess.defaultMaxIterations
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] = ...
+```
+
+```scala
+  @deprecated("Use run0 instead", "2.1.25")
+def run[F[_]](
+    fetch: ResolutionProcess.Fetch[F],
+    maxIterations: Int = ResolutionProcess.defaultMaxIterations
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] = ...
+```
+
+```scala
+  @tailrec
+final def next_[F[_]](
+    fetch: ResolutionProcess.Fetch0[F],
+    fastForward: Boolean = true
+  )(implicit
+    F: Monad[F]
+  ): F[ResolutionProcess] = ...
+```
+
+```scala
+  @deprecated("Use next_ instead", "2.1.25")
+final def next[F[_]](
+    fetch: ResolutionProcess.Fetch[F],
+    fastForward: Boolean = true
+  )(implicit
+    F: Monad[F]
+  ): F[ResolutionProcess] = ...
+```
+
+```scala
+def current: Resolution
+```
+
+```scala
+object ResolutionProcess
+```
+
+```scala
+  @deprecated("Use ResolutionProcess.MD0 instead", "2.1.25")
+type MD = ...
+```
+
+```scala
+  @deprecated("Use ResolutionProcess.Fetch0 instead", "2.1.25")
+type Fetch[F[_]] = ...
+```
+
+```scala
+type MD0 = ...
+```
+
+```scala
+type Fetch0[F[_]] = ...
+```
+
+> Try to find `module` among `repositories`.
+>
+> Look at `repositories` from the left, one-by-one, and stop at first success. Else, return all
+> errors, in the same order.
+>
+> The `version` field of the returned `Project` in case of success may not be equal to the
+> provided one, in case the latter is not a specific version (e.g. version interval). Which
+> version get chosen depends on the repository implementation.
+
+```scala
+def fetchOne[F[_]](
+    repositories: Seq[Repository],
+    module: Module,
+    version: VersionConstraint0,
+    fetch: Repository.Fetch[F],
+    fetchs: Seq[Repository.Fetch[F]]
+  )(implicit
+    F: Gather[F]
+  ): EitherT[F, Seq[String], (ArtifactSource, Project)] = ...
+```
+
+```scala
+def fetchOne[F[_]](
+    repositories: Seq[Repository],
+    module: Module,
+    version: String,
+    fetch: Repository.Fetch[F],
+    fetchs: Seq[Repository.Fetch[F]]
+  )(implicit
+    F: Gather[F]
+  ): EitherT[F, Seq[String], (ArtifactSource, Project)] = ...
+```
+
+```scala
+def fetch0[F[_]](
+    repositories: Seq[Repository],
+    fetch: Repository.Fetch[F],
+    fetchs: Seq[Repository.Fetch[F]] = Nil
+  )(implicit
+    F: Gather[F]
+  ): Fetch0[F] = ...
+```
+
+```scala
+  @deprecated("Use fetch0 instead", "2.1.25")
+def fetch[F[_]](
+    repositories: Seq[Repository],
+    fetch: Repository.Fetch[F],
+    fetchs: Seq[Repository.Fetch[F]] = Nil
+  )(implicit
+    F: Gather[F]
+  ): Fetch[F] = ...
+```
+
+```scala
+def defaultMaxIterations: Int = ...
+```
+
+```scala
+def apply(resolution: Resolution): ResolutionProcess = ...
+```
+
+#### `scala/coursier/core/Variant.scala`
+
+```scala
+sealed abstract class Variant extends Product with Serializable
+```
+
+```scala
+def asConfiguration: Option[Configuration0]
+```
+
+```scala
+def isEmpty: Boolean
+```
+
+```scala
+object Variant
+```
+
+```scala
+lazy val emptyConfiguration: Variant = ...
+```
+
+#### `scala/coursier/core/VariantSelector.scala`
+
+```scala
+sealed abstract class VariantSelector extends Product with Serializable
+```
+
+```scala
+def asConfiguration: Option[Configuration]
+```
+
+```scala
+def isEmpty: Boolean
+```
+
+```scala
+final def nonEmpty: Boolean = ...
+```
+
+```scala
+def repr: String
+```
+
+```scala
+object VariantSelector
+```
+
+```scala
+object AttributesBased
+```
+
+```scala
+def empty: AttributesBased = ...
+```
+
+```scala
+lazy val emptyConfiguration: VariantSelector = ...
+```
+
+```scala
+sealed abstract class VariantMatcher extends Product with Serializable
+```
+
+```scala
+def matches(value: String): Boolean
+```
+
+```scala
+def repr: String
+```
+
+```scala
+object VariantMatcher
+```
+
+```scala
+case object Api extends VariantMatcher
+```
+
+```scala
+def matches(inputValue: String): Boolean = ...
+```
+
+```scala
+def repr: String = ...
+```
+
+```scala
+case object Runtime extends VariantMatcher
+```
+
+```scala
+def matches(inputValue: String): Boolean = ...
+```
+
+```scala
+def repr: String = ...
+```
+
+```scala
+val Library: VariantMatcher = ...
+```
+
+```scala
+def fromString(key: String, value: String): (String, VariantMatcher) = ...
+```
+
+#### `scala/coursier/core/Version.scala`
+
+```scala
+object Version
+```
+
+```scala
+sealed abstract class Item extends Ordered[Item]
+```
+
+```scala
+def compare(other: Item): Int = ...
+```
+
+```scala
+def order: Int
+```
+
+```scala
+def isEmpty: Boolean = ...
+```
+
+```scala
+def compareToEmpty: Int = ...
+```
+
+```scala
+sealed abstract class Numeric extends Item
+```
+
+```scala
+def repr: String
+```
+
+```scala
+def next: Numeric
+```
+
+```scala
+case object Min extends Item
+```
+
+```scala
+val order = ...
+```
+
+```scala
+override def compareToEmpty = ...
+```
+
+```scala
+case object Max extends Item
+```
+
+```scala
+val order = ...
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+object Tokenizer
+```
+
+```scala
+sealed abstract class Separator
+```
+
+```scala
+case object Dot        extends Separator
+```
+
+```scala
+case object Hyphen     extends Separator
+```
+
+```scala
+case object Underscore extends Separator
+```
+
+```scala
+case object Plus       extends Separator
+```
+
+```scala
+case object None       extends Separator
+```
+
+```scala
+def apply(str: String): (Item, LazyList[(Separator, Item)]) = ...
+```
+
+```scala
+def isNumeric(item: Item) = ...
+```
+
+```scala
+def isBuildMetadata(item: Item) = ...
+```
+
+```scala
+def items(repr: String): Vector[Item] = ...
+```
+
+```scala
+def listCompare(first0: Vector[Item], second0: Vector[Item]): Int = ...
+```
+
+#### `scala/coursier/core/VersionConstraint.scala`
+
+```scala
+@deprecated("Use coursier.version.VersionConstraint instead", "2.1.25")
+object VersionConstraint
+```
+
+```scala
+def preferred(version: Version): VersionConstraint = ...
+```
+
+```scala
+def interval(interval: VersionInterval): VersionConstraint = ...
+```
+
+```scala
+val all = ...
+```
+
+```scala
+def merge(constraints: VersionConstraint*): Option[VersionConstraint] = ...
+```
+
+```scala
+def relaxedMerge(constraints: VersionConstraint*): VersionConstraint = ...
+```
+
+#### `scala/coursier/core/VersionInterval.scala`
+
+```scala
+@deprecated("Use coursier.version.VersionInterval instead", "2.1.25")
+object VersionInterval
+```
+
+```scala
+val zero = ...
+```
+
+#### `scala/coursier/core/Versions.scala`
+
+```scala
+object Versions
+```
+
+```scala
+val empty = ...
+```
+
+```scala
+  @deprecated("Use the override accepting Version-s instead", "2.1.25")
+def apply(
+    latest: String,
+    release: String,
+    available: List[String],
+    lastUpdated: Option[Versions.DateTime]
+  ): Versions = ...
+```
+
+#### `scala/coursier/error/DependencyError.scala`
+
+```scala
+abstract class DependencyError(val message: String, cause: Throwable = null)
+```
+
+#### `scala/coursier/error/VariantError.scala`
+
+```scala
+abstract class VariantError(message: String) extends DependencyError(message)
+```
+
+```scala
+object VariantError
+```
+
+```scala
+class NoVariantFound(
+    module: Module,
+    version: Version,
+    attributes: VariantSelector.AttributesBased,
+    available: Seq[(Variant.Attributes, Map[String, String])]
+  ) extends VariantError(
+        s"No variant found in ${module.repr}:${version.asString} for ${attributes.repr} among:" + nl +
+          desc(available).mkString(nl)
+      )
+```
+
+```scala
+class FoundTooManyVariants(
+    module: Module,
+    version: Version,
+    attributes: VariantSelector.AttributesBased,
+    retained: Seq[(Variant.Attributes, Map[String, String])]
+  ) extends VariantError(
+        s"Found too many variants in ${module.repr}:${version.asString} for ${attributes.repr}:" + nl +
+          desc(retained).mkString(nl)
+      )
+```
+
+```scala
+class CannotFindEquivalentVariants(
+    module: Module,
+    versionConstraint: VersionConstraint,
+    configuration: Configuration
+  ) extends VariantError(
+        s"Cannot find equivalent variants for configuration ${configuration.value} of ${module.repr}:${versionConstraint.asString}"
+      )
+```
+
+#### `scala/coursier/graph/Conflict.scala`
+
+```scala
+object Conflict
+```
+
+```scala
+def conflicted(
+    resolution: Resolution,
+    withExclusions: Boolean = false,
+    semVer: Boolean = false
+  ): Seq[Conflicted] = ...
+```
+
+```scala
+def apply(
+    resolution: Resolution,
+    withExclusions: Boolean = false,
+    semVer: Boolean = false
+  ): Seq[Conflict] = ...
+```
+
+```scala
+  @deprecated("Use the override acception a Version and VersionConstraint-s instead", "2.1.25")
+def apply(
+    module: Module,
+    version: String,
+    wantedVersion: String,
+    wasExcluded: Boolean,
+    dependeeModule: Module,
+    dependeeVersion: String
+  ): Conflict = ...
+```
+
+#### `scala/coursier/graph/DependencyTree.scala`
+
+> Simple dependency tree.
+
+```scala
+sealed abstract class DependencyTree
+```
+
+```scala
+def dependency: Dependency
+```
+
+> Whether this dependency was excluded by its parent (but landed in the classpath nonetheless
+> via other dependencies.
+
+```scala
+def excluded: Boolean
+```
+
+```scala
+def reconciledVersionConstraint: VersionConstraint
+```
+
+```scala
+  @deprecated("Use reconciledVersion0 instead", "2.1.25")
+def reconciledVersion: String = ...
+```
+
+> The final version of this dependency.
+
+```scala
+def retainedVersion0: Version
+```
+
+```scala
+  @deprecated("Use retainedVersion0 instead", "2.1.25")
+def retainedVersion: String = ...
+```
+
+> Dependencies of this node.
+
+```scala
+def children: Seq[DependencyTree]
+```
+
+```scala
+object DependencyTree
+```
+
+```scala
+def apply(
+    resolution: Resolution,
+    roots: Seq[Dependency] = null,
+    withExclusions: Boolean = false
+  ): Seq[DependencyTree] = ...
+```
+
+```scala
+def one(
+    resolution: Resolution,
+    root: Dependency,
+    withExclusions: Boolean = false
+  ): DependencyTree = ...
+```
+
+#### `scala/coursier/graph/ModuleTree.scala`
+
+> Simple [[Module]] tree.
+
+```scala
+sealed abstract class ModuleTree
+```
+
+```scala
+def module: Module
+```
+
+```scala
+def reconciledVersionConstraint: VersionConstraint
+```
+
+```scala
+  @deprecated("Use reconciledVersion0 instead", "2.1.25")
+def reconciledVersion: String = ...
+```
+
+> The final version of this dependency.
+
+```scala
+def retainedVersion0: Version
+```
+
+```scala
+  @deprecated("Use reconciledVersion0 instead", "2.1.25")
+def retainedVersion: String = ...
+```
+
+> The dependencies of this module.
+
+```scala
+def children: Seq[ModuleTree]
+```
+
+```scala
+object ModuleTree
+```
+
+```scala
+def apply(
+    resolution: Resolution,
+    roots: Seq[Dependency] = null
+  ): Seq[ModuleTree] = ...
+```
+
+```scala
+def one(
+    resolution: Resolution,
+    root: Dependency
+  ): ModuleTree = ...
+```
+
+```scala
+def apply(dependencyTrees: Seq[DependencyTree]): Seq[ModuleTree] = ...
+```
+
+#### `scala/coursier/graph/ReverseModuleTree.scala`
+
+> Tree allowing to walk the dependency graph from dependency to dependees.
+
+```scala
+sealed abstract class ReverseModuleTree
+```
+
+```scala
+def module: Module
+```
+
+> The final version of this dependency.
+
+```scala
+def reconciledVersionConstraint: VersionConstraint
+```
+
+```scala
+  @deprecated("Use retainedVersion0 instead", "2.1.25")
+def reconciledVersion: String = ...
+```
+
+```scala
+def retainedVersion0: Version
+```
+
+```scala
+  @deprecated("Use retainedVersion0 instead", "2.1.25")
+def retainedVersion: String = ...
+```
+
+> Module of the parent dependency of to this node.
+>
+> This node is a dependee. This method corresponds to what we depend on.
+
+```scala
+def dependsOnModule: Module
+```
+
+> Version of the parent dependency of to this node.
+>
+> This node is a dependee. This method corresponds to what we depend on.
+>
+> This is the version this module explicitly depends on.
+
+```scala
+def dependsOnVersionConstraint: VersionConstraint
+```
+
+```scala
+  @deprecated("Use retainedVersion0 instead", "2.1.25")
+def dependsOnVersion: String = ...
+```
+
+> Final version of the parent dependency of to this node.
+>
+> This node is a dependee. This method corresponds to what we depend on.
+>
+> This is the version that was selected during resolution.
+
+```scala
+def dependsOnRetainedVersion0: Version
+```
+
+```scala
+def dependsOnReconciledVersion: String = ...
+```
+
+> Whether the parent dependency was excluded by us, but landed anyway in the classpath.
+>
+> This node is a dependee. This method corresponds to what we depend on.
+>
+> This says whether this dependency was excluded by us, but landed anyway in the classpath.
+
+```scala
+def excludedDependsOn: Boolean
+```
+
+> Dependees of this module.
+
+```scala
+def dependees: Seq[ReverseModuleTree]
+```
+
+```scala
+object ReverseModuleTree
+```
+
+```scala
+def fromModuleTree(roots: Seq[Module], moduleTrees: Seq[ModuleTree]): Seq[ReverseModuleTree] = ...
+```
+
+```scala
+def fromDependencyTree(
+    roots: Seq[Module],
+    dependencyTrees: Seq[DependencyTree]
+  ): Seq[ReverseModuleTree] = ...
+```
+
+```scala
+def apply(
+    resolution: Resolution,
+    roots: Seq[Module] = null,
+    withExclusions: Boolean = false
+  ): Seq[ReverseModuleTree] = ...
+```
+
+#### `scala/coursier/graph/package.scala`
+
+> This package offers various ways of walking the dependency graph of [[Resolution]] s.
+
+```scala
+package object graph
+```
+
+#### `scala/coursier/ivy/IvyRepository.scala`
+
+```scala
+object IvyRepository
+```
+
+```scala
+def isSnapshot(version: String): Boolean = ...
+```
+
+```scala
+def parse(
+    pattern: String,
+    metadataPatternOpt: Option[String] = None,
+    changing: Option[Boolean] = None,
+    properties: Map[String, String] = Map.empty,
+    withChecksums: Boolean = true,
+    withSignatures: Boolean = true,
+    withArtifacts: Boolean = true,
+    // hack for sbt putting infos in properties
+    dropInfoAttributes: Boolean = false,
+    authentication: Option[Authentication] = None,
+    substituteDefault: Boolean = true
+  ): Either[String, IvyRepository] = ...
+```
+
+```scala
+def fromPattern(
+    pattern: Pattern,
+    metadataPatternOpt: Option[Pattern] = None,
+    changing: Option[Boolean] = None,
+    withChecksums: Boolean = true,
+    withSignatures: Boolean = true,
+    withArtifacts: Boolean = true,
+    // hack for sbt putting infos in properties
+    dropInfoAttributes: Boolean = false,
+    authentication: Option[Authentication] = None
+  ): IvyRepository = ...
+```
+
+#### `scala/coursier/ivy/IvyXml.scala`
+
+```scala
+object IvyXml
+```
+
+```scala
+val attributesNamespace = ...
+```
+
+```scala
+def mappings(mapping: String): Seq[(Configuration, Configuration)] = ...
+```
+
+```scala
+def project(node: Node): Either[String, Project] = ...
+```
+
+#### `scala/coursier/ivy/Pattern.scala`
+
+```scala
+object PropertiesPattern
+```
+
+```scala
+sealed abstract class ChunkOrProperty extends Product with Serializable
+```
+
+```scala
+def string: String
+```
+
+```scala
+object ChunkOrProperty
+```
+
+```scala
+object Opt
+```
+
+```scala
+def apply(elem: ChunkOrProperty): Opt = ...
+```
+
+```scala
+def apply(elem: ChunkOrProperty, elem1: ChunkOrProperty): Opt = ...
+```
+
+```scala
+def apply(elem: ChunkOrProperty, elem1: ChunkOrProperty, elem2: ChunkOrProperty): Opt = ...
+```
+
+```scala
+implicit def fromString(s: String): ChunkOrProperty = ...
+```
+
+```scala
+def parse(pattern: String): Either[String, PropertiesPattern] = ...
+```
+
+```scala
+object Pattern
+```
+
+```scala
+sealed abstract class Chunk extends Product with Serializable
+```
+
+```scala
+def string: String
+```
+
+```scala
+object Chunk
+```
+
+```scala
+object Opt
+```
+
+```scala
+def apply(chunk: Chunk): Opt = ...
+```
+
+```scala
+def apply(chunk: Chunk, chunk1: Chunk): Opt = ...
+```
+
+```scala
+def apply(chunk: Chunk, chunk1: Chunk, chunk2: Chunk): Opt = ...
+```
+
+```scala
+implicit def fromString(s: String): Chunk = ...
+```
+
+```scala
+val default = ...
+```
+
+#### `scala/coursier/maven/GradleModule.scala`
+
+```scala
+object GradleModule
+```
+
+```scala
+final case class StringOrInt(value: String)
+```
+
+```scala
+object StringOrInt
+```
+
+```scala
+implicit lazy val codec: JsonValueCodec[StringOrInt] = ...
+```
+
+```scala
+implicit lazy val codec: JsonValueCodec[GradleModule] = ...
+```
+
+```scala
+val defaultConfigurations: Map[Configuration, Seq[Configuration]] = ...
+```
+
+#### `scala/coursier/maven/MavenAttributes.scala`
+
+```scala
+object MavenAttributes
+```
+
+```scala
+val typeExtensions: Map[Type, Extension] = ...
+```
+
+```scala
+def typeExtension(`type`: Type): Extension = ...
+```
+
+```scala
+val typeDefaultClassifiers: Map[Type, Classifier] = ...
+```
+
+```scala
+def typeDefaultClassifierOpt(`type`: Type): Option[Classifier] = ...
+```
+
+```scala
+def typeDefaultClassifier(`type`: Type): Classifier = ...
+```
+
+```scala
+val classifierExtensionDefaultTypes: Map[(Classifier, Extension), Type] = ...
+```
+
+```scala
+def classifierExtensionDefaultTypeOpt(classifier: Classifier, ext: Extension): Option[Type] = ...
+```
+
+#### `scala/coursier/maven/MavenComplete.scala`
+
+```scala
+object MavenComplete
+```
+
+#### `scala/coursier/maven/MavenRepository.scala`
+
+```scala
+object MavenRepository
+```
+
+```scala
+def defaultConfigurations = ...
+```
+
+```scala
+def apply(root: String): MavenRepository = ...
+```
+
+```scala
+def apply(root: String, authentication: Option[Authentication]): MavenRepository = ...
+```
+
+#### `scala/coursier/maven/MavenRepositoryInternal.scala`
+
+```scala
+extension: Extension
+  ): Option[Version] = ...
+```
+
+#### `scala/coursier/maven/MavenRepositoryLike.scala`
+
+> A [[Repository]] instance backed by a Maven repository
+>
+> As such, it has a root URL, and may require some authentication. Methods below allows to read
+> and update those.
+
+```scala
+trait MavenRepositoryLike extends Repository
+```
+
+```scala
+def root: String
+```
+
+```scala
+def authentication: Option[Authentication]
+```
+
+```scala
+def versionsCheckHasModule: Boolean
+```
+
+```scala
+def withRoot(root: String): MavenRepositoryLike
+```
+
+```scala
+def withAuthentication(authentication: Option[Authentication]): MavenRepositoryLike
+```
+
+```scala
+def withVersionsCheckHasModule(versionsCheckHasModule: Boolean): MavenRepositoryLike
+```
+
+```scala
+def urlFor(path: Seq[String], isDir: Boolean = false): String
+```
+
+```scala
+def artifactFor(url: String, changing: Boolean): Artifact
+```
+
+```scala
+def moduleDirectory(module: Module): String
+```
+
+```scala
+object MavenRepositoryLike
+```
+
+```scala
+trait WithModuleSupport extends MavenRepositoryLike with ArtifactSource.ModuleBased
+```
+
+```scala
+def checkModule: Boolean
+```
+
+```scala
+def withCheckModule(checkModule: Boolean): MavenRepositoryLike
+```
+
+#### `scala/coursier/maven/Pom.scala`
+
+```scala
+object Pom
+```
+
+> Returns either a property's key-value pair or an error if the elem is not an element.
+>
+> This method trims all spaces, whereas Maven has an option to preserve them.
+>
+> @param elem
+> a property element
+> @return
+> the key and the value of the property
+> @see
+> [[https://issues.apache.org/jira/browse/MNG-5380]]
+
+```scala
+def property(elem: Node): Either[String, (String, String)] = ...
+```
+
+```scala
+def dependency(node: Node): Either[String, (Configuration, Dependency)] = ...
+```
+
+```scala
+def profile(node: Node): Either[String, Profile] = ...
+```
+
+```scala
+def packagingOpt(pom: Node): Option[Type] = ...
+```
+
+```scala
+def project(pom: Node): Either[String, Project] = ...
+```
+
+```scala
+def versions(node: Node): Either[String, Versions] = ...
+```
+
+```scala
+def snapshotVersion(node: Node): Either[String, SnapshotVersion] = ...
+```
+
+> If `snapshotVersion` is missing, guess it based on `version`, `timestamp` and `buildNumber`,
+> as is done in:
+> https://github.com/sbt/ivy/blob/2.3.x-sbt/src/java/org/apache/ivy/plugins/resolver/IBiblioResolver.java
+
+```scala
+def guessedSnapshotVersion(
+    version: String,
+    timestamp: String,
+    buildNumber: Int
+  ): SnapshotVersion = ...
+```
+
+```scala
+def snapshotVersioning(node: Node): Either[String, SnapshotVersioning] = ...
+```
+
+```scala
+val extraAttributeSeparator = ...
+```
+
+```scala
+val extraAttributePrefix = ...
+```
+
+```scala
+val extraAttributeOrg = ...
+```
+
+```scala
+val extraAttributeName = ...
+```
+
+```scala
+val extraAttributeVersion = ...
+```
+
+```scala
+val extraAttributeBase = ...
+```
+
+```scala
+val extraAttributeDropPrefix = ...
+```
+
+```scala
+def addOptionalDependenciesInConfig(
+    proj: Project,
+    fromConfigs: Set[Configuration],
+    optionalConfig: Configuration
+  ): Project = ...
+```
+
+#### `scala/coursier/maven/PomParser.scala`
+
+```scala
+final class PomParser extends SaxHandler
+```
+
+```scala
+def startElement(tagName: String): Unit = ...
+```
+
+```scala
+def characters(ch: Array[Char], start: Int, length: Int): Unit = ...
+```
+
+```scala
+def endElement(tagName: String): Unit = ...
+```
+
+```scala
+def project: Either[String, Project] = ...
+```
+
+```scala
+object PomParser
+```
+
+#### `scala/coursier/util/Config.scala`
+
+```scala
+@deprecated("Unused by coursier", "2.1.25")
+object Config
+```
+
+```scala
+def allDependenciesByConfig0(
+    res: Resolution,
+    depsByConfig: Map[Configuration, Set[Dependency]],
+    configs: Map[Configuration, Set[Configuration]]
+  ): Either[DependencyError, Map[Configuration, Set[Dependency]]] = ...
+```
+
+```scala
+  @deprecated("Use allDependenciesByConfig0 instead", "2.1.25")
+def allDependenciesByConfig(
+    res: Resolution,
+    depsByConfig: Map[Configuration, Set[Dependency]],
+    configs: Map[Configuration, Set[Configuration]]
+  ): Map[Configuration, Set[Dependency]] = ...
+```
+
+```scala
+def dependenciesWithConfig(
+    res: Resolution,
+    depsByConfig: Map[Configuration, Set[Dependency]],
+    configs: Map[Configuration, Set[Configuration]]
+  ): Set[Dependency] = ...
+```
+
+#### `scala/coursier/util/Print.scala`
+
+```scala
+object Print
+```
+
+```scala
+object Colors
+```
+
+```scala
+def get(colors: Boolean): Colors = ...
+```
+
+```scala
+  @data class Colors private (red: String, yellow: String, reset: String)
+def dependency(dep: Dependency): String = ...
+```
+
+```scala
+def dependency(dep: Dependency, printExclusions: Boolean): String = ...
+```
+
+```scala
+def dependenciesUnknownConfigs0(
+    deps: Seq[Dependency],
+    projects: Map[(Module, VersionConstraint), Project]
+  ): String = ...
+```
+
+```scala
+  @deprecated("Use dependenciesUnknownConfigs0 instead", "2.1.25")
+def dependenciesUnknownConfigs(
+    deps: Seq[Dependency],
+    projects: Map[(Module, String), Project]
+  ): String = ...
+```
+
+```scala
+def dependenciesUnknownConfigs0(
+    deps: Seq[Dependency],
+    projects: Map[(Module, VersionConstraint), Project],
+    printExclusions: Boolean,
+    useFinalVersions: Boolean = true,
+    reorder: Boolean = false
+  ): String = ...
+```
+
+```scala
+  @deprecated("Use dependenciesUnknownConfigs0 instead", "2.1.25")
+def dependenciesUnknownConfigs(
+    deps: Seq[Dependency],
+    projects: Map[(Module, String), Project],
+    printExclusions: Boolean,
+    useFinalVersions: Boolean = true,
+    reorder: Boolean = false
+  ): String = ...
+```
+
+```scala
+def compatibleVersions(compatibleWith: VersionConstraint, selected: Version): Boolean = ...
+```
+
+```scala
+  @deprecated("Use the override accepting a VersionConstraint and a Version instead", "2.1.25")
+def compatibleVersions(compatibleWith: String, selected: String): Boolean = ...
+```
+
+```scala
+def dependencyTree(
+    resolution: Resolution,
+    roots: Seq[Dependency] = null,
+    printExclusions: Boolean = false,
+    reverse: Boolean = false,
+    colors: Boolean = true
+  ): String = ...
+```
+
+```scala
+def conflicts(conflicts: Seq[Conflict]): Seq[String] = ...
+```
+
+#### `scala/coursier/util/SaxHandler.scala`
+
+```scala
+abstract class SaxHandler
+```
+
+```scala
+def startElement(tagName: String): Unit // TODO attributes
+```
+
+```scala
+def characters(ch: Array[Char], start: Int, length: Int): Unit
+```
+
+```scala
+def endElement(tagName: String): Unit
+```
+
+#### `scala/coursier/util/Tree.scala`
+
+```scala
+object Tree
+```
+
+```scala
+def apply[A](roots: IndexedSeq[A])(children: A => Seq[A]) = ...
+```
+
+```scala
+final class Tree[A](val roots: IndexedSeq[A], val children: A => Seq[A])
+```
+
+```scala
+def render(show: A => String): String = ...
+```
+
+```scala
+def customRender(
+    assumeTopRoot: Boolean = true,
+    extraPrefix: String = "",
+    extraSeparator: Option[String] = None
+  )(show: A => String): String = ...
+```
+
+#### `scala/coursier/util/Xml.scala`
+
+```scala
+object Xml
+```
+
+> A representation of an XML node/document, with different implementations on JVM and JS
+
+```scala
+trait Node
+```
+
+```scala
+def label: String
+```
+
+> Namespace / key / value
+
+```scala
+def attributes: Seq[(String, String, String)]
+```
+
+```scala
+def children: Seq[Node]
+```
+
+```scala
+def isText: Boolean
+```
+
+```scala
+def textContent: String
+```
+
+```scala
+def isElement: Boolean
+```
+
+```scala
+def attributesFromNamespace(namespace: String): Seq[(String, String)] = ...
+```
+
+```scala
+lazy val attributesMap = ...
+```
+
+```scala
+def attribute(name: String): Either[String, String] = ...
+```
+
+```scala
+object Node
+```
+
+```scala
+val empty: Node = ...
+```
+
+```scala
+object Text
+```
+
+```scala
+def unapply(n: Node): Option[String] = ...
+```
+
+```scala
+def text(elem: Node, label: String, description: String): Either[String, String] = ...
+```
+
+```scala
+def parseDateTime(s: String): Option[Versions.DateTime] = ...
+```
+
+### `io.get-coursier:coursier-cache_2.13:2.1.25-M3`
+
+Source: https://repo1.maven.org/maven2/io/get-coursier/coursier-cache_2.13/2.1.25-M3/coursier-cache_2.13-2.1.25-M3-sources.jar
+
+#### `coursier/cache/ArchiveCache.scala`
+
+```scala
+object ArchiveCache
+```
+
+```scala
+def apply[F[_]]()(implicit S: Sync[F] = Task.sync): ArchiveCache[F] = ...
+```
+
+```scala
+def priviledged[F[_]]()(implicit S: Sync[F] = Task.sync): ArchiveCache[F] = ...
+```
+
+#### `coursier/cache/ArchiveType.scala`
+
+```scala
+sealed abstract class ArchiveType extends Product with Serializable
+```
+
+```scala
+def singleFile: Boolean = ...
+```
+
+```scala
+object ArchiveType
+```
+
+```scala
+sealed abstract class Tar extends ArchiveType
+```
+
+```scala
+sealed abstract class Compressed extends ArchiveType
+```
+
+```scala
+override def singleFile: Boolean = ...
+```
+
+```scala
+def tar: Tar
+```
+
+```scala
+case object Zip  extends ArchiveType
+```
+
+```scala
+case object Ar   extends ArchiveType
+```
+
+```scala
+case object Tar  extends Tar
+```
+
+```scala
+case object Tgz  extends Tar
+```
+
+```scala
+case object Tbz2 extends Tar
+```
+
+```scala
+case object Txz  extends Tar
+```
+
+```scala
+case object Tzst extends Tar
+```
+
+```scala
+case object Gzip extends Compressed
+```
+
+```scala
+def tar = ...
+```
+
+```scala
+case object Xz extends Compressed
+```
+
+```scala
+def tar = ...
+```
+
+```scala
+def parse(input: String): Option[ArchiveType] = ...
+```
+
+```scala
+def fromMimeType(mimeType: String): Option[ArchiveType] = ...
+```
+
+#### `coursier/cache/ArtifactError.scala`
+
+```scala
+sealed abstract class ArtifactError(
+  val `type`: String,
+  val message: String,
+  parentOpt: Option[Throwable]
+) extends Exception(s"${`type`}: $message", parentOpt.orNull)
+```
+
+```scala
+def this(`type`: String, message: String) = ...
+```
+
+```scala
+def describe: String = ...
+```
+
+```scala
+final def notFound: Boolean = ...
+```
+
+```scala
+final def forbidden: Boolean = ...
+```
+
+```scala
+object ArtifactError
+```
+
+```scala
+final class DownloadError(val reason: String, e: Option[Throwable]) extends ArtifactError(
+    "download error",
+    reason,
+    e
+  )
+```
+
+```scala
+final class NotFound(
+    val file: String,
+    val permanent: Option[Boolean] = None
+  ) extends ArtifactError(
+    "not found",
+    file
+  )
+```
+
+```scala
+final class Forbidden(
+    val file: String
+  ) extends ArtifactError(
+    "forbidden",
+    file
+  )
+```
+
+```scala
+final class Unauthorized(
+    val file: String,
+    val realm: Option[String]
+  ) extends ArtifactError(
+    "unauthorized",
+    file + realm.fold("")(" (" + _ + ")")
+  )
+```
+
+```scala
+final class ChecksumNotFound(
+    val sumType: String,
+    val file: String
+  ) extends ArtifactError(
+    "checksum not found",
+    file
+  )
+```
+
+```scala
+final class ChecksumErrors(
+    val errors: Seq[(String, String)]
+  ) extends ArtifactError(
+    "checksum errors",
+    errors.map { case (k, v) => s"$k: $v" }.mkString(", ")
+  )
+```
+
+```scala
+final class ChecksumFormatError(
+    val sumType: String,
+    val file: String
+  ) extends ArtifactError(
+    "checksum format error",
+    file
+  )
+```
+
+```scala
+final class WrongChecksum(
+    val sumType: String,
+    val got: String,
+    val expected: String,
+    val file: String,
+    val sumFile: String
+  ) extends ArtifactError(
+    "wrong checksum",
+    s"$file (expected $sumType $expected in $sumFile, got $got)"
+  )
+```
+
+```scala
+final class WrongLength(
+    val got: Long,
+    val expected: Long,
+    val file: String
+  ) extends ArtifactError(
+    "wrong length",
+    s"$file (expected $expected B, got $got B)"
+  )
+```
+
+```scala
+final class FileTooOldOrNotFound(
+    val file: String
+  ) extends ArtifactError(
+    "file in cache not found or too old",
+    file
+  )
+```
+
+```scala
+final class ForbiddenChangingArtifact(val url: String) extends ArtifactError(
+    "changing artifact found",
+    url
+  )
+```
+
+```scala
+sealed abstract class Recoverable(
+    `type`: String,
+    message: String,
+    parentOpt: Option[Throwable]
+  ) extends ArtifactError(`type`, message, parentOpt)
+```
+
+```scala
+def this(`type`: String, message: String) = ...
+```
+
+```scala
+final class Locked(val file: File) extends Recoverable(
+    "locked",
+    file.toString
+  )
+```
+
+```scala
+  @deprecated("Not thrown by coursier anymore", "2.1.0-RC2")
+final class ConcurrentDownload(val url: String) extends Recoverable(
+    "concurrent download",
+    url
+  )
+```
+
+#### `coursier/cache/AuthenticatedURLConnection.scala`
+
+```scala
+trait AuthenticatedURLConnection extends URLConnection
+```
+
+```scala
+def authenticate(authentication: Authentication): Unit
+```
+
+#### `coursier/cache/CacheChecksum.scala`
+
+```scala
+object CacheChecksum
+```
+
+```scala
+def parseChecksum(content: String): Option[BigInteger] = ...
+```
+
+```scala
+def parseRawChecksum(content: Array[Byte]): Option[BigInteger] = ...
+```
+
+#### `coursier/cache/CacheDefaults.scala`
+
+```scala
+object CacheDefaults
+```
+
+```scala
+lazy val location: File = ...
+```
+
+```scala
+lazy val archiveCacheLocation: File = ...
+```
+
+```scala
+lazy val priviledgedArchiveCacheLocation: File = ...
+```
+
+```scala
+lazy val digestBasedCacheLocation: File = ...
+```
+
+```scala
+def warnLegacyCacheLocation(): Unit = ...
+```
+
+```scala
+lazy val concurrentDownloadCount: Int = ...
+```
+
+```scala
+lazy val pool = ...
+```
+
+```scala
+def parseDuration(s: String): Either[Throwable, Duration] = ...
+```
+
+```scala
+lazy val ttl: Option[Duration] = ...
+```
+
+```scala
+val checksums = ...
+```
+
+```scala
+def defaultRetryCount = ...
+```
+
+```scala
+lazy val retryCount = ...
+```
+
+```scala
+lazy val retryBackoffInitialDelay = ...
+```
+
+```scala
+lazy val retryBackoffMultiplier = ...
+```
+
+```scala
+  @deprecated("Use retryCount instead", "2.1.11")
+lazy val sslRetryCount = ...
+```
+
+```scala
+lazy val maxRedirections: Option[Int] = ...
+```
+
+```scala
+val bufferSize = ...
+```
+
+```scala
+def credentials: Seq[Credentials] = ...
+```
+
+```scala
+def credentialsFromConfig(configPath: Path): Seq[Credentials] = ...
+```
+
+```scala
+val noEnvCachePolicies = ...
+```
+
+```scala
+def cachePolicies: Seq[CachePolicy] = ...
+```
+
+#### `coursier/cache/CacheLocks.scala`
+
+```scala
+object CacheLocks
+```
+
+> Should be acquired when doing operations changing the file structure of the cache (creating
+> new directories, creating / acquiring locks, ...), so that these don't hinder each other.
+>
+> Should hopefully address some transient errors seen on the CI of ensime-server.
+
+```scala
+def withStructureLock[T](cache: File)(f: => T): T = ...
+```
+
+```scala
+def withStructureLock[T](cache: Path)(f: => T): T = ...
+```
+
+```scala
+def withLockOr[T](
+    cache: File,
+    file: File
+  )(
+    f: => T,
+    ifLocked: => Option[T]
+  ): T = ...
+```
+
+```scala
+def withLockOr[T](
+    cache: File,
+    file: File,
+    retry: Retry
+  )(
+    f: => T,
+    ifLocked: => Option[T]
+  ): T = ...
+```
+
+```scala
+def withLockFor[T](
+    cache: File,
+    file: File
+  )(f: => Either[ArtifactError, T]): Either[ArtifactError, T] = ...
+```
+
+```scala
+def withUrlLock[T](url: String)(f: => T): Option[T] = ...
+```
+
+#### `coursier/cache/CachePolicy.scala`
+
+```scala
+sealed abstract class CachePolicy extends Product with Serializable
+```
+
+```scala
+def acceptChanging: CachePolicy.Mixed
+```
+
+```scala
+def rejectChanging: CachePolicy.NoChanging
+```
+
+```scala
+def acceptsChangingArtifacts: Boolean
+```
+
+```scala
+object CachePolicy
+```
+
+```scala
+sealed abstract class Mixed extends CachePolicy
+```
+
+```scala
+def acceptChanging: Mixed = ...
+```
+
+```scala
+def acceptsChangingArtifacts: Boolean = ...
+```
+
+> Only pick local files, possibly from the cache. Don't try to download anything.
+
+```scala
+case object LocalOnly extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Only pick local files, possibly from the cache. Don't return changing artifacts (whose last
+> check is) older than TTL
+
+```scala
+case object LocalOnlyIfValid extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Only pick local files. If one of these local files corresponds to a changing artifact, check
+> for updates, and download these if needed.
+>
+> If no local file is found, *don't* try download it. Updates are only checked for files already
+> in cache.
+>
+> Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+
+```scala
+case object LocalUpdateChanging extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Only pick local files, check if any update is available for them, and download these if
+> needed.
+>
+> If no local file is found, *don't* try download it. Updates are only checked for files already
+> in cache.
+>
+> Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+>
+> Unlike `LocalUpdateChanging`, all found local files are checked for updates, not just the
+> changing ones.
+
+```scala
+case object LocalUpdate extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Pick local files, and download the missing ones.
+>
+> For changing ones, check for updates, and download those if any.
+>
+> Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+
+```scala
+case object UpdateChanging extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Pick local files, download the missing ones, check for updates and download those if any.
+>
+> Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+>
+> Unlike `UpdateChanging`, all found local files are checked for updates, not just the changing
+> ones.
+
+```scala
+case object Update extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> Pick local files, download the missing ones.
+>
+> No updates are checked for files already downloaded.
+
+```scala
+case object FetchMissing extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+> (Re-)download all files.
+>
+> Erases files already in cache.
+
+```scala
+case object ForceDownload extends Mixed
+```
+
+```scala
+def rejectChanging = ...
+```
+
+```scala
+sealed abstract class NoChanging extends CachePolicy
+```
+
+```scala
+def rejectChanging: CachePolicy.NoChanging = ...
+```
+
+```scala
+def acceptsChangingArtifacts: Boolean = ...
+```
+
+```scala
+object NoChanging
+```
+
+```scala
+case object LocalOnly extends NoChanging
+```
+
+```scala
+def acceptChanging = ...
+```
+
+```scala
+case object LocalUpdate extends NoChanging
+```
+
+```scala
+def acceptChanging = ...
+```
+
+```scala
+case object FetchMissing extends NoChanging
+```
+
+```scala
+def acceptChanging = ...
+```
+
+```scala
+case object ForceDownload extends NoChanging
+```
+
+```scala
+def acceptChanging = ...
+```
+
+#### `coursier/cache/CacheUrl.scala`
+
+```scala
+object CacheUrl
+```
+
+> Returns a `java.net.URL` for `s`, possibly using the custom protocol handlers found under the
+> `coursier.cache.protocol` namespace.
+>
+> E.g. URL `"test://abc.com/foo"`, having protocol `"test"`, can be handled by a
+> `URLStreamHandler` named `coursier.cache.protocol.TestHandler` (protocol name gets
+> capitalized, and suffixed with `Handler` to get the class name).
+>
+> @param s
+> @param classLoaders:
+> class loaders to load custom protocol handlers from
+> @return
+
+```scala
+def url(s: String, classLoaders: Seq[ClassLoader]): URL = ...
+```
+
+```scala
+def url(s: String): URL = ...
+```
+
+```scala
+  @deprecated("Create a ConnectionBuilder() and call connection() on it instead", "2.0.0")
+def urlConnection(
+    url0: String,
+    authentication: Option[Authentication],
+    followHttpToHttpsRedirections: Boolean = false,
+    followHttpsToHttpRedirections: Boolean = false,
+    credentials: Seq[DirectCredentials] = Nil,
+    sslSocketFactoryOpt: Option[SSLSocketFactory] = None,
+    hostnameVerifierOpt: Option[HostnameVerifier] = None,
+    method: String = "GET",
+    maxRedirectionsOpt: Option[Int] = Some(20)
+  ): URLConnection = ...
+```
+
+```scala
+def urlConnectionMaybePartial(
+    url0: String,
+    authentication: Option[Authentication],
+    alreadyDownloaded: Long,
+    followHttpToHttpsRedirections: Boolean,
+    followHttpsToHttpRedirections: Boolean,
+    autoCredentials: Seq[DirectCredentials],
+    sslSocketFactoryOpt: Option[SSLSocketFactory],
+    hostnameVerifierOpt: Option[HostnameVerifier],
+    method: String,
+    maxRedirectionsOpt: Option[Int]
+  ): (URLConnection, Boolean) = ...
+```
+
+```scala
+def responseCode(conn: URLConnection): Option[Int] = ...
+```
+
+```scala
+def realm(conn: URLConnection): Option[String] = ...
+```
+
+```scala
+  @deprecated("Use coursier.proxy.SetupProxy.setup() instead", "2.1.0-M7")
+def setupProxyAuth(credentials: Map[(String, String, String), (String, String)]): Unit = ...
+```
+
+```scala
+  @deprecated("Use coursier.proxy.SetupProxy.setup() instead", "2.1.0-M7")
+def setupProxyAuth(): Unit = ...
+```
+
+```scala
+def disableProxyAuth(): Unit = ...
+```
+
+#### `coursier/cache/DigestBasedCache.scala`
+
+```scala
+object DigestBasedCache
+```
+
+```scala
+def apply(): DigestBasedCache[Task] = ...
+```
+
+#### `coursier/cache/FileCache.scala`
+
+```scala
+object FileCache
+```
+
+```scala
+def apply[F[_]]()(implicit S: Sync[F] = Task.sync): FileCache[F] = ...
+```
+
+#### `coursier/cache/MockCache.scala`
+
+```scala
+object MockCache
+```
+
+```scala
+def create[F[_]: Sync](
+    base: Path,
+    pool: ExecutorService,
+    extraData: Seq[Path] = Nil,
+    writeMissing: Boolean = false
+  ): MockCache[F] = ...
+```
+
+#### `coursier/cache/PlatformCache.scala`
+
+```scala
+abstract class PlatformCache[F[_]]
+```
+
+> This method computes the task needed to get a file.
+
+```scala
+def file(artifact: Artifact): EitherT[F, ArtifactError, File]
+```
+
+#### `coursier/cache/PlatformCacheCompanion.scala`
+
+```scala
+abstract class PlatformCacheCompanion
+```
+
+```scala
+lazy val default: Cache[Task] = ...
+```
+
+#### `coursier/cache/UnArchiver.scala`
+
+```scala
+trait UnArchiver
+```
+
+```scala
+def extract(archiveType: ArchiveType, archive: File, destDir: File, overwrite: Boolean): Unit
+```
+
+```scala
+object UnArchiver
+```
+
+```scala
+trait OpenStream
+```
+
+```scala
+def inputStream(archiveType: ArchiveType.Compressed, is: InputStream): InputStream
+```
+
+```scala
+def default(): UnArchiver with OpenStream = ...
+```
+
+```scala
+def priviledged(): UnArchiver = ...
+```
+
+```scala
+def priviledgedTestMode(): UnArchiver = ...
+```
+
+#### `coursier/cache/internal/ConsoleDim.scala`
+
+```scala
+final class ConsoleDim
+```
+
+```scala
+def width(): Int = ...
+```
+
+```scala
+def height(): Int = ...
+```
+
+```scala
+object ConsoleDim
+```
+
+```scala
+lazy val get: ConsoleDim = ...
+```
+
+```scala
+def width(): Int = ...
+```
+
+```scala
+def height(): Int = ...
+```
+
+#### `coursier/cache/internal/Downloader.scala`
+
+```scala
+object Downloader
+```
+
+#### `coursier/cache/internal/FileUtil.scala`
+
+```scala
+object FileUtil
+```
+
+```scala
+def readFullyUnsafe(is: InputStream): Array[Byte] = ...
+```
+
+```scala
+def readFully(is: => InputStream): Array[Byte] = ...
+```
+
+```scala
+def withContent(is: InputStream, f: WithContent, bufferSize: Int = 16384): Unit = ...
+```
+
+```scala
+trait WithContent
+```
+
+```scala
+def apply(arr: Array[Byte], z: Int): Unit
+```
+
+```scala
+class UpdateDigest(md: java.security.MessageDigest) extends FileUtil.WithContent
+```
+
+```scala
+def apply(arr: Array[Byte], z: Int): Unit = ...
+```
+
+#### `coursier/cache/internal/Retry.scala`
+
+```scala
+final case class Retry(
+  count: Int,
+  initialDelay: FiniteDuration,
+  delayMultiplier: Double
+)
+```
+
+```scala
+def retry[T](f: => T)(catchEx: PartialFunction[Throwable, Unit]): T = ...
+```
+
+```scala
+def retryOpt[T](f: => Option[T])(catchEx: PartialFunction[Throwable, Unit]): T = ...
+```
+
+#### `coursier/cache/internal/SigWinchNativeWindows.java`
+
+```java
+@TargetClass(className = "coursier.cache.internal.SigWinch")
+@Platforms(Platform.WINDOWS.class)
+public final class SigWinchNativeWindows
+```
+
+```java
+  @Substitute
+public static void addHandler(Runnable runnable)
+```
+
+#### `coursier/cache/internal/Terminal.scala`
+
+```scala
+object Terminal
+```
+
+```scala
+  @deprecated("Should be made private at some point in future releases", "2.0.0-RC3")
+lazy val ttyAvailable: Boolean = ...
+```
+
+```scala
+  @deprecated("Should be removed at some point in future releases", "2.0.0-RC3")
+def consoleDim(s: String): Option[Int] = ...
+```
+
+```scala
+  @deprecated("Should be removed at some point in future releases", "2.0.0-RC3")
+def consoleDimOrThrow(s: String): Int = ...
+```
+
+```scala
+def consoleDims(): (Int, Int) = ...
+```
+
+```scala
+implicit class Ansi(val output: Writer) extends AnyVal
+```
+
+```scala
+def up(n: Int): Unit = ...
+```
+
+```scala
+def down(n: Int): Unit = ...
+```
+
+```scala
+def left(n: Int): Unit = ...
+```
+
+```scala
+def clearLine(n: Int): Unit = ...
+```
+
+#### `coursier/cache/internal/ThreadUtil.scala`
+
+```scala
+object ThreadUtil
+```
+
+```scala
+def daemonThreadFactory(): ThreadFactory = ...
+```
+
+```scala
+def fixedThreadPool(size: Int): ExecutorService = ...
+```
+
+```scala
+def fixedScheduledThreadPool(size: Int): ScheduledExecutorService = ...
+```
+
+```scala
+def withFixedThreadPool[T](size: Int)(f: ExecutorService => T): T = ...
+```
+
+#### `coursier/cache/internal/TmpConfig.scala`
+
+```scala
+@deprecated("Unused by coursier now", "2.1.15")
+object TmpConfig
+```
+
+```scala
+  @deprecated("Use scala.cli.config.Keys.repositoryCredentials instead", "2.1.15")
+val credentialsKey: Key[List[DirectCredentials]] = ...
+```
+
+#### `coursier/cache/loggers/FallbackRefreshDisplay.scala`
+
+```scala
+class FallbackRefreshDisplay(quiet: Boolean = false) extends RefreshDisplay
+```
+
+```scala
+val refreshInterval: Duration = ...
+```
+
+```scala
+override def newEntry(out: Writer, url: String, info: RefreshInfo): Unit = ...
+```
+
+```scala
+override def removeEntry(out: Writer, url: String, info: RefreshInfo): Unit = ...
+```
+
+```scala
+def update(
+    out: Writer,
+    done: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit = ...
+```
+
+```scala
+override def stop(out: Writer): Unit = ...
+```
+
+#### `coursier/cache/loggers/FileTypeRefreshDisplay.scala`
+
+```scala
+class FileTypeRefreshDisplay(
+  /** Whether to keep details on screen after this display is stopped */
+  val keepOnScreen: Boolean,
+  beforeOutput: => Unit,
+  afterOutput: => Unit
+) extends RefreshDisplay
+```
+
+```scala
+val refreshInterval: Duration = ...
+```
+
+```scala
+override def sizeHint(n: Int) = ...
+```
+
+```scala
+override def stop(out: Writer): Unit = ...
+```
+
+```scala
+def update(
+    out: Writer,
+    done0: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit = ...
+```
+
+```scala
+object FileTypeRefreshDisplay
+```
+
+```scala
+def create(): FileTypeRefreshDisplay = ...
+```
+
+```scala
+def create(keepOnScreen: Boolean): FileTypeRefreshDisplay = ...
+```
+
+```scala
+def create(
+    keepOnScreen: Boolean,
+    beforeOutput: => Unit,
+    afterOutput: => Unit
+  ): FileTypeRefreshDisplay = ...
+```
+
+#### `coursier/cache/loggers/ProgressBarRefreshDisplay.scala`
+
+```scala
+class ProgressBarRefreshDisplay(
+  beforeOutput: => Unit,
+  afterOutput: => Unit
+) extends RefreshDisplay
+```
+
+```scala
+val refreshInterval: Duration = ...
+```
+
+```scala
+override def stop(out: Writer): Unit = ...
+```
+
+```scala
+def update(
+    out: Writer,
+    done: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit = ...
+```
+
+```scala
+object ProgressBarRefreshDisplay
+```
+
+```scala
+def create(): ProgressBarRefreshDisplay = ...
+```
+
+```scala
+def create(
+    beforeOutput: => Unit,
+    afterOutput: => Unit
+  ): ProgressBarRefreshDisplay = ...
+```
+
+```scala
+def byteCount(bytes: Long, si: Boolean = false) = ...
+```
+
+#### `coursier/cache/loggers/RefreshDisplay.scala`
+
+```scala
+trait RefreshDisplay
+```
+
+```scala
+def newEntry(out: Writer, url: String, info: RefreshInfo): Unit = ...
+```
+
+```scala
+def removeEntry(out: Writer, url: String, info: RefreshInfo): Unit = ...
+```
+
+```scala
+def sizeHint(n: Int): Unit = ...
+```
+
+```scala
+def update(
+    out: Writer,
+    done: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit
+```
+
+```scala
+def stop(out: Writer): Unit = ...
+```
+
+```scala
+def refreshInterval: Duration
+```
+
+```scala
+object RefreshDisplay
+```
+
+```scala
+def truncated(s: String, width: Int): String = ...
+```
+
+#### `coursier/cache/loggers/RefreshInfo.scala`
+
+```scala
+sealed abstract class RefreshInfo extends Product with Serializable
+```
+
+```scala
+def fraction: Option[Double]
+```
+
+```scala
+def watching: Boolean
+```
+
+```scala
+def success: Boolean
+```
+
+```scala
+def withSuccess(success: Boolean): RefreshInfo
+```
+
+```scala
+  @deprecated("Call the override accepting an argument", "2.1.25")
+final def withSuccess(): RefreshInfo = ...
+```
+
+```scala
+object RefreshInfo
+```
+
+#### `coursier/cache/loggers/RefreshLogger.scala`
+
+```scala
+object RefreshLogger
+```
+
+```scala
+def defaultDisplay(
+    fallbackMode: Boolean = defaultFallbackMode,
+    quiet: Boolean = false
+  ): RefreshDisplay = ...
+```
+
+```scala
+def create(): RefreshLogger = ...
+```
+
+```scala
+def create(os: OutputStream): RefreshLogger = ...
+```
+
+```scala
+def create(writer: OutputStreamWriter): RefreshLogger = ...
+```
+
+```scala
+def create(display: RefreshDisplay): RefreshLogger = ...
+```
+
+```scala
+def create(os: OutputStream, display: RefreshDisplay): RefreshLogger = ...
+```
+
+```scala
+def create(os: OutputStream, display: RefreshDisplay, logChanging: Boolean): RefreshLogger = ...
+```
+
+```scala
+def create(
+    os: OutputStream,
+    display: RefreshDisplay,
+    logChanging: Boolean,
+    logPickedVersions: Boolean
+  ): RefreshLogger = ...
+```
+
+```scala
+def create(writer: OutputStreamWriter, display: RefreshDisplay): RefreshLogger = ...
+```
+
+```scala
+def create(
+    writer: OutputStreamWriter,
+    display: RefreshDisplay,
+    logChanging: Boolean
+  ): RefreshLogger = ...
+```
+
+```scala
+def create(
+    writer: OutputStreamWriter,
+    display: RefreshDisplay,
+    logChanging: Boolean,
+    logPickedVersions: Boolean
+  ): RefreshLogger = ...
+```
+
+```scala
+lazy val defaultFallbackMode: Boolean = ...
+```
+
+```scala
+class RefreshLogger(
+  out: Writer,
+  display: RefreshDisplay,
+  val fallbackMode: Boolean = RefreshLogger.defaultFallbackMode,
+  logChanging: Boolean = false,
+  logPickedVersions: Boolean = false
+) extends CacheLogger
+```
+
+```scala
+def this(
+    out: Writer,
+    display: RefreshDisplay
+  ) = ...
+```
+
+```scala
+def this(
+    out: Writer,
+    display: RefreshDisplay,
+    fallbackMode: Boolean
+  ) = ...
+```
+
+```scala
+override def init(sizeHint: Option[Int]): Unit = ...
+```
+
+```scala
+override def stop(): Unit = ...
+```
+
+```scala
+override def checkingArtifact(url: String, artifact: Artifact): Unit = ...
+```
+
+```scala
+override def pickedModuleVersion(module: String, version: String): Unit = ...
+```
+
+```scala
+override def downloadingArtifact(url: String, artifact: Artifact): Unit = ...
+```
+
+```scala
+override def downloadLength(
+    url: String,
+    totalLength: Long,
+    alreadyDownloaded: Long,
+    watching: Boolean
+  ): Unit = ...
+```
+
+```scala
+override def downloadProgress(url: String, downloaded: Long): Unit = ...
+```
+
+```scala
+override def downloadedArtifact(url: String, success: Boolean): Unit = ...
+```
+
+```scala
+override def checkingUpdates(url: String, currentTimeOpt: Option[Long]): Unit = ...
+```
+
+```scala
+override def checkingUpdatesResult(
+    url: String,
+    currentTimeOpt: Option[Long],
+    remoteTimeOpt: Option[Long]
+  ): Unit = ...
+```
+
+#### `coursier/cache/loggers/SingleLineRefreshDisplay.scala`
+
+```scala
+class SingleLineRefreshDisplay(
+  beforeOutput: => Unit,
+  afterOutput: => Unit
+) extends RefreshDisplay
+```
+
+```scala
+val refreshInterval: Duration = ...
+```
+
+```scala
+override def stop(out: Writer): Unit = ...
+```
+
+```scala
+def update(
+    out: Writer,
+    done: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit = ...
+```
+
+```scala
+object SingleLineRefreshDisplay
+```
+
+```scala
+def create(): SingleLineRefreshDisplay = ...
+```
+
+```scala
+def create(
+    beforeOutput: => Unit,
+    afterOutput: => Unit
+  ): SingleLineRefreshDisplay = ...
+```
+
+```scala
+def byteCount(bytes: Long, si: Boolean = false) = ...
+```
+
+#### `coursier/parse/CachePolicyParser.scala`
+
+```scala
+object CachePolicyParser
+```
+
+```scala
+def cachePolicy(input: String): Either[String, CachePolicy] = ...
+```
+
+```scala
+def cachePolicies(input: String): ValidationNel[String, Seq[CachePolicy]] = ...
+```
+
+```scala
+def cachePolicies(
+    input: String,
+    default: Seq[CachePolicy]
+  ): ValidationNel[String, Seq[CachePolicy]] = ...
+```
+
+#### `coursier/util/PlatformSync.scala`
+
+```scala
+trait PlatformSync[F[_]]
+```
+
+```scala
+def schedule[A](pool: ExecutorService)(f: => A): F[A]
+```
+
+#### `coursier/util/PlatformSyncCompanion.scala`
+
+```scala
+abstract class PlatformSyncCompanion
+```
+
+#### `coursier/util/PlatformTaskCompanion.scala`
+
+```scala
+abstract class PlatformTaskCompanion
+```
+
+```scala
+def schedule[A](pool: ExecutorService)(f: => A): Task[A] = ...
+```
+
+```scala
+def completeAfter(pool: ScheduledExecutorService, duration: FiniteDuration): Task[Unit] = ...
+```
+
+```scala
+implicit val sync: Sync[Task] = ...
+```
+
+```scala
+implicit class PlatformTaskOps[T](private val task: Task[T])
+```
+
+```scala
+def unsafeRun()(implicit ec: ExecutionContext): T = ...
+```
+
+#### `main/java/coursier/paths/CachePath.java`
+
+> Cache paths logic, shared by the cache and bootstrap modules
+
+```java
+public class CachePath
+```
+
+```java
+public static File localFile(String url, File cache, String user, boolean localArtifactsShouldBeCached) throws MalformedURLException
+```
+
+```java
+public static File temporaryFile(File file)
+```
+
+```java
+public static Path lockFile(Path path)
+```
+
+```java
+public static File lockFile(File file)
+```
+
+```java
+public static File defaultCacheDirectory() throws IOException
+```
+
+```java
+public static File defaultArchiveCacheDirectory() throws IOException
+```
+
+```java
+public static File defaultPriviledgedArchiveCacheDirectory() throws IOException
+```
+
+```java
+public static File defaultDigestBasedCacheDirectory() throws IOException
+```
+
+```java
+public static <V> V withStructureLock(File cache, Callable<V> callable) throws Exception
+```
+
+```java
+public static <V> V withStructureLock(Path cache, Callable<V> callable) throws Exception
+```
+
+#### `main/java/coursier/paths/CoursierPaths.java`
+
+> Computes Coursier's directories according to the standard
+> defined by operating system Coursier is running on.
+>
+> @implNote If more paths e. g. for configuration or application data is required,
+> use {@link #coursierDirectories} and do not roll your own logic.
+
+```java
+public final class CoursierPaths
+```
+
+```java
+public static File cacheDirectory() throws IOException
+```
+
+```java
+public static File archiveCacheDirectory() throws IOException
+```
+
+```java
+public static File priviledgedArchiveCacheDirectory() throws IOException
+```
+
+```java
+public static File digestBasedCacheDirectory() throws IOException
+```
+
+```java
+public static File jvmCacheDirectory() throws IOException
+```
+
+```java
+public static ProjectDirectories directoriesInstance(String name)
+```
+
+```java
+public static File[] configDirectories() throws IOException
+```
+
+```java
+    @Deprecated
+public static File configDirectory() throws IOException
+```
+
+```java
+public static File defaultConfigDirectory() throws IOException
+```
+
+```java
+public static File dataLocalDirectory() throws IOException
+```
+
+```java
+public static File projectCacheDirectory() throws IOException
+```
+
+```java
+public static Path scalaConfigFile() throws Throwable
+```
+
+#### `main/java/coursier/paths/Jep.java`
+
+```java
+public class Jep
+```
+
+```java
+final char[] buffer = ...
+```
+
+```java
+final StringBuilder out = ...
+```
+
+```java
+public static class JepException extends Exception
+```
+
+```java
+public static File location() throws Exception
+```
+
+```java
+public static File jar(File jepDirectory) throws JepException
+```
+
+```java
+public static String version(File jepJar) throws JepException
+```
+
+```java
+public static String pythonHome() throws Exception
+```
+
+```java
+public static List<Map.Entry<String, String>> pythonProperties() throws Exception
+```
+
+#### `main/java/coursier/paths/Mirror.java`
+
+```java
+public class Mirror
+```
+
+```java
+public final static class Types
+```
+
+```java
+public static final String MAVEN = ...
+```
+
+```java
+public static final String TREE = ...
+```
+
+```java
+public static Mirror of(List<String> from, String to, String type)
+```
+
+```java
+public static File[] defaultConfigFiles() throws IOException
+```
+
+```java
+  @Deprecated
+public static File defaultConfigFile() throws IOException
+```
+
+```java
+public static File extraConfigFile() throws IOException
+```
+
+```java
+public static List<Mirror> load() throws MirrorPropertiesException, IOException
+```
+
+```java
+public static List<Mirror> parse(File file) throws MirrorPropertiesException, IOException
+```
+
+```java
+public static class MirrorPropertiesException extends Exception
+```
+
+```java
+public static List<Mirror> parse(Properties props) throws MirrorPropertiesException
+```
+
+```java
+public List<String> from()
+```
+
+```java
+public String to()
+```
+
+```java
+public String type()
+```
+
+```java
+  @Override
+public boolean equals(Object obj)
+```
+
+```java
+  @Override
+public int hashCode()
+```
+
+```java
+  @Override
+public String toString()
+```
+
+```java
+public String transform(String url)
+```
+
+```java
+public String matches(String url)
+```
+
+```java
+public String matches(String url, String defaults)
+```
+
+```java
+public static String transform(List<Mirror> mirrors, String url)
+```
+
+#### `main/java/coursier/paths/Util.java`
+
+```java
+public class Util
+```
+
+```java
+public static Map<String, String> expandProperties(Map<String, String> properties)
+```
+
+```java
+public static Map<String, String> expandProperties(
+        Properties systemProperties,
+        Map<String, String> properties)
+```
+
+```java
+final Map<String, String> resolved = ...
+```
+
+```java
+final Map<String, String> withProps = ...
+```
+
+```java
+public static void createDirectories(Path path) throws IOException
+```
+
+```java
+public static boolean useColorOutput()
+```
+
+```java
+public static boolean useAnsiOutput()
+```
+
+```java
+public static boolean useJni()
+```
+
+```java
+public static boolean useJni(Runnable beforeJni)
+```
+
+#### `scala/coursier/cache/Cache.scala`
+
+```scala
+abstract class Cache[F[_]] extends PlatformCache[F]
+```
+
+> Method to fetch an [[Artifact]].
+>
+> Note that this method tries all the [[coursier.cache.CachePolicy]] ies of this cache
+> straightaway. During resolutions, you should prefer to try all repositories for the first
+> policy, then the other policies if needed (in pseudo-code, `for (policy <- policies; repo <-
+> repositories) …`, rather than `for (repo <- repositories, policy <- policies) …`). You should
+> use the [[fetchs]] method in that case.
+
+```scala
+def fetch: Fetch[F]
+```
+
+> Sequence of [[Fetch]] able to fetch an [[Artifact]].
+>
+> Each element correspond to a [[coursier.cache.CachePolicy]] of this [[Cache]]. You may want to
+> pass each of them to `coursier.core.ResolutionProcess.fetch0()`.
+>
+> @return
+> a non empty sequence
+
+```scala
+def fetchs: Seq[Fetch[F]] = ...
+```
+
+```scala
+def ec: ExecutionContext
+```
+
+```scala
+def loggerOpt: Option[CacheLogger] = ...
+```
+
+```scala
+object Cache extends PlatformCacheCompanion
+```
+
+```scala
+type Fetch[F[_]] = ...
+```
+
+#### `scala/coursier/cache/CacheLogger.scala`
+
+```scala
+trait CacheLogger
+```
+
+```scala
+def foundLocally(url: String): Unit = ...
+```
+
+```scala
+def checkingArtifact(url: String, artifact: Artifact): Unit = ...
+```
+
+```scala
+def downloadingArtifact(url: String): Unit = ...
+```
+
+```scala
+def downloadingArtifact(url: String, artifact: Artifact): Unit = ...
+```
+
+```scala
+def downloadProgress(url: String, downloaded: Long): Unit = ...
+```
+
+```scala
+def downloadedArtifact(url: String, success: Boolean): Unit = ...
+```
+
+```scala
+def checkingUpdates(url: String, currentTimeOpt: Option[Long]): Unit = ...
+```
+
+```scala
+def checkingUpdatesResult(
+    url: String,
+    currentTimeOpt: Option[Long],
+    remoteTimeOpt: Option[Long]
+  ): Unit = ...
+```
+
+```scala
+def downloadLength(
+    url: String,
+    totalLength: Long,
+    alreadyDownloaded: Long,
+    watching: Boolean
+  ): Unit = ...
+```
+
+```scala
+def gettingLength(url: String): Unit = ...
+```
+
+```scala
+def gettingLengthResult(url: String, length: Option[Long]): Unit = ...
+```
+
+```scala
+def removedCorruptFile(url: String, reason: Option[String]): Unit = ...
+```
+
+```scala
+def pickedModuleVersion(module: String, version: String): Unit = ...
+```
+
+```scala
+def init(sizeHint: Option[Int] = None): Unit = ...
+```
+
+```scala
+def stop(): Unit = ...
+```
+
+```scala
+final def use[T](f: => T): T = ...
+```
+
+```scala
+final def using[T]: CacheLogger.Using[T] = ...
+```
+
+```scala
+object CacheLogger
+```
+
+```scala
+final class Using[T](logger: CacheLogger)
+```
+
+```scala
+def apply[F[_]](task: F[T])(implicit sync: Sync[F]): F[T] = ...
+```
+
+```scala
+def nop: CacheLogger = ...
+```
+
+#### `scala/coursier/cache/internal/MockCacheEscape.scala`
+
+```scala
+object MockCacheEscape
+```
+
+```scala
+def urlAsPath(url: String): String = ...
+```
+
+#### `scala/coursier/util/Sync.scala`
+
+```scala
+trait Sync[F[_]] extends Gather[F] with PlatformSync[F]
+```
+
+```scala
+def delay[A](a: => A): F[A]
+```
+
+```scala
+def handle[A](a: F[A])(f: PartialFunction[Throwable, A]): F[A]
+```
+
+```scala
+def fromAttempt[A](a: Either[Throwable, A]): F[A]
+```
+
+```scala
+def attempt[A](f: F[A]): F[Either[Throwable, A]] = ...
+```
+
+```scala
+object Sync extends PlatformSyncCompanion
+```
+
+```scala
+def apply[F[_]](implicit sync: Sync[F]): Sync[F] = ...
+```
+
+#### `scala/coursier/util/Task.scala`
+
+```scala
+final case class Task[+T](value: ExecutionContext => Future[T]) extends AnyVal
+```
+
+```scala
+def map[U](f: T => U): Task[U] = ...
+```
+
+```scala
+def flatMap[U](f: T => Task[U]): Task[U] = ...
+```
+
+```scala
+def handle[U >: T](f: PartialFunction[Throwable, U]): Task[U] = ...
+```
+
+```scala
+def future()(implicit ec: ExecutionContext): Future[T] = ...
+```
+
+```scala
+def attempt: Task[Either[Throwable, T]] = ...
+```
+
+```scala
+def schedule(duration: Duration, es: ScheduledExecutorService): Task[T] = ...
+```
+
+```scala
+object Task extends PlatformTaskCompanion
+```
+
+```scala
+def point[A](a: A): Task[A] = ...
+```
+
+```scala
+def delay[A](a: => A): Task[A] = ...
+```
+
+```scala
+def never[A]: Task[A] = ...
+```
+
+```scala
+def fromEither[T](e: Either[Throwable, T]): Task[T] = ...
+```
+
+```scala
+def fail(e: Throwable): Task[Nothing] = ...
+```
+
+```scala
+def tailRecM[A, B](a: A)(fn: A => Task[Either[A, B]]): Task[B] = ...
+```
+
+```scala
+def gather: Gather[Task] = ...
+```
+
+```scala
+final class WrappedException(cause: Throwable) extends Throwable(cause)
+```
+
+#### `scala/coursier/util/TaskSync.scala`
+
+```scala
+trait TaskSync extends Sync[Task]
+```
+
+```scala
+def point[A](a: A) = ...
+```
+
+```scala
+def bind[A, B](elem: Task[A])(f: A => Task[B]) = ...
+```
+
+```scala
+override def map[A, B](elem: Task[A])(f: A => B): Task[B] = ...
+```
+
+```scala
+def gather[A](elems: Seq[Task[A]]) = ...
+```
+
+```scala
+def delay[A](a: => A) = ...
+```
+
+```scala
+override def fromAttempt[A](a: Either[Throwable, A]): Task[A] = ...
+```
+
+```scala
+def handle[A](a: Task[A])(f: PartialFunction[Throwable, A]) = ...
+```
+
+### `io.get-coursier:coursier-proxy-setup:2.1.25-M3`
+
+Source: https://repo1.maven.org/maven2/io/get-coursier/coursier-proxy-setup/2.1.25-M3/coursier-proxy-setup-2.1.25-M3-sources.jar
+
+#### `coursier/proxy/SetupProxy.java`
+
+```java
+public final class SetupProxy
+```
+
+```java
+public static void setupTunnelingProp()
+```
+
+```java
+        @Override
+public void startDocument()
+```
+
+```java
+        @Override
+public void startElement(String uri, String localName, String qName, Attributes attributes)
+```
+
+```java
+        @Override
+public void characters(char[] ch, int start, int length)
+```
+
+```java
+        @Override
+public void endElement(String uri, String localName, String qName)
+```
+
+```java
+public List<Map<String, String>> getProxies()
+```
+
+```java
+static void setProperty(String key, String value)
+```
+
+```java
+public static void setProxyProperties(
+        String addressValue,
+        String usernameValue,
+        String passwordValue,
+        String nonProxyHostsValue
+    ) throws URISyntaxException
+```
+
+```java
+public static void setProxyProperties(
+        String protocolValue,
+        String hostValue,
+        String portValue,
+        String usernameValue,
+        String passwordValue,
+        String nonProxyHostsValue,
+        String propertyPrefix
+    )
+```
+
+```java
+public static void setupPropertiesFrom(File m2Settings, String propertyPrefix) throws ParserConfigurationException, SAXException, IOException
+```
+
+```java
+public static void setupProperties() throws ParserConfigurationException, SAXException, IOException
+```
+
+```java
+public static boolean setupAuthenticator(
+            String httpProtocol,
+            String httpHost,
+            String httpPort,
+            String httpUser,
+            String httpPassword,
+            String httpsProtocol,
+            String httpsHost,
+            String httpsPort,
+            String httpsUser,
+            String httpsPassword,
+            String extraHttpProtocol,
+            String extraHttpHost,
+            String extraHttpPort,
+            String extraHttpUser,
+            String extraHttpPassword
+    )
+```
+
+```java
+public static boolean setupAuthenticator()
+```
+
+```java
+public static boolean setup() throws ParserConfigurationException, SAXException, IOException
+```
+
+### `io.get-coursier:dependency_2.13:0.3.2`
+
+Source: https://repo1.maven.org/maven2/io/get-coursier/dependency_2.13/0.3.2/dependency_2.13-0.3.2-sources.jar
+
+#### `dependency/CovariantSet.scala`
+
+```scala
+object CovariantSet extends IterableFactory[CovariantSet]
+```
+
+```scala
+def from[A](source: IterableOnce[A]): CovariantSet[A] = ...
+```
+
+```scala
+def empty[A]: CovariantSet[A] = ...
+```
+
+```scala
+def newBuilder[A]: Builder[A, CovariantSet[A]] = ...
+```
+
+#### `dependency/DependencyLike.scala`
+
+```scala
+final case class DependencyLike[+A <: NameAttributes, +E <: NameAttributes](
+  module: ModuleLike[A],
+  version: String,
+  exclude: CovariantSet[ModuleLike[E]],
+  userParams: Seq[(String, Option[String])]
+)
+```
+
+```scala
+def applyParams(params: ScalaParameters): Dependency = ...
+```
+
+```scala
+def organization: String = ...
+```
+
+```scala
+def name: String = ...
+```
+
+```scala
+def nameAttributes: A = ...
+```
+
+```scala
+def attributes: Map[String, String] = ...
+```
+
+```scala
+lazy val userParamsMap: Map[String, Seq[Option[String]]] = ...
+```
+
+```scala
+def render: String = ...
+```
+
+```scala
+override def toString: String = ...
+```
+
+```scala
+object DependencyLike
+```
+
+```scala
+def apply[A <: NameAttributes, E <: NameAttributes](
+    module: ModuleLike[A],
+    version: String,
+    exclude: CovariantSet[ModuleLike[E]]
+  ): DependencyLike[A, E] = ...
+```
+
+```scala
+def apply[A <: NameAttributes](
+    module: ModuleLike[A],
+    version: String
+  ): DependencyLike[A, NameAttributes] = ...
+```
+
+#### `dependency/ModuleLike.scala`
+
+```scala
+final case class ModuleLike[+A <: NameAttributes](
+  organization: String,
+  name: String,
+  nameAttributes: A,
+  attributes: Map[String, String]
+)
+```
+
+```scala
+def applyParams(params: ScalaParameters): Module = ...
+```
+
+```scala
+def render: String = ...
+```
+
+```scala
+def render(separator: String): String = ...
+```
+
+```scala
+override def toString: String = ...
+```
+
+```scala
+object ModuleLike
+```
+
+#### `dependency/NameAttributes.scala`
+
+```scala
+sealed abstract class NameAttributes extends Product with Serializable
+```
+
+```scala
+def suffix(params: ScalaParameters): String
+```
+
+```scala
+def render(name: String, separator: String): String
+```
+
+```scala
+final def render(name: String): String = ...
+```
+
+```scala
+final case class ScalaNameAttributes(
+  fullCrossVersion: Option[Boolean],
+  platform: Option[Boolean]
+) extends NameAttributes
+```
+
+```scala
+def platformSuffix(params: ScalaParameters): String = ...
+```
+
+```scala
+def versionSuffix(params: ScalaParameters): String = ...
+```
+
+```scala
+def suffix(params: ScalaParameters): String = ...
+```
+
+```scala
+def render(name: String, separator: String): String = ...
+```
+
+```scala
+case object NoAttributes extends NameAttributes
+```
+
+```scala
+def suffix(params: ScalaParameters): String = ...
+```
+
+```scala
+def render(name: String, separator: String): String = ...
+```
+
+#### `dependency/ScalaParameters.scala`
+
+```scala
+final case class ScalaParameters(
+  scalaVersion: String,
+  scalaBinaryVersion: String,
+  platform: Option[String]
+)
+```
+
+```scala
+object ScalaParameters
+```
+
+```scala
+def apply(
+    scalaVersion: String,
+    scalaBinaryVersion: String
+  ): ScalaParameters = ...
+```
+
+```scala
+def apply(scalaVersion: String): ScalaParameters = ...
+```
+
+#### `dependency/ScalaVersion.scala`
+
+```scala
+object ScalaVersion
+```
+
+```scala
+def binary(scalaVersion: String): String = ...
+```
+
+```scala
+def jsBinary(scalaJsVersion: String): Option[String] = ...
+```
+
+```scala
+def nativeBinary(scalaNativeVersion: String): Option[String] = ...
+```
+
+#### `dependency/literal/DependencyLiteralMacros.scala`
+
+```scala
+class DependencyLiteralMacros(override val c: whitebox.Context) extends ModuleLiteralMacros(c)
+```
+
+```scala
+def dependency(args: c.Tree*): c.Tree = ...
+```
+
+#### `dependency/literal/Extensions.scala`
+
+```scala
+trait Extensions
+```
+
+```scala
+implicit class moduleString(val sc: StringContext)
+```
+
+```scala
+def mod(args: Any*): ModuleLike[NameAttributes] = ...
+```
+
+```scala
+implicit class dependencyString(val sc: StringContext)
+```
+
+```scala
+def dep(args: Any*): DependencyLike[NameAttributes, NameAttributes] = ...
+```
+
+#### `dependency/literal/LiteralMacros.scala`
+
+```scala
+abstract class LiteralMacros(val c: whitebox.Context)
+```
+
+```scala
+def mappings(args: Seq[c.Tree]): Mappings = ...
+```
+
+```scala
+def input(inputs: Seq[String], mappings: Mappings): String = ...
+```
+
+#### `dependency/literal/ModuleLiteralMacros.scala`
+
+```scala
+class ModuleLiteralMacros(override val c: whitebox.Context) extends LiteralMacros(c)
+```
+
+```scala
+def module(args: c.Tree*): c.Tree = ...
+```
+
+#### `dependency/package.scala`
+
+```scala
+package object dependency extends dependency.literal.Extensions
+```
+
+```scala
+type Module = ...
+```
+
+```scala
+type Dependency = ...
+```
+
+```scala
+type ScalaModule = ...
+```
+
+```scala
+type ScalaDependency = ...
+```
+
+```scala
+type AnyModule = ...
+```
+
+```scala
+type AnyDependency = ...
+```
+
+```scala
+object Module
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      attributes: Map[String, String]
+    ): Module = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String
+    ): Module = ...
+```
+
+```scala
+object Dependency
+```
+
+```scala
+def apply(
+      module: Module,
+      version: String,
+      exclude: CovariantSet[Module],
+      userParams: Seq[(String, Option[String])]
+    ): Dependency = ...
+```
+
+```scala
+def apply(
+      module: Module,
+      version: String,
+      exclude: CovariantSet[Module]
+    ): Dependency = ...
+```
+
+```scala
+def apply(
+      module: Module,
+      version: String
+    ): Dependency = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      version: String
+    ): Dependency = ...
+```
+
+```scala
+object ScalaModule
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      fullCrossVersion: Boolean,
+      platform: Boolean,
+      attributes: Map[String, String]
+    ): ScalaModule = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      fullCrossVersion: Boolean,
+      platform: Boolean
+    ): ScalaModule = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      fullCrossVersion: Boolean
+    ): ScalaModule = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String
+    ): ScalaModule = ...
+```
+
+```scala
+object ScalaDependency
+```
+
+```scala
+def apply(
+      module: ScalaModule,
+      version: String,
+      exclude: CovariantSet[AnyModule],
+      userParams: Seq[(String, Option[String])]
+    ): ScalaDependency = ...
+```
+
+```scala
+def apply(
+      module: ScalaModule,
+      version: String,
+      exclude: CovariantSet[AnyModule]
+    ): ScalaDependency = ...
+```
+
+```scala
+def apply(
+      module: ScalaModule,
+      version: String
+    ): ScalaDependency = ...
+```
+
+```scala
+def apply(
+      organization: String,
+      name: String,
+      version: String
+    ): ScalaDependency = ...
+```
+
+#### `dependency/parser/DependencyParser.scala`
+
+```scala
+object DependencyParser
+```
+
+```scala
+def parse(input: String): Either[String, AnyDependency] = ...
+```
+
+```scala
+def parse(input: String, acceptInlineConfiguration: Boolean): Either[String, AnyDependency] = ...
+```
+
+#### `dependency/parser/ModuleParser.scala`
+
+```scala
+object ModuleParser
+```
+
+> Parses a module like
+> org:name
+> possibly with attributes, like
+> org:name;attr1=val1;attr2=val2
+>
+> Two semi-columns after the org part is interpreted as a scala module. E.g. if
+> the scala version is 2.13., org::name is equivalent to org:name_2.13.
+
+```scala
+def parse(input: String): Either[String, AnyModule] = ...
+```
+
+```scala
+def parsePrefix(input: String): Either[String, (AnyModule, String)] = ...
+```
+

--- a/docs/dependency-api-reference.md
+++ b/docs/dependency-api-reference.md
@@ -1,0 +1,21 @@
+# Dependency API Reference
+
+Local API references for the direct dependencies declared around `build.mill` lines 14-22. Each dependency has its own markdown file generated from Maven source artifacts, with usage notes and extracted non-private signatures.
+
+| Dependency | Direct coordinate | File | Extracted signatures | Source files |
+| --- | --- | --- | ---: | ---: |
+| mainargs | `com.lihaoyi::mainargs:0.5.0` | [`mainargs-0.5.0.md`](./mainargs-0.5.0.md) | 170 | 15 |
+| os-lib | `com.lihaoyi::os-lib:0.10.0` | [`os-lib-0.10.0.md`](./os-lib-0.10.0.md) | 514 | 15 |
+| upickle | `com.lihaoyi::upickle:3.3.1` | [`upickle-3.3.1.md`](./upickle-3.3.1.md) | 1220 | 70 |
+| cask | `com.lihaoyi::cask:0.11.3` | [`cask-0.11.3.md`](./cask-0.11.3.md) | 509 | 26 |
+| requests | `com.lihaoyi::requests:0.9.2` | [`requests-0.9.2.md`](./requests-0.9.2.md) | 150 | 7 |
+| scalasql | `com.lihaoyi::scalasql:0.3.1` | [`scalasql-0.3.1.md`](./scalasql-0.3.1.md) | 1367 | 80 |
+| sqlite-jdbc | `org.xerial:sqlite-jdbc:3.46.1.0` | [`sqlite-jdbc-3.46.1.0.md`](./sqlite-jdbc-3.46.1.0.md) | 1441 | 56 |
+| slf4j-nop | `org.slf4j:slf4j-nop:2.0.13` | [`slf4j-nop-2.0.13.md`](./slf4j-nop-2.0.13.md) | 7 | 1 |
+| coursier | `io.get-coursier:coursier_2.13:2.1.25-M3` | [`coursier-2.1.25-M3.md`](./coursier-2.1.25-M3.md) | 1412 | 163 |
+
+## Notes
+
+- Scala `::` dependencies are documented with their Scala 3 artifacts, matching this project.
+- Façade dependencies such as `upickle`, `scalasql`, and `coursier` include selected transitive source artifacts because their commonly imported public types live there.
+- The extractor preserves declarations and adjacent Scaladoc/Javadoc comments, but omits implementation bodies to keep the files usable as API references.

--- a/docs/mainargs-0.5.0.md
+++ b/docs/mainargs-0.5.0.md
@@ -1,0 +1,1028 @@
+# mainargs 0.5.0 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `170` non-private declaration signatures from `15` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::mainargs:0.5.0`
+- Upstream docs: https://com-lihaoyi.github.io/mainargs/
+- Source artifacts included:
+  - `com.lihaoyi:mainargs_3:0.5.0`
+
+## Common imports
+
+```scala
+import mainargs.{main, arg, ParserForMethods, TokensReader, Flag}
+```
+
+## Usage notes
+
+Small annotation-based command-line parser used by `MillIvyFetcher` for `@main`, `@arg`, flags, and custom argument readers.
+
+```scala
+import mainargs.{main, arg, ParserForMethods, TokensReader, Flag}
+
+object Cli:
+  implicit object PathRead extends TokensReader.Simple[os.Path]:
+    def shortName = "path"
+    def read(strs: Seq[String]) = Right(os.Path(strs.head, os.pwd))
+
+  @main
+  def run(
+      @arg(short = 'p', name = "project-dir") projectDir: os.Path,
+      verbose: Flag = Flag(false)
+  ): Unit = println(s"project=$projectDir verbose=${verbose.value}")
+
+  def main(args: Array[String]): Unit =
+    ParserForMethods(this).runOrExit(args)
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:mainargs_3:0.5.0`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/mainargs_3/0.5.0/mainargs_3-0.5.0-sources.jar
+
+#### `Annotations.scala`
+
+```scala
+class arg(
+    val name: String = null,
+    val short: Char = 0,
+    val doc: String = null,
+    val noDefaultName: Boolean = false,
+    val positional: Boolean = false,
+    val hidden: Boolean = false
+) extends ClassfileAnnotation
+```
+
+```scala
+class main(val name: String = null, val doc: String = null) extends ClassfileAnnotation
+```
+
+#### `Compat.scala`
+
+```scala
+object Compat
+```
+
+```scala
+def exit(n: Int) = ...
+```
+
+#### `Flag.scala`
+
+```scala
+case class Flag(value: Boolean = false)
+```
+
+#### `Invoker.scala`
+
+```scala
+object Invoker
+```
+
+```scala
+def construct[T](
+      cep: TokensReader.Class[T],
+      args: Seq[String],
+      allowPositional: Boolean,
+      allowRepeats: Boolean
+  ): Result[T] = ...
+```
+
+```scala
+def invoke0[T, B](
+      base: B,
+      mainData: MainData[T, B],
+      kvs: Map[ArgSig, Seq[String]],
+      extras: Seq[String]
+  ): Result[T] = ...
+```
+
+```scala
+def invoke[T, B](target: B, main: MainData[T, B], grouping: TokenGrouping[B]): Result[T] = ...
+```
+
+```scala
+def runMains[B](
+      mains: MethodMains[B],
+      args: Seq[String],
+      allowPositional: Boolean,
+      allowRepeats: Boolean
+  ): Either[Result.Failure.Early, (MainData[Any, B], Result[Any])] = ...
+```
+
+```scala
+def tryEither[T](t: => T, error: Throwable => Result.ParamError): Either[Result.ParamError, T] = ...
+```
+
+```scala
+def makeReadCall[T](
+      dict: Map[ArgSig, Seq[String]],
+      base: Any,
+      arg: ArgSig,
+      reader: TokensReader.Simple[_]
+  ): ParamResult[T] = ...
+```
+
+```scala
+def makeReadVarargsCall[T](
+      arg: ArgSig,
+      values: Seq[String],
+      reader: TokensReader.Leftover[_, _]
+  ): ParamResult[T] = ...
+```
+
+#### `Leftover.scala`
+
+```scala
+case class Leftover[T](value: T*)
+```
+
+#### `Macros.scala`
+
+```scala
+object Macros
+```
+
+```scala
+def parserForMethods[B](base: Expr[B])(using Quotes, Type[B]): Expr[ParserForMethods[B]] = ...
+```
+
+```scala
+def parserForClass[B](using Quotes, Type[B]): Expr[ParserForClass[B]] = ...
+```
+
+```scala
+def createMainData[T: Type, B: Type](using Quotes)(method: quotes.reflect.Symbol, annotation: quotes.reflect.Term): Expr[MainData[T, B]] = ...
+```
+
+#### `Parser.scala`
+
+```scala
+object ParserForMethods extends ParserForMethodsCompanionVersionSpecific
+```
+
+```scala
+class ParserForMethods[B](val mains: MethodMains[B])
+```
+
+```scala
+def helpText(
+      totalWidth: Int = 100,
+      docsOnNewLine: Boolean = false,
+      customNames: Map[String, String] = Map(),
+      customDocs: Map[String, String] = Map(),
+      sorted: Boolean = true
+  ): String = ...
+```
+
+```scala
+def runOrExit(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      stderr: PrintStream = System.err,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customNames: Map[String, String] = Map(),
+      customDocs: Map[String, String] = Map()
+  ): Any = ...
+```
+
+```scala
+def runOrThrow(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customNames: Map[String, String] = Map(),
+      customDocs: Map[String, String] = Map()
+  ): Any = ...
+```
+
+```scala
+def runEither(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customNames: Map[String, String] = Map(),
+      customDocs: Map[String, String] = Map(),
+      sorted: Boolean = false
+  ): Either[String, Any] = ...
+```
+
+```scala
+def runRaw(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false
+  ): Result[Any] = ...
+```
+
+```scala
+def runRaw0(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false
+  ): Either[Result.Failure.Early, (MainData[_, B], Result[Any])] = ...
+```
+
+```scala
+object ParserForClass extends ParserForClassCompanionVersionSpecific
+```
+
+```scala
+class ParserForClass[T](val main: MainData[T, Any], val companion: () => Any)
+```
+
+```scala
+def helpText(
+      totalWidth: Int = 100,
+      docsOnNewLine: Boolean = false,
+      customName: String = null,
+      customDoc: String = null,
+      sorted: Boolean = true
+  ): String = ...
+```
+
+```scala
+def constructOrExit(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      stderr: PrintStream = System.err,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customName: String = null,
+      customDoc: String = null
+  ): T = ...
+```
+
+```scala
+def constructOrThrow(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customName: String = null,
+      customDoc: String = null
+  ): T = ...
+```
+
+```scala
+def constructEither(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false,
+      totalWidth: Int = 100,
+      printHelpOnExit: Boolean = true,
+      docsOnNewLine: Boolean = false,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
+      customName: String = null,
+      customDoc: String = null,
+      sorted: Boolean = true
+  ): Either[String, T] = ...
+```
+
+```scala
+def constructRaw(
+      args: Seq[String],
+      allowPositional: Boolean = false,
+      allowRepeats: Boolean = false
+  ): Result[T] = ...
+```
+
+#### `Renderer.scala`
+
+```scala
+object Renderer
+```
+
+```scala
+def getLeftColWidth(items: Seq[ArgSig]) = ...
+```
+
+```scala
+val newLine = ...
+```
+
+```scala
+def normalizeNewlines(s: String) = ...
+```
+
+```scala
+def renderArgShort(arg: ArgSig) = ...
+```
+
+```scala
+object ArgOrd extends math.Ordering[ArgSig]
+```
+
+```scala
+override def compare(x: ArgSig, y: ArgSig): Int = ...
+```
+
+```scala
+def renderArg(
+      arg: ArgSig,
+      leftOffset: Int,
+      wrappedWidth: Int
+  ): (String, String) = ...
+```
+
+```scala
+def formatMainMethods(
+      mainMethods: Seq[MainData[_, _]],
+      totalWidth: Int,
+      docsOnNewLine: Boolean,
+      customNames: Map[String, String],
+      customDocs: Map[String, String],
+      sorted: Boolean
+  ): String = ...
+```
+
+```scala
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+def formatMainMethods(
+      mainMethods: Seq[MainData[_, _]],
+      totalWidth: Int,
+      docsOnNewLine: Boolean,
+      customNames: Map[String, String],
+      customDocs: Map[String, String]
+  ): String = ...
+```
+
+```scala
+def formatMainMethodSignature(
+      main: MainData[_, _],
+      leftIndent: Int,
+      totalWidth: Int,
+      leftColWidth: Int,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String],
+      sorted: Boolean
+  ): String = ...
+```
+
+```scala
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+def formatMainMethodSignature(
+      main: MainData[_, _],
+      leftIndent: Int,
+      totalWidth: Int,
+      leftColWidth: Int,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String]
+  ): String = ...
+```
+
+```scala
+def softWrap(s: String, leftOffset: Int, maxWidth: Int) = ...
+```
+
+```scala
+def pluralize(s: String, n: Int) = ...
+```
+
+```scala
+def renderEarlyError(result: Result.Failure.Early) = ...
+```
+
+```scala
+def renderResult(
+      main: MainData[_, _],
+      result: Result.Failure,
+      totalWidth: Int,
+      printHelpOnError: Boolean,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String],
+      sorted: Boolean
+  ): String = ...
+```
+
+```scala
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+def renderResult(
+      main: MainData[_, _],
+      result: Result.Failure,
+      totalWidth: Int,
+      printHelpOnError: Boolean,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String]
+  ): String = ...
+```
+
+#### `Result.scala`
+
+> Represents what comes out of an attempt to invoke an [[Main]].
+> Could succeed with a value, but could fail in many different ways.
+
+```scala
+sealed trait Result[+T]
+```
+
+```scala
+def map[V](f: T => V): Result[V] = ...
+```
+
+```scala
+def flatMap[V](f: T => Result[V]): Result[V] = ...
+```
+
+```scala
+object Result
+```
+
+> Invoking the [[Main]] was totally successful, and returned a
+> result
+
+```scala
+case class Success[T](value: T) extends Result[T]
+```
+
+> Invoking the [[Main]] was not successful
+
+```scala
+sealed trait Failure extends Result[Nothing]
+```
+
+```scala
+object Failure
+```
+
+```scala
+sealed trait Early extends Failure
+```
+
+```scala
+object Early
+```
+
+```scala
+case class NoMainMethodsDetected() extends Early
+```
+
+```scala
+case class SubcommandNotSpecified(options: Seq[String]) extends Early
+```
+
+```scala
+case class UnableToFindSubcommand(options: Seq[String], token: String) extends Early
+```
+
+```scala
+case class SubcommandSelectionDashes(token: String) extends Early
+```
+
+> Invoking the [[Main]] failed with an exception while executing
+> code within it.
+
+```scala
+case class Exception(t: Throwable) extends Failure
+```
+
+> Invoking the [[Main]] failed because the arguments provided
+> did not line up with the arguments expected
+
+```scala
+case class MismatchedArguments(
+        missing: Seq[ArgSig] = Nil,
+        unknown: Seq[String] = Nil,
+        duplicate: Seq[(ArgSig, Seq[String])] = Nil,
+        incomplete: Option[ArgSig] = None
+    ) extends Failure
+```
+
+> Invoking the [[Main]] failed because there were problems
+> deserializing/parsing individual arguments
+
+```scala
+case class InvalidArguments(values: Seq[ParamError]) extends Failure
+```
+
+```scala
+sealed trait ParamError
+```
+
+```scala
+object ParamError
+```
+
+> Something went wrong trying to de-serialize the input parameter
+
+```scala
+case class Failed(arg: ArgSig, tokens: Seq[String], errMsg: String)
+```
+
+> Something went wrong trying to de-serialize the input parameter;
+> the thrown exception is stored in [[ex]]
+
+```scala
+case class Exception(arg: ArgSig, tokens: Seq[String], ex: Throwable)
+```
+
+> Something went wrong trying to evaluate the default value
+> for this input parameter
+
+```scala
+case class DefaultFailed(arg: ArgSig, ex: Throwable) extends ParamError
+```
+
+```scala
+sealed trait ParamResult[+T]
+```
+
+```scala
+def map[V](f: T => V): ParamResult[V] = ...
+```
+
+```scala
+def flatMap[V](f: T => ParamResult[V]): ParamResult[V] = ...
+```
+
+```scala
+object ParamResult
+```
+
+```scala
+case class Failure(errors: Seq[Result.ParamError]) extends ParamResult[Nothing]
+```
+
+```scala
+case class Success[T](value: T) extends ParamResult[T]
+```
+
+#### `TokenGrouping.scala`
+
+```scala
+case class TokenGrouping[B](remaining: List[String], grouped: Map[ArgSig, Seq[String]])
+```
+
+```scala
+object TokenGrouping
+```
+
+```scala
+def groupArgs[B](
+      flatArgs0: Seq[String],
+      argSigs: Seq[(ArgSig, TokensReader.Terminal[_])],
+      allowPositional: Boolean,
+      allowRepeats: Boolean,
+      allowLeftover: Boolean
+  ): Result[TokenGrouping[B]] = ...
+```
+
+#### `TokensReader.scala`
+
+> Represents the ability to parse CLI input arguments into a type [[T]]
+>
+> Has a fixed number of direct subtypes - [[Simple]], [[Constant]], [[Flag]],
+> [[Leftover]], and [[Class]] - but each of those can be extended by an
+> arbitrary number of user-specified instances.
+
+```scala
+sealed trait TokensReader[T]
+```
+
+```scala
+def isLeftover = ...
+```
+
+```scala
+def isFlag = ...
+```
+
+```scala
+def isClass = ...
+```
+
+```scala
+def isConstant = ...
+```
+
+```scala
+def isSimple = ...
+```
+
+```scala
+object TokensReader
+```
+
+```scala
+sealed trait Terminal[T] extends TokensReader[T]
+```
+
+```scala
+sealed trait ShortNamed[T] extends Terminal[T]
+```
+
+> The label that shows up in the CLI help message, e.g. the `bar` in
+> `--foo <bar>`
+
+```scala
+def shortName: String
+```
+
+> A [[TokensReader]] for a single CLI parameter that takes a value
+> e.g. `--foo bar`
+
+```scala
+trait Simple[T] extends ShortNamed[T]
+```
+
+> Converts the given input tokens to a [[T]] or an error `String`.
+> The input is a `Seq` because input tokens can be passed more than once,
+> e.g. `--foo bar --foo qux` will result in [[read]] being passed
+> `["foo", "qux"]`
+
+```scala
+def read(strs: Seq[String]): Either[String, T]
+```
+
+> Whether is CLI param is repeatable
+
+```scala
+def alwaysRepeatable: Boolean = ...
+```
+
+> Whether this CLI param can be no passed from the CLI, even if a default
+> value is not specified. In that case, [[read]] receives an empty `Seq`
+
+```scala
+def allowEmpty: Boolean = ...
+```
+
+```scala
+override def isSimple = ...
+```
+
+> A [[TokensReader]] that doesn't read any tokens and just returns a value.
+> Useful sometimes for injecting things into main methods that aren't
+> strictly computed from CLI argument tokens but nevertheless need to get
+> passed in.
+
+```scala
+trait Constant[T] extends Terminal[T]
+```
+
+```scala
+def read(): Either[String, T]
+```
+
+```scala
+override def isConstant = ...
+```
+
+> A [[TokensReader]] for a flag that does not take any value, e.g. `--foo`
+
+```scala
+trait Flag extends Terminal[mainargs.Flag]
+```
+
+```scala
+override def isFlag = ...
+```
+
+> A [[TokensReader]] for parsing the left-over parameters that do not belong
+> to any other flag or parameter.
+
+```scala
+trait Leftover[T, V] extends ShortNamed[T]
+```
+
+```scala
+def read(strs: Seq[String]): Either[String, T]
+```
+
+```scala
+def shortName: String
+```
+
+```scala
+override def isLeftover = ...
+```
+
+> A [[TokensReader]] that can parse an instance of the class [[T]], which
+> may contain multiple fields each parsed by their own [[TokensReader]]
+
+```scala
+trait Class[T] extends TokensReader[T]
+```
+
+```scala
+def companion: () = ...
+```
+
+```scala
+def main: MainData[T, Any]
+```
+
+```scala
+override def isClass = ...
+```
+
+```scala
+def tryEither[T](f: => T) = ...
+```
+
+```scala
+implicit object FlagRead extends Flag
+```
+
+```scala
+implicit object StringRead extends Simple[String]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object BooleanRead extends Simple[Boolean]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object ByteRead extends Simple[Byte]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object ShortRead extends Simple[Short]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object IntRead extends Simple[Int]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object LongRead extends Simple[Long]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object FloatRead extends Simple[Float]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit object DoubleRead extends Simple[Double]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+implicit def LeftoverRead[T: TokensReader.Simple]: TokensReader.Leftover[mainargs.Leftover[T], T] = ...
+```
+
+```scala
+class LeftoverRead[T](implicit wrapped: TokensReader.Simple[T])
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+implicit def OptionRead[T: TokensReader.Simple]: TokensReader[Option[T]] = ...
+```
+
+```scala
+class OptionRead[T: TokensReader.Simple] extends Simple[Option[T]]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+override def allowEmpty = ...
+```
+
+```scala
+implicit def SeqRead[C[_] <: Iterable[_], T: TokensReader.Simple](implicit
+      factory: Factory[T, C[T]]
+  ): TokensReader[C[T]] = ...
+```
+
+```scala
+class SeqRead[C[_] <: Iterable[_], T: TokensReader.Simple](implicit factory: Factory[T, C[T]])
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+override def alwaysRepeatable = ...
+```
+
+```scala
+override def allowEmpty = ...
+```
+
+```scala
+implicit def MapRead[K: TokensReader.Simple, V: TokensReader.Simple]: TokensReader[Map[K, V]] = ...
+```
+
+```scala
+class MapRead[K: TokensReader.Simple, V: TokensReader.Simple] extends Simple[Map[K, V]]
+```
+
+```scala
+def shortName = ...
+```
+
+```scala
+def read(strs: Seq[String]) = ...
+```
+
+```scala
+override def alwaysRepeatable = ...
+```
+
+```scala
+override def allowEmpty = ...
+```
+
+```scala
+object ArgSig
+```
+
+```scala
+def create[T, B](name0: String, arg: mainargs.arg, defaultOpt: Option[B => T])
+```
+
+```scala
+def flatten[T](x: ArgSig): Seq[(ArgSig, TokensReader.Terminal[_])] = ...
+```
+
+> Models what is known by the router about a single argument: that it has
+> a [[name]], a human-readable [[typeString]] describing what the type is
+> (just for logging and reading, not a replacement for a `TypeTag`) and
+> possible a function that can compute its default value
+
+```scala
+case class ArgSig(
+    name: Option[String],
+    shortName: Option[Char],
+    doc: Option[String],
+    default: Option[Any => Any],
+    reader: TokensReader[_],
+    positional: Boolean,
+    hidden: Boolean
+)
+```
+
+```scala
+case class MethodMains[B](value: Seq[MainData[Any, B]], base: () => B)
+```
+
+> What is known about a single endpoint for our routes. It has a [[name]],
+> [[flattenedArgSigs]] for each argument, and a macro-generated [[invoke0]]
+> that performs all the necessary argument parsing and de-serialization.
+>
+> Realistically, you will probably spend most of your time calling [[Invoker.invoke]]
+> instead, which provides a nicer API to call it that mimmicks the API of
+> calling a Scala method.
+
+```scala
+case class MainData[T, B](
+    name: String,
+    argSigs0: Seq[ArgSig],
+    doc: Option[String],
+    invokeRaw: (B, Seq[Any]) => T
+)
+```
+
+```scala
+val flattenedArgSigs: Seq[(ArgSig, TokensReader.Terminal[_])] = ...
+```
+
+```scala
+val renderedArgSigs: Seq[ArgSig] = ...
+```
+
+```scala
+object MainData
+```
+
+```scala
+def create[T, B](
+      methodName: String,
+      main: mainargs.main,
+      argSigs: Seq[ArgSig],
+      invokeRaw: (B, Seq[Any]) => T
+  ) = ...
+```
+
+#### `Util.scala`
+
+```scala
+object Util
+```
+
+```scala
+def literalize(s: IndexedSeq[Char], unicode: Boolean = false) = ...
+```
+
+```scala
+def stripDashes(s: String) = ...
+```
+
+```scala
+def appendMap[K, V](current: Map[K, Vector[V]], k: K, v: V): Map[K, Vector[V]] = ...
+```
+
+#### `acyclic.scala`
+
+```scala
+def skipped = ...
+```
+

--- a/docs/os-lib-0.10.0.md
+++ b/docs/os-lib-0.10.0.md
@@ -1,0 +1,2999 @@
+# os-lib 0.10.0 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `514` non-private declaration signatures from `15` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::os-lib:0.10.0`
+- Upstream docs: https://com-lihaoyi.github.io/os-lib/
+- Source artifacts included:
+  - `com.lihaoyi:os-lib_3:0.10.0`
+
+## Common imports
+
+```scala
+import os.* // usually accessed as os.pwd, os.Path, os.read, os.write, os.proc, ...
+```
+
+## Usage notes
+
+Filesystem, subprocess, path, and environment helper library used throughout this project via the `os` package object.
+
+```scala
+val repo = os.pwd / ".mif" / "repository"
+val pom = repo / os.RelPath("com/example/app/1.0.0/app-1.0.0.pom")
+
+os.makeDir.all(pom / os.up)
+os.write.over(pom, "<project></project>")
+
+val bytes: Array[Byte] = os.read.bytes(pom)
+val files: Seq[os.Path] = os.walk(repo).filter(os.isFile)
+
+val result = os.proc("git", "--version").call(cwd = os.pwd)
+println(result.out.text())
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:os-lib_3:0.10.0`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/os-lib_3/0.10.0/os-lib_3-0.10.0-sources.jar
+
+#### `FileOps.scala`
+
+> Create a single directory at the specified path. Optionally takes in a
+> [[PermSet]] to specify the filesystem permissions of the created
+> directory.
+>
+> Errors out if the directory already exists, or if the parent directory of the
+> specified path does not exist. To automatically create enclosing directories and
+> ignore the destination if it already exists, using [[os.makeDir.all]]
+
+```scala
+object makeDir extends Function1[Path, Unit]
+```
+
+```scala
+def apply(path: Path): Unit = ...
+```
+
+```scala
+def apply(path: Path, perms: PermSet): Unit = ...
+```
+
+> Similar to [[os.makeDir]], but automatically creates any necessary
+> enclosing directories if they do not exist, and does not raise an error if the
+> destination path already containts a directory
+
+```scala
+object all extends Function1[Path, Unit]
+```
+
+```scala
+def apply(path: Path): Unit = ...
+```
+
+```scala
+def apply(path: Path, perms: PermSet = null, acceptLinkedDirectory: Boolean = true): Unit = ...
+```
+
+> Moves a file or folder from one path to another. Errors out if the destination
+> path already exists, or is within the source path.
+
+```scala
+object move
+```
+
+```scala
+def matching(
+      replaceExisting: Boolean = false,
+      atomicMove: Boolean = false,
+      createFolders: Boolean = false
+  )(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = ...
+```
+
+```scala
+def matching(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = ...
+```
+
+```scala
+def apply(
+      from: Path,
+      to: Path,
+      replaceExisting: Boolean = false,
+      atomicMove: Boolean = false,
+      createFolders: Boolean = false
+  ): Unit = ...
+```
+
+> Move a file into a particular folder, rather
+> than into a particular path
+
+```scala
+object into
+```
+
+```scala
+def apply(
+        from: Path,
+        to: Path,
+        replaceExisting: Boolean = false,
+        atomicMove: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = ...
+```
+
+> Move a file into a particular folder, rather
+> than into a particular path
+
+```scala
+object over
+```
+
+```scala
+def apply(
+        from: Path,
+        to: Path,
+        replaceExisting: Boolean = false,
+        atomicMove: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = ...
+```
+
+> Copy a file or folder from one path to another. Recursively copies folders with
+> all their contents. Errors out if the destination path already exists, or is
+> within the source path.
+
+```scala
+object copy
+```
+
+```scala
+def matching(
+      followLinks: Boolean = true,
+      replaceExisting: Boolean = false,
+      copyAttributes: Boolean = false,
+      createFolders: Boolean = false,
+      mergeFolders: Boolean = false
+  )(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = ...
+```
+
+```scala
+def matching(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = ...
+```
+
+```scala
+def apply(
+      from: Path,
+      to: Path,
+      followLinks: Boolean = true,
+      replaceExisting: Boolean = false,
+      copyAttributes: Boolean = false,
+      createFolders: Boolean = false,
+      mergeFolders: Boolean = false
+  ): Unit = ...
+```
+
+```scala
+def apply(
+      from: Path,
+      to: Path,
+      followLinks: Boolean,
+      replaceExisting: Boolean,
+      copyAttributes: Boolean,
+      createFolders: Boolean
+  ): Unit = ...
+```
+
+> Copy a file into a particular folder, rather
+> than into a particular path
+
+```scala
+object into
+```
+
+```scala
+def apply(
+        from: Path,
+        to: Path,
+        followLinks: Boolean = true,
+        replaceExisting: Boolean = false,
+        copyAttributes: Boolean = false,
+        createFolders: Boolean = false,
+        mergeFolders: Boolean = false
+    ): Unit = ...
+```
+
+```scala
+def apply(
+        from: Path,
+        to: Path,
+        followLinks: Boolean,
+        replaceExisting: Boolean,
+        copyAttributes: Boolean,
+        createFolders: Boolean
+    ): Unit = ...
+```
+
+> Copy a file into a particular path
+
+```scala
+object over
+```
+
+```scala
+def apply(
+        from: Path,
+        to: Path,
+        followLinks: Boolean = true,
+        replaceExisting: Boolean = false,
+        copyAttributes: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = ...
+```
+
+> Roughly equivalent to bash's `rm -rf`. Deletes
+> any files or folders in the target path, or
+> does nothing if there aren't any
+
+```scala
+object remove extends Function1[Path, Boolean]
+```
+
+```scala
+def apply(target: Path): Boolean = ...
+```
+
+```scala
+def apply(target: Path, checkExists: Boolean = false): Boolean = ...
+```
+
+```scala
+object all extends Function1[Path, Unit]
+```
+
+```scala
+def apply(target: Path) = ...
+```
+
+> Checks if a file or folder exists at the given path.
+
+```scala
+object exists extends Function1[Path, Boolean]
+```
+
+```scala
+def apply(p: Path): Boolean = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): Boolean = ...
+```
+
+> Creates a hardlink between two paths
+
+```scala
+object hardlink
+```
+
+```scala
+def apply(link: Path, dest: Path) = ...
+```
+
+> Creates a symbolic link between two paths
+
+```scala
+object symlink
+```
+
+```scala
+def apply(link: Path, dest: FilePath, perms: PermSet = null): Unit = ...
+```
+
+> Attempts to any symbolic links in the given path and return the canonical path.
+> Returns `None` if the path cannot be resolved (i.e. some symbolic link in the
+> given path is broken)
+
+```scala
+object followLink extends Function1[Path, Option[Path]]
+```
+
+```scala
+def apply(src: Path): Option[Path] = ...
+```
+
+> Reads the destination that the given symbolic link is pointed to
+
+```scala
+object readLink extends Function1[Path, os.FilePath]
+```
+
+```scala
+def apply(src: Path): FilePath = ...
+```
+
+```scala
+def absolute(src: Path): os.Path = ...
+```
+
+#### `GlobInterpolator.scala`
+
+```scala
+object GlobInterpolator
+```
+
+```scala
+class Interped(parts: Seq[String])
+```
+
+```scala
+def unapplySeq(s: String) = ...
+```
+
+> Lets you pattern match strings with interpolated glob-variables
+
+```scala
+class GlobInterpolator(sc: StringContext)
+```
+
+```scala
+def g(parts: Any*) = ...
+```
+
+```scala
+def g = ...
+```
+
+#### `Internals.scala`
+
+```scala
+object Internals
+```
+
+```scala
+val emptyStringArray = ...
+```
+
+```scala
+def transfer0(src: InputStream, sink: (Array[Byte], Int) => Unit) = ...
+```
+
+```scala
+def transfer(src: InputStream, dest: OutputStream) = ...
+```
+
+#### `ListOps.scala`
+
+> Returns all the files and folders directly within the given folder. If the
+> given path is not a folder, raises an error. Can be called with
+> [[list.stream]] to return an iterator. To list files recursively, use
+> [[walk]]
+>
+> For convenience `os.list` sorts the entries in the folder before returning
+> them. You can disable sorted by passing in the flag `sort = false`.
+
+```scala
+object list extends Function1[Path, IndexedSeq[Path]]
+```
+
+```scala
+def apply(src: Path, sort: Boolean = true): IndexedSeq[Path] = ...
+```
+
+```scala
+def apply(src: Path): IndexedSeq[Path] = ...
+```
+
+> Similar to [[os.list]]], except provides a [[os.Generator]] of results
+> rather than accumulating all of them in memory. Useful if the result set
+> is large.
+
+```scala
+object stream extends Function1[Path, geny.Generator[Path]]
+```
+
+```scala
+def apply(arg: Path) = ...
+```
+
+> Recursively walks the given folder and returns the paths of every file or folder
+> within.
+>
+> You can pass in a `skip` callback to skip files or folders you are not
+> interested in. This can avoid walking entire parts of the folder hierarchy,
+> saving time as compared to filtering them after the fact.
+>
+> By default, the paths are returned as a pre-order traversal: the enclosing
+> folder is occurs first before any of it's contents. You can pass in `preOrder =
+> false` to turn it into a post-order traversal, such that the enclosing folder
+> occurs last after all it's contents.
+>
+> `os.walk` returns but does not follow symlinks; pass in `followLinks = true` to
+> override that behavior. You can also specify a maximum depth you wish to walk
+> via the `maxDepth` parameter.
+
+```scala
+object walk
+```
+
+> @param path the root path whose contents you wish to walk
+>
+> @param skip Skip certain files or folders from appearing in the output.
+> If you skip a folder, its entire subtree is ignored
+>
+> @param preOrder Whether you want a folder to appear before or after its
+> contents in the final sequence. e.g. if you're deleting
+> them recursively you want it to be false so the folder
+> gets deleted last, but if you're copying them recursively
+> you want `preOrder` to be `true` so the folder gets
+> created first.
+>
+> @param followLinks Whether or not to follow symlinks while walking; defaults
+> to false
+>
+> @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+>
+> @param includeTarget Whether or not to include the given path as part of the walk.
+> If `true`, does not raise an error if the given path is a
+> simple file and not a folder
+
+```scala
+def apply(
+      path: Path,
+      skip: Path => Boolean = _ => false,
+      preOrder: Boolean = true,
+      followLinks: Boolean = false,
+      maxDepth: Int = Int.MaxValue,
+      includeTarget: Boolean = false
+  ): IndexedSeq[Path] = ...
+```
+
+> @param path the root path whose contents you wish to walk
+>
+> @param skip Skip certain files or folders from appearing in the output.
+> If you skip a folder, its entire subtree is ignored
+>
+> @param preOrder Whether you want a folder to appear before or after its
+> contents in the final sequence. e.g. if you're deleting
+> them recursively you want it to be false so the folder
+> gets deleted last, but if you're copying them recursively
+> you want `preOrder` to be `true` so the folder gets
+> created first.
+>
+> @param followLinks Whether or not to follow symlinks while walking; defaults
+> to false
+>
+> @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+>
+> @param includeTarget Whether or not to include the given path as part of the walk.
+> If `true`, does not raise an error if the given path is a
+> simple file and not a folder
+
+```scala
+def attrs(
+      path: Path,
+      skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
+      preOrder: Boolean = true,
+      followLinks: Boolean = false,
+      maxDepth: Int = Int.MaxValue,
+      includeTarget: Boolean = false
+  ): IndexedSeq[(Path, os.StatInfo)] = ...
+```
+
+```scala
+object stream
+```
+
+> @param path the root path whose contents you wish to walk
+>
+> @param skip Skip certain files or folders from appearing in the output.
+> If you skip a folder, its entire subtree is ignored
+>
+> @param preOrder Whether you want a folder to appear before or after its
+> contents in the final sequence. e.g. if you're deleting
+> them recursively you want it to be false so the folder
+> gets deleted last, but if you're copying them recursively
+> you want `preOrder` to be `true` so the folder gets
+> created first.
+>
+> @param followLinks Whether or not to follow symlinks while walking; defaults
+> to false
+>
+> @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+>
+> @param includeTarget Whether or not to include the given path as part of the walk.
+> If `true`, does not raise an error if the given path is a
+> simple file and not a folder
+
+```scala
+def apply(
+        path: Path,
+        skip: Path => Boolean = _ => false,
+        preOrder: Boolean = true,
+        followLinks: Boolean = false,
+        maxDepth: Int = Int.MaxValue,
+        includeTarget: Boolean = false
+    ): Generator[Path] = ...
+```
+
+> @param path the root path whose contents you wish to walk
+>
+> @param skip Skip certain files or folders from appearing in the output.
+> If you skip a folder, its entire subtree is ignored
+>
+> @param preOrder Whether you want a folder to appear before or after its
+> contents in the final sequence. e.g. if you're deleting
+> them recursively you want it to be false so the folder
+> gets deleted last, but if you're copying them recursively
+> you want `preOrder` to be `true` so the folder gets
+> created first.
+>
+> @param followLinks Whether or not to follow symlinks while walking; defaults
+> to false
+>
+> @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+>
+> @param includeTarget Whether or not to include the given path as part of the walk.
+> If `true`, does not raise an error if the given path is a
+> simple file and not a folder
+
+```scala
+def attrs(
+        path: Path,
+        skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
+        preOrder: Boolean = true,
+        followLinks: Boolean = false,
+        maxDepth: Int = Int.MaxValue,
+        includeTarget: Boolean = false
+    ): Generator[(Path, os.StatInfo)] = ...
+```
+
+#### `Model.scala`
+
+> Simple enum with the possible filesystem objects a path can resolve to
+
+```scala
+sealed trait FileType
+```
+
+```scala
+object FileType
+```
+
+```scala
+case object File extends FileType
+```
+
+```scala
+case object Dir extends FileType
+```
+
+```scala
+case object SymLink extends FileType
+```
+
+```scala
+case object Other extends FileType
+```
+
+```scala
+object PermSet
+```
+
+```scala
+implicit def fromSet(value: java.util.Set[PosixFilePermission]): PermSet = ...
+```
+
+> Parses a `rwx-wxr-w` string into a [[PermSet]]
+
+```scala
+implicit def fromString(arg: String): PermSet = ...
+```
+
+> Parses a 0x777 integer into a [[PermSet]]
+
+```scala
+implicit def fromInt(value: Int): PermSet = ...
+```
+
+```scala
+def permToMask(elem: PosixFilePermission) = ...
+```
+
+```scala
+def permToChar(elem: PosixFilePermission) = ...
+```
+
+```scala
+def permToOffset(elem: PosixFilePermission) = ...
+```
+
+> A set of permissions; can be converted easily to the rw-rwx-r-x form via
+> [[toString]], or to a set of [[PosixFilePermission]]s via [[toSet]] and the
+> other way via `PermSet.fromString`/`PermSet.fromSet`
+
+```scala
+case class PermSet(value: Int)
+```
+
+```scala
+def contains(elem: PosixFilePermission) = ...
+```
+
+```scala
+def +(elem: PosixFilePermission) = ...
+```
+
+```scala
+def ++(other: PermSet) = ...
+```
+
+```scala
+def -(elem: PosixFilePermission) = ...
+```
+
+```scala
+def --(other: PermSet) = ...
+```
+
+```scala
+def toInt(): Int = ...
+```
+
+```scala
+def toSet(): java.util.Set[PosixFilePermission] = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+> Contains the accumulated output for the invocation of a subprocess command.
+>
+> Apart from the exit code, the primary data-structure is a sequence of byte
+> chunks, tagged with [[Left]] for stdout and [[Right]] for stderr. This is
+> interleaved roughly in the order it was emitted by the subprocess, and
+> reflects what a user would have see if the subprocess was run manually.
+>
+> Derived from that, is the aggregate `out` and `err` [[StreamValue]]s,
+> wrapping stdout/stderr respectively, and providing convenient access to
+> the aggregate output of each stream, as bytes or strings or lines.
+
+```scala
+case class CommandResult(
+    command: Seq[String],
+    exitCode: Int,
+    chunks: Seq[Either[geny.Bytes, geny.Bytes]]
+)
+```
+
+> The standard output and error of the executed command, exposed in a
+> number of ways for convenient access
+
+```scala
+val (out, err) = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+> Thrown when a shellout command results in a non-zero exit code.
+>
+> Doesn't contain any additional information apart from the [[CommandResult]]
+> that is normally returned, but ensures that failures in subprocesses happen
+> loudly and won't get ignored unless intentionally caught
+
+```scala
+case class SubprocessException(result: CommandResult) extends Exception(result.toString)
+```
+
+> An implicit wrapper defining the things that can
+> be "interpolated" directly into a subprocess call.
+
+```scala
+case class Shellable(value: Seq[String])
+```
+
+```scala
+object Shellable
+```
+
+```scala
+implicit def StringShellable(s: String): Shellable = ...
+```
+
+```scala
+implicit def CharSequenceShellable(cs: CharSequence): Shellable = ...
+```
+
+```scala
+implicit def SymbolShellable(s: Symbol): Shellable = ...
+```
+
+```scala
+implicit def PathShellable(s: Path): Shellable = ...
+```
+
+```scala
+implicit def RelPathShellable(s: RelPath): Shellable = ...
+```
+
+```scala
+implicit def NumericShellable[T: Numeric](s: T): Shellable = ...
+```
+
+```scala
+implicit def OptionShellable[T](s: Option[T])(implicit f: T => Shellable): Shellable = ...
+```
+
+```scala
+implicit def IterableShellable[T](s: Iterable[T])(implicit f: T => Shellable): Shellable = ...
+```
+
+```scala
+implicit def ArrayShellable[T](s: Array[T])(implicit f: T => Shellable): Shellable = ...
+```
+
+> The result from doing an system `stat` on a particular path.
+>
+> Note: ctime is not same as ctime (Change Time) in `stat`,
+> it is creation time maybe fall back to mtime if system not supported it.
+>
+> Created via `stat! filePath`.
+>
+> If you want more information, use `stat.full`
+
+```scala
+case class StatInfo(
+    size: Long,
+    mtime: FileTime,
+    ctime: FileTime,
+    atime: FileTime,
+    fileType: FileType
+)
+```
+
+```scala
+def isDir = ...
+```
+
+```scala
+def isSymLink = ...
+```
+
+```scala
+def isFile = ...
+```
+
+```scala
+object StatInfo
+```
+
+```scala
+def make(attrs: BasicFileAttributes) = ...
+```
+
+```scala
+case class PosixStatInfo(owner: UserPrincipal, permissions: PermSet)
+```
+
+```scala
+object PosixStatInfo
+```
+
+```scala
+def make(posixAttrs: PosixFileAttributes) = ...
+```
+
+#### `Path.scala`
+
+```scala
+trait PathChunk
+```
+
+```scala
+def segments: Seq[String]
+```
+
+```scala
+def ups: Int
+```
+
+```scala
+object PathChunk
+```
+
+```scala
+implicit class RelPathChunk(r: RelPath) extends PathChunk
+```
+
+```scala
+def segments = ...
+```
+
+```scala
+def ups = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+```scala
+implicit class SubPathChunk(r: SubPath) extends PathChunk
+```
+
+```scala
+def segments = ...
+```
+
+```scala
+def ups = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+```scala
+implicit class StringPathChunk(s: String) extends PathChunk
+```
+
+```scala
+def segments = ...
+```
+
+```scala
+def ups = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+```scala
+implicit class SymbolPathChunk(s: Symbol) extends PathChunk
+```
+
+```scala
+def segments = ...
+```
+
+```scala
+def ups = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+```scala
+implicit class ArrayPathChunk[T](a: Array[T])(implicit f: T => PathChunk) extends PathChunk
+```
+
+```scala
+val inner = ...
+```
+
+```scala
+def segments = ...
+```
+
+```scala
+def ups = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+```scala
+implicit class SeqPathChunk[T](a: Seq[T])(implicit f: T => PathChunk) extends PathChunk
+```
+
+```scala
+    @deprecated("never used, really shouldn't exist, kept for bincompat")
+var segments0 = ...
+```
+
+```scala
+    @deprecated("never used, really shouldn't exist, kept for bincompat")
+var ups0 = ...
+```
+
+```scala
+val (segments, ups) = ...
+```
+
+```scala
+override def toString() = ...
+```
+
+> A path which is either an absolute [[Path]], a relative [[RelPath]],
+> or a [[ResourcePath]] with shared APIs and implementations.
+>
+> Most of the filesystem-independent path-manipulation logic that lets you
+> splice paths together or navigate in and out of paths lives in this interface
+
+```scala
+trait BasePath
+```
+
+```scala
+type ThisType <: BasePath
+```
+
+> Combines this path with the given relative path, returning
+> a path of the same type as this one (e.g. `Path` returns `Path`,
+> `RelPath` returns `RelPath`
+
+```scala
+def /(chunk: PathChunk): ThisType
+```
+
+> Relativizes this path with the given `target` path, finding a
+> relative path `p` such that base/p == this.
+>
+> Note that you can only relativize paths of the same type, e.g.
+> `Path` & `Path` or `RelPath` & `RelPath`. In the case of `RelPath`,
+> this can throw a [[PathError.NoRelativePath]] if there is no
+> relative path that satisfies the above requirement in the general
+> case.
+
+```scala
+def relativeTo(target: ThisType): RelPath
+```
+
+> Relativizes this path with the given `target` path, finding a
+> sub path `p` such that base/p == this.
+
+```scala
+def subRelativeTo(target: ThisType): SubPath = ...
+```
+
+> This path starts with the target path, including if it's identical
+
+```scala
+def startsWith(target: ThisType): Boolean
+```
+
+> This path ends with the target path, including if it's identical
+
+```scala
+def endsWith(target: RelPath): Boolean
+```
+
+> The last segment in this path. Very commonly used, e.g. it
+> represents the name of the file/folder in filesystem paths
+
+```scala
+def last: String
+```
+
+> Gives you the file extension of this path, or the empty
+> string if there is no extension
+
+```scala
+def ext: String
+```
+
+> Gives you the base name of this path, ie without the extension
+
+```scala
+def baseName: String
+```
+
+> The individual path segments of this path.
+
+```scala
+def segments: TraversableOnce[String]
+```
+
+```scala
+object BasePath
+```
+
+```scala
+def checkSegment(s: String) = ...
+```
+
+```scala
+def chunkify(s: java.nio.file.Path) = ...
+```
+
+```scala
+trait SegmentedPath extends BasePath
+```
+
+> The individual path segments of this path.
+
+```scala
+def segments: IndexedSeq[String]
+```
+
+```scala
+override def /(chunk: PathChunk): ThisType = ...
+```
+
+```scala
+def endsWith(target: RelPath): Boolean = ...
+```
+
+```scala
+trait BasePathImpl extends BasePath
+```
+
+```scala
+def /(chunk: PathChunk): ThisType
+```
+
+```scala
+def ext = ...
+```
+
+```scala
+override def baseName: String = ...
+```
+
+```scala
+def last: String = ...
+```
+
+```scala
+def lastOpt: Option[String]
+```
+
+```scala
+object PathError
+```
+
+```scala
+type IAE = ...
+```
+
+```scala
+case class InvalidSegment(segment: String, msg: String) extends IAE(errorMsg(segment, msg))
+```
+
+```scala
+case object AbsolutePathOutsideRoot
+      extends IAE("The path created has enough ..s that it would start outside the root directory")
+```
+
+```scala
+case class NoRelativePath(src: RelPath, base: RelPath)
+```
+
+```scala
+case class LastOnEmptyPath()
+```
+
+> Represents a value that is either an absolute [[Path]] or a
+> relative [[RelPath]], and can be constructed from a
+> java.nio.file.Path or java.io.File
+
+```scala
+sealed trait FilePath extends BasePath
+```
+
+```scala
+def toNIO: java.nio.file.Path
+```
+
+```scala
+def resolveFrom(base: os.Path): os.Path
+```
+
+```scala
+object FilePath
+```
+
+```scala
+def apply[T: PathConvertible](f0: T) = ...
+```
+
+> A relative path on the filesystem. Note that the path is
+> normalized and cannot contain any empty or ".". Parent ".."
+> segments can only occur at the left-end of the path, and
+> are collapsed into a single number [[ups]].
+
+```scala
+class RelPath private[os] (segments0: Array[String], val ups: Int)
+```
+
+```scala
+def lastOpt = ...
+```
+
+```scala
+val segments: IndexedSeq[String] = ...
+```
+
+```scala
+type ThisType = ...
+```
+
+```scala
+def relativeTo(base: RelPath): RelPath = ...
+```
+
+```scala
+def startsWith(target: RelPath) = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+override def hashCode = ...
+```
+
+```scala
+override def equals(o: Any): Boolean = ...
+```
+
+```scala
+def toNIO = ...
+```
+
+```scala
+def asSubPath = ...
+```
+
+```scala
+def resolveFrom(base: os.Path) = ...
+```
+
+```scala
+object RelPath
+```
+
+```scala
+def apply[T: PathConvertible](f0: T): RelPath = ...
+```
+
+```scala
+def apply(segments0: IndexedSeq[String], ups: Int) = ...
+```
+
+```scala
+implicit val relPathOrdering: Ordering[RelPath] = ...
+```
+
+```scala
+val up: RelPath = ...
+```
+
+```scala
+val rel: RelPath = ...
+```
+
+```scala
+implicit def SubRelPath(p: SubPath): RelPath = ...
+```
+
+> A relative path on the filesystem, without any `..` or `.` segments
+
+```scala
+class SubPath private[os] (val segments0: Array[String])
+```
+
+```scala
+def lastOpt = ...
+```
+
+```scala
+val segments: IndexedSeq[String] = ...
+```
+
+```scala
+override type ThisType = ...
+```
+
+```scala
+def relativeTo(base: SubPath): RelPath = ...
+```
+
+```scala
+def startsWith(target: SubPath) = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+override def hashCode = ...
+```
+
+```scala
+override def equals(o: Any): Boolean = ...
+```
+
+```scala
+def toNIO = ...
+```
+
+```scala
+def resolveFrom(base: os.Path) = ...
+```
+
+```scala
+object SubPath
+```
+
+```scala
+def apply[T: PathConvertible](f0: T): SubPath = ...
+```
+
+```scala
+def apply(segments0: IndexedSeq[String]): SubPath = ...
+```
+
+```scala
+implicit val subPathOrdering: Ordering[SubPath] = ...
+```
+
+```scala
+val sub: SubPath = ...
+```
+
+```scala
+object Path
+```
+
+```scala
+def apply(p: FilePath, base: Path) = ...
+```
+
+> Equivalent to [[os.Path.apply]], but automatically expands a
+> leading `~/` into the user's home directory, for convenience
+
+```scala
+def expandUser[T: PathConvertible](f0: T, base: Path = null) = ...
+```
+
+```scala
+def apply[T: PathConvertible](f: T, base: Path): Path = ...
+```
+
+```scala
+def apply[T: PathConvertible](f0: T): Path = ...
+```
+
+```scala
+implicit val pathOrdering: Ordering[Path] = ...
+```
+
+> @return true if Windows OS and path begins with slash or backslash.
+> Examples:
+> driveRelative("/Users")   // true in `Windows`, false elsewhere.
+> driveRelative("\\Users")  // true in `Windows`, false elsewhere.
+> driveRelative("C:/Users") // false always
+
+```scala
+def driveRelative[T: PathConvertible](f0: T): Boolean = ...
+```
+
+> @return current working drive if Windows, empty string elsewhere.
+> Paths.get(driveRoot) == current working directory on all platforms.
+
+```scala
+lazy val driveRoot: String = ...
+```
+
+```scala
+trait ReadablePath
+```
+
+```scala
+def toSource: os.Source
+```
+
+```scala
+def getInputStream: java.io.InputStream
+```
+
+> An absolute path on the filesystem. Note that the path is
+> normalized and cannot contain any empty `""`, `"."` or `".."` segments
+
+```scala
+class Path private[os] (val wrapped: java.nio.file.Path)
+```
+
+```scala
+def toSource: SeekableSource = ...
+```
+
+```scala
+def root = ...
+```
+
+```scala
+def fileSystem = ...
+```
+
+```scala
+def segments: Iterator[String] = ...
+```
+
+```scala
+def getSegment(i: Int): String = ...
+```
+
+```scala
+def segmentCount = ...
+```
+
+```scala
+override type ThisType = ...
+```
+
+```scala
+def lastOpt = ...
+```
+
+```scala
+override def /(chunk: PathChunk): Path = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+override def equals(o: Any): Boolean = ...
+```
+
+```scala
+override def hashCode = ...
+```
+
+```scala
+def startsWith(target: Path) = ...
+```
+
+```scala
+def endsWith(target: RelPath) = ...
+```
+
+```scala
+def relativeTo(base: Path): RelPath = ...
+```
+
+```scala
+def toIO: java.io.File = ...
+```
+
+```scala
+def toNIO: java.nio.file.Path = ...
+```
+
+```scala
+def resolveFrom(base: os.Path) = ...
+```
+
+```scala
+def getInputStream = ...
+```
+
+```scala
+sealed trait PathConvertible[T]
+```
+
+```scala
+def apply(t: T): java.nio.file.Path
+```
+
+```scala
+def isCustomFs(t: T): Boolean = ...
+```
+
+```scala
+object PathConvertible
+```
+
+```scala
+implicit object StringConvertible extends PathConvertible[String]
+```
+
+```scala
+def apply(t: String) = ...
+```
+
+```scala
+implicit object JavaIoFileConvertible extends PathConvertible[java.io.File]
+```
+
+```scala
+def apply(t: java.io.File) = ...
+```
+
+```scala
+implicit object NioPathConvertible extends PathConvertible[java.nio.file.Path]
+```
+
+```scala
+def apply(t: java.nio.file.Path) = ...
+```
+
+```scala
+override def isCustomFs(t: java.nio.file.Path): Boolean = ...
+```
+
+```scala
+implicit object UriPathConvertible extends PathConvertible[URI]
+```
+
+```scala
+def apply(uri: URI) = ...
+```
+
+#### `PermsOps.scala`
+
+> Get the filesystem permissions of the file/folder at the given path
+
+```scala
+object perms extends Function1[Path, PermSet]
+```
+
+```scala
+def apply(p: Path): PermSet = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): PermSet = ...
+```
+
+> Set the filesystem permissions of the file/folder at the given path
+>
+> Note that if you want to create a file or folder with a given set of
+> permissions, you can pass in an [[os.PermSet]] to [[os.write]]
+> or [[os.makeDir]]. That will ensure the file or folder is created
+> atomically with the given permissions, rather than being created with the
+> default set of permissions and having `os.perms.set` over-write them later
+
+```scala
+object set
+```
+
+```scala
+def apply(p: Path, arg2: PermSet): Unit = ...
+```
+
+> Get the owner of the file/folder at the given path
+
+```scala
+object owner extends Function1[Path, UserPrincipal]
+```
+
+```scala
+def apply(p: Path): UserPrincipal = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): UserPrincipal = ...
+```
+
+> Set the owner of the file/folder at the given path
+
+```scala
+object set
+```
+
+```scala
+def apply(arg1: Path, arg2: UserPrincipal): Unit = ...
+```
+
+```scala
+def apply(arg1: Path, arg2: String): Unit = ...
+```
+
+> Get the owning group of the file/folder at the given path
+
+```scala
+object group extends Function1[Path, GroupPrincipal]
+```
+
+```scala
+def apply(p: Path): GroupPrincipal = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): GroupPrincipal = ...
+```
+
+> Set the owning group of the file/folder at the given path
+
+```scala
+object set
+```
+
+```scala
+def apply(arg1: Path, arg2: GroupPrincipal): Unit = ...
+```
+
+```scala
+def apply(arg1: Path, arg2: String): Unit = ...
+```
+
+#### `ProcessOps.scala`
+
+> Convenience APIs around [[java.lang.Process]] and [[java.lang.ProcessBuilder]]:
+>
+> - os.proc.call provides a convenient wrapper for "function-like" processes
+> that you invoke with some input, whose entire output you need, but
+> otherwise do not have any intricate back-and-forth communication
+>
+> - os.proc.stream provides a lower level API: rather than providing the output
+> all at once, you pass in callbacks it invokes whenever there is a chunk of
+> output received from the spawned process.
+>
+> - os.proc(...) provides the lowest level API: an simple Scala API around
+> [[java.lang.ProcessBuilder]], that spawns a normal [[java.lang.Process]]
+> for you to deal with. You can then interact with it normally through
+> the standard stdin/stdout/stderr streams, using whatever protocol you
+> want
+
+```scala
+case class proc(command: Shellable*)
+```
+
+```scala
+def commandChunks: Seq[String] = ...
+```
+
+> Invokes the given subprocess like a function, passing in input and returning a
+> [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
+> `result.out.bytes` or `result.err.text()` to access the aggregated stdout and
+> stderr of the subprocess in a number of convenient ways. If a non-zero exit code
+> is returned, this throws a [[os.SubprocessException]] containing the
+> [[CommandResult]], unless you pass in `check = false`.
+>
+> If you want to spawn an interactive subprocess, such as `vim`, `less`, or a
+> `python` shell, set all of `stdin`/`stdout`/`stderr` to [[os.Inherit]]
+>
+> `call` provides a number of parameters that let you configure how the subprocess
+> is run:
+>
+> @param cwd             the working directory of the subprocess
+> @param env             any additional environment variables you wish to set in the subprocess
+> @param stdin           any data you wish to pass to the subprocess's standard input
+> @param stdout          How the process's output stream is configured.
+> @param stderr          How the process's error stream is configured.
+> @param mergeErrIntoOut merges the subprocess's stderr stream into it's stdout
+> @param timeout         how long to wait in milliseconds for the subprocess to complete
+> @param check           disable this to avoid throwing an exception if the subprocess
+> fails with a non-zero exit code
+> @param propagateEnv    disable this to avoid passing in this parent process's
+> environment variables to the subprocess
+
+```scala
+def call(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      timeout: Long = -1,
+      check: Boolean = true,
+      propagateEnv: Boolean = true
+  ): CommandResult = ...
+```
+
+> The most flexible of the [[os.proc]] calls, `os.proc.spawn` simply configures
+> and starts a subprocess, and returns it as a `java.lang.Process` for you to
+> interact with however you like.
+>
+> Note that if you provide `ProcessOutput` callbacks to `stdout`/`stderr`,
+> the calls to those callbacks take place on newly spawned threads that
+> execute in parallel with the main thread. Thus make sure any data
+> processing you do in those callbacks is thread safe!
+
+```scala
+def spawn(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      propagateEnv: Boolean = true
+  ): SubProcess = ...
+```
+
+> Pipes the output of this process into the input of the [[next]] process. Returns a
+> [[ProcGroup]] containing both processes, which you can then either execute or
+> pipe further.
+
+```scala
+def pipeTo(next: proc): ProcGroup = ...
+```
+
+> A group of processes that are piped together, corresponding to e.g. `ls -l | grep .scala`.
+> You can create a `ProcGroup` by calling `.pipeTo` on a [[proc]] multiple times.
+> Contains methods corresponding to the methods on [[proc]], but defined for pipelines
+> of processes.
+
+```scala
+case class ProcGroup private[os] (commands: Seq[proc])
+```
+
+> Invokes the given pipeline like a function, passing in input and returning a
+> [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
+> `result.out.bytes` or `result.err.string` to access the aggregated stdout and
+> stderr of the subprocess in a number of convenient ways. If a non-zero exit code
+> is returned, this throws a [[os.SubprocessException]] containing the
+> [[CommandResult]], unless you pass in `check = false`.
+>
+> For each process in pipeline, the output will be forwarded to the input of the next
+> process. Input of the first process is set to provided [[stdin]] The output of the last
+> process will be returned as the output of the pipeline. [[stderr]] is set for all processes.
+>
+> `call` provides a number of parameters that let you configure how the pipeline
+> is run:
+>
+> @param cwd              the working directory of the pipeline
+> @param env              any additional environment variables you wish to set in the pipeline
+> @param stdin            any data you wish to pass to the pipelines's standard input (to the first process)
+> @param stdout           How the pipelines's output stream is configured (the last process stdout)
+> @param stderr           How the process's error stream is configured (set for all processes)
+> @param mergeErrIntoOut  merges the pipeline's stderr stream into it's stdout. Note that then the
+> stderr will be forwarded with stdout to subsequent processes in the pipeline.
+> @param timeout          how long to wait in milliseconds for the pipeline to complete
+> @param check            disable this to avoid throwing an exception if the pipeline
+> fails with a non-zero exit code
+> @param propagateEnv     disable this to avoid passing in this parent process's
+> environment variables to the pipeline
+> @param pipefail         if true, the pipeline's exitCode will be the exit code of the first
+> failing process. If no process fails, the exit code will be 0.
+> @param handleBrokenPipe if true, every [[java.io.IOException]] when redirecting output of a process
+> will be caught and handled by killing the writing process. This behaviour
+> is consistent with handlers of SIGPIPE signals in most programs
+> supporting interruptable piping. Disabled by default on Windows.
+
+```scala
+def call(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      timeout: Long = -1,
+      check: Boolean = true,
+      propagateEnv: Boolean = true,
+      pipefail: Boolean = true,
+      handleBrokenPipe: Boolean = !isWindows
+  ): CommandResult = ...
+```
+
+> The most flexible of the [[os.ProcGroup]] calls. It sets-up a pipeline of processes,
+> and returns a [[ProcessPipeline]] for you to interact with however you like.
+>
+> Note that if you provide `ProcessOutput` callbacks to `stdout`/`stderr`,
+> the calls to those callbacks take place on newly spawned threads that
+> execute in parallel with the main thread. Thus make sure any data
+> processing you do in those callbacks is thread safe!
+> @param cwd              the working directory of the pipeline
+> @param env              any additional environment variables you wish to set in the pipeline
+> @param stdin            any data you wish to pass to the pipelines's standard input (to the first process)
+> @param stdout           How the pipelines's output stream is configured (the last process stdout)
+> @param stderr           How the process's error stream is configured (set for all processes)
+> @param mergeErrIntoOut  merges the pipeline's stderr stream into it's stdout. Note that then the
+> stderr will be forwarded with stdout to subsequent processes in the pipeline.
+> @param propagateEnv     disable this to avoid passing in this parent process's
+> environment variables to the pipeline
+> @param pipefail         if true, the pipeline's exitCode will be the exit code of the first
+> failing process. If no process fails, the exit code will be 0.
+> @param handleBrokenPipe if true, every [[java.io.IOException]] when redirecting output of a process
+> will be caught and handled by killing the writing process. This behaviour
+> is consistent with handlers of SIGPIPE signals in most programs
+> supporting interruptable piping. Disabled by default on Windows.
+
+```scala
+def spawn(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      propagateEnv: Boolean = true,
+      pipefail: Boolean = true,
+      handleBrokenPipe: Boolean = !isWindows
+  ): ProcessPipeline = ...
+```
+
+> Pipes the output of this pipeline into the input of the [[next]] process.
+
+```scala
+def pipeTo(next: proc) = ...
+```
+
+#### `ReadWriteOps.scala`
+
+> Write some data to a file. This can be a String, an Array[Byte], or a
+> Seq[String] which is treated as consecutive lines. By default, this
+> fails if a file already exists at the target location. Use [[write.over]]
+> or [[write.append]] if you want to over-write it or add to what's already
+> there.
+
+```scala
+object write
+```
+
+> Open a [[java.io.OutputStream]] to write to the given file
+
+```scala
+def outputStream(
+      target: Path,
+      perms: PermSet = null,
+      createFolders: Boolean = false,
+      openOptions: Seq[OpenOption] = Seq(CREATE, WRITE)
+  ) = ...
+```
+
+> Performs the actual opening and writing to a file. Basically cribbed
+> from `java.nio.file.Files.write` so we could re-use it properly for
+> different combinations of flags and all sorts of [[Source]]s
+
+```scala
+def write(
+      target: Path,
+      data: Source,
+      flags: Seq[StandardOpenOption],
+      perms: PermSet,
+      offset: Long
+  ) = ...
+```
+
+```scala
+def apply(
+      target: Path,
+      data: Source,
+      perms: PermSet = null,
+      createFolders: Boolean = false
+  ): Unit = ...
+```
+
+> Identical to [[write]], except if the file already exists,
+> appends to the file instead of error-ing out
+
+```scala
+object append
+```
+
+```scala
+def apply(
+        target: Path,
+        data: Source,
+        perms: PermSet = null,
+        createFolders: Boolean = false
+    ): Unit = ...
+```
+
+> Open a [[java.io.OutputStream]] to write or append to the given file
+
+```scala
+def outputStream(target: Path, perms: PermSet = null, createFolders: Boolean = false) = ...
+```
+
+> Similar to [[os.write]], except if the file already exists this
+> over-writes the existing file contents. You can also pass in `truncate = false`
+> to avoid truncating the file if the new contents is shorter than the old
+> contents, and an `offset` to the file you want to write to.
+
+```scala
+object over
+```
+
+```scala
+def apply(
+        target: Path,
+        data: Source,
+        perms: PermSet = null,
+        offset: Long = 0,
+        createFolders: Boolean = false,
+        truncate: Boolean = true
+    ): Unit = ...
+```
+
+> Open a [[java.io.OutputStream]] to write to the given file
+
+```scala
+def outputStream(target: Path, perms: PermSet = null, createFolders: Boolean = false) = ...
+```
+
+> Opens a [[SeekableByteChannel]] to write to the given file.
+
+```scala
+object channel extends Function1[Path, SeekableByteChannel]
+```
+
+```scala
+def write(p: Path, options: Seq[StandardOpenOption]) = ...
+```
+
+```scala
+def apply(p: Path): SeekableByteChannel = ...
+```
+
+> Opens a [[SeekableByteChannel]] to write to the given file.
+
+```scala
+object append extends Function1[Path, SeekableByteChannel]
+```
+
+```scala
+def apply(p: Path): SeekableByteChannel = ...
+```
+
+> Opens a [[SeekableByteChannel]] to write to the given file.
+
+```scala
+object over extends Function1[Path, SeekableByteChannel]
+```
+
+```scala
+def apply(p: Path): SeekableByteChannel = ...
+```
+
+> Truncate the given file to the given size. If the file is smaller than the
+> given size, does nothing.
+
+```scala
+object truncate
+```
+
+```scala
+def apply(p: Path, size: Long): Unit = ...
+```
+
+> Reads the contents of a [[os.Path]] or other [[os.Source]] as a
+> `java.lang.String`. Defaults to reading the entire file as UTF-8, but you can
+> also select a different `charSet` to use, and provide an `offset`/`count` to
+> read from if the source supports seeking.
+
+```scala
+object read extends Function1[ReadablePath, String]
+```
+
+```scala
+def apply(arg: ReadablePath): String = ...
+```
+
+```scala
+def apply(arg: ReadablePath, charSet: Codec): String = ...
+```
+
+```scala
+def apply(
+      arg: Path,
+      charSet: Codec = java.nio.charset.StandardCharsets.UTF_8,
+      offset: Long = 0,
+      count: Int = Int.MaxValue
+  ): String = ...
+```
+
+> Opens a [[java.io.InputStream]] to read from the given file
+
+```scala
+object inputStream extends Function1[ReadablePath, java.io.InputStream]
+```
+
+```scala
+def apply(p: ReadablePath): java.io.InputStream = ...
+```
+
+```scala
+object stream extends Function1[ReadablePath, geny.Readable]
+```
+
+```scala
+def apply(p: ReadablePath): geny.Readable = ...
+```
+
+> Opens a [[SeekableByteChannel]] to read from the given file.
+
+```scala
+object channel extends Function1[Path, SeekableByteChannel]
+```
+
+```scala
+def apply(p: Path): SeekableByteChannel = ...
+```
+
+> Reads the contents of a [[os.Path]] or [[os.Source]] as an
+> `Array[Byte]`; you can provide an `offset`/`count` to read from if the source
+> supports seeking.
+
+```scala
+object bytes extends Function1[ReadablePath, Array[Byte]]
+```
+
+```scala
+def apply(arg: ReadablePath): Array[Byte] = ...
+```
+
+```scala
+def apply(arg: Path, offset: Long, count: Int): Array[Byte] = ...
+```
+
+> Reads the contents of the given [[os.Path]] in chunks of the given size;
+> returns a generator which provides a byte array and an offset into that
+> array which contains the data for that chunk. All chunks will be of the
+> given size, except for the last chunk which may be smaller.
+>
+> Note that the array returned by the generator is shared between each
+> callback; make sure you copy the bytes/array somewhere else if you want
+> to keep them around.
+>
+> Optionally takes in a provided input `buffer` instead of a `chunkSize`,
+> allowing you to re-use the buffer between invocations.
+
+```scala
+object chunks
+```
+
+```scala
+def apply(p: ReadablePath, chunkSize: Int): geny.Generator[(Array[Byte], Int)] = ...
+```
+
+```scala
+def apply(p: ReadablePath, buffer: Array[Byte]): geny.Generator[(Array[Byte], Int)] = ...
+```
+
+> Reads the given [[os.Path]] or other [[os.Source]] as a string
+> and splits it into lines; defaults to reading as UTF-8, which you
+> can override by specifying a `charSet`.
+
+```scala
+object lines extends Function1[ReadablePath, IndexedSeq[String]]
+```
+
+```scala
+def apply(src: ReadablePath): IndexedSeq[String] = ...
+```
+
+```scala
+def apply(arg: ReadablePath, charSet: Codec): IndexedSeq[String] = ...
+```
+
+> Identical to [[os.read.lines]], but streams the results back to you
+> in a [[os.Generator]] rather than accumulating them in memory. Useful
+> if the file is large.
+
+```scala
+object stream extends Function1[ReadablePath, geny.Generator[String]]
+```
+
+```scala
+def apply(arg: ReadablePath) = ...
+```
+
+```scala
+def apply(arg: ReadablePath, charSet: Codec) = ...
+```
+
+#### `ResourcePath.scala`
+
+```scala
+object ResourcePath
+```
+
+```scala
+def resource(resRoot: ResourceRoot) = ...
+```
+
+> Represents path to a resource on the java classpath.
+>
+> Classloaders are tricky: http://stackoverflow.com/questions/12292926
+
+```scala
+class ResourcePath private[os] (val resRoot: ResourceRoot, segments0: Array[String])
+```
+
+```scala
+def getInputStream = ...
+```
+
+```scala
+def toSource = ...
+```
+
+```scala
+val segments: IndexedSeq[String] = ...
+```
+
+```scala
+type ThisType = ...
+```
+
+```scala
+def lastOpt = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+def relativeTo(base: ResourcePath) = ...
+```
+
+```scala
+def startsWith(target: ResourcePath) = ...
+```
+
+> Thrown when you try to read from a resource that doesn't exist.
+> @param path
+
+```scala
+case class ResourceNotFoundException(path: ResourcePath) extends Exception(path.toString)
+```
+
+> Represents a possible root where classpath resources can be loaded from;
+> either a [[ResourceRoot.ClassLoader]] or a [[ResourceRoot.Class]]. Resources
+> loaded from classloaders are always loaded via their absolute path, while
+> resources loaded via classes are always loaded relatively.
+
+```scala
+sealed trait ResourceRoot
+```
+
+```scala
+def getResourceAsStream(s: String): InputStream
+```
+
+```scala
+def errorName: String
+```
+
+```scala
+object ResourceRoot
+```
+
+```scala
+implicit def classResourceRoot(cls: java.lang.Class[_]): ResourceRoot = ...
+```
+
+```scala
+case class Class(cls: java.lang.Class[_]) extends ResourceRoot
+```
+
+```scala
+def getResourceAsStream(s: String) = ...
+```
+
+```scala
+def errorName = ...
+```
+
+```scala
+implicit def classLoaderResourceRoot(cl: java.lang.ClassLoader): ResourceRoot = ...
+```
+
+```scala
+case class ClassLoader(cl: java.lang.ClassLoader) extends ResourceRoot
+```
+
+```scala
+def getResourceAsStream(s: String) = ...
+```
+
+```scala
+def errorName = ...
+```
+
+#### `Source.scala`
+
+> A source of bytes; must provide either an [[InputStream]] or a
+> [[SeekableByteChannel]] to read from. Can be constructed implicitly from
+> strings, byte arrays, inputstreams, channels or file paths
+
+```scala
+trait Source extends geny.Writable
+```
+
+```scala
+override def httpContentType = ...
+```
+
+```scala
+def getHandle(): Either[geny.Writable, SeekableByteChannel]
+```
+
+```scala
+def writeBytesTo(out: java.io.OutputStream) = ...
+```
+
+```scala
+def writeBytesTo(out: WritableByteChannel) = ...
+```
+
+```scala
+object Source extends WritableLowPri
+```
+
+```scala
+implicit class ChannelSource(cn: SeekableByteChannel) extends Source
+```
+
+```scala
+def getHandle() = ...
+```
+
+```scala
+implicit class WritableSource[T](s: T)(implicit f: T => geny.Writable) extends Source
+```
+
+```scala
+val writable = ...
+```
+
+```scala
+def getHandle() = ...
+```
+
+```scala
+trait WritableLowPri
+```
+
+```scala
+implicit def WritableGenerator[T](a: geny.Generator[T])(implicit
+      f: T => geny.Writable
+  ): Source = ...
+```
+
+```scala
+implicit def WritableTraversable[M[_], T](a: M[T])(implicit
+      f: T => geny.Writable,
+      g: M[T] => TraversableOnce[T]
+  ): Source = ...
+```
+
+> A source which is guaranteeds to provide a [[SeekableByteChannel]]
+
+```scala
+trait SeekableSource extends Source
+```
+
+```scala
+def getHandle(): Right[geny.Writable, SeekableByteChannel]
+```
+
+```scala
+def getChannel() = ...
+```
+
+```scala
+object SeekableSource
+```
+
+```scala
+implicit class ChannelSource(cn: SeekableByteChannel) extends SeekableSource
+```
+
+```scala
+def getHandle() = ...
+```
+
+#### `StatOps.scala`
+
+> Checks whether the given path is a symbolic link
+>
+> Returns `false` if the path does not exist
+
+```scala
+object isLink extends Function1[Path, Boolean]
+```
+
+```scala
+def apply(p: Path): Boolean = ...
+```
+
+> Checks whether the given path is a regular file
+>
+> Returns `false` if the path does not exist
+
+```scala
+object isFile extends Function1[Path, Boolean]
+```
+
+```scala
+def apply(p: Path): Boolean = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): Boolean = ...
+```
+
+> Checks whether the given path is a directory
+>
+> Returns `false` if the path does not exist
+
+```scala
+object isDir extends Function1[Path, Boolean]
+```
+
+```scala
+def apply(p: Path): Boolean = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): Boolean = ...
+```
+
+> Gets the size of the given file or folder
+>
+> Throws an exception if the file or folder does not exist
+>
+> When called on folders, returns the size of the folder metadata
+> (i.e. the list of children names), and not the size of the folder's
+> recursive contents. Use [[os.walk]] if you want to sum up the total
+> size of a directory tree.
+
+```scala
+object size extends Function1[Path, Long]
+```
+
+```scala
+def apply(p: Path): Long = ...
+```
+
+> Gets the mtime of the given file or directory
+
+```scala
+object mtime extends Function1[Path, Long]
+```
+
+```scala
+def apply(p: Path): Long = ...
+```
+
+```scala
+def apply(p: Path, followLinks: Boolean = true): Long = ...
+```
+
+> Sets the mtime of the given file.
+>
+> Note that this always follows links to set the mtime of the referred-to file.
+> Unfortunately there is no Java API to set the mtime of the link itself:
+>
+> https://stackoverflow.com/questions/17308363/symlink-lastmodifiedtime-in-java-1-7
+
+```scala
+object set
+```
+
+```scala
+def apply(p: Path, millis: Long) = ...
+```
+
+> Reads in the basic filesystem metadata for the given file. By default follows
+> symbolic links to read the metadata of whatever the link is pointing at; set
+> `followLinks = false` to disable that and instead read the metadata of the
+> symbolic link itself.
+>
+> Throws an exception if the file or folder does not exist
+
+```scala
+object stat extends Function1[os.Path, os.StatInfo]
+```
+
+```scala
+def apply(p: os.Path): os.StatInfo = ...
+```
+
+```scala
+def apply(p: os.Path, followLinks: Boolean = true): os.StatInfo = ...
+```
+
+> Reads POSIX metadata for the given file: ownership and permissions data
+
+```scala
+object posix
+```
+
+```scala
+def apply(p: os.Path): os.PosixStatInfo = ...
+```
+
+```scala
+def apply(p: os.Path, followLinks: Boolean = true): os.PosixStatInfo = ...
+```
+
+#### `SubProcess.scala`
+
+> Parent type for single processes and process pipelines.
+
+```scala
+sealed trait ProcessLike extends java.lang.AutoCloseable
+```
+
+> The exit code of this [[ProcessLike]]. Conventionally, 0 exit code represents a
+> successful termination, and non-zero exit code indicates a failure.
+>
+> Throws an exception if the subprocess has not terminated
+
+```scala
+def exitCode(): Int
+```
+
+> Returns `true` if the [[ProcessLike]] is still running and has not terminated
+
+```scala
+def isAlive(): Boolean
+```
+
+> Attempt to destroy the [[ProcessLike]] (gently), via the underlying JVM APIs
+
+```scala
+def destroy(): Unit
+```
+
+> Force-destroys the [[ProcessLike]], via the underlying JVM APIs
+
+```scala
+def destroyForcibly(): Unit
+```
+
+> Alias for [[destroy]], implemented for [[java.lang.AutoCloseable]]
+
+```scala
+override def close(): Unit
+```
+
+> Wait up to `millis` for the [[ProcessLike]] to terminate, by default waits
+> indefinitely. Returns `true` if the [[ProcessLike]] has terminated by the time
+> this method returns.
+
+```scala
+def waitFor(timeout: Long = -1): Boolean
+```
+
+> Wait up to `millis` for the [[ProcessLike]] to terminate and all stdout and stderr
+> from the subprocess to be handled. By default waits indefinitely; if a time
+> limit is given, explicitly destroys the [[ProcessLike]] if it has not completed by
+> the time the timeout has occurred
+
+```scala
+def join(timeout: Long = -1): Boolean
+```
+
+> Represents a spawn subprocess that has started and may or may not have
+> completed.
+
+```scala
+class SubProcess(
+    val wrapped: java.lang.Process,
+    val inputPumperThread: Option[Thread],
+    val outputPumperThread: Option[Thread],
+    val errorPumperThread: Option[Thread]
+) extends ProcessLike
+```
+
+```scala
+val stdin: SubProcess.InputStream = ...
+```
+
+```scala
+val stdout: SubProcess.OutputStream = ...
+```
+
+```scala
+val stderr: SubProcess.OutputStream = ...
+```
+
+> The subprocess' exit code. Conventionally, 0 exit code represents a
+> successful termination, and non-zero exit code indicates a failure.
+>
+> Throws an exception if the subprocess has not terminated
+
+```scala
+def exitCode(): Int = ...
+```
+
+> Returns `true` if the subprocess is still running and has not terminated
+
+```scala
+def isAlive(): Boolean = ...
+```
+
+> Attempt to destroy the subprocess (gently), via the underlying JVM APIs
+
+```scala
+def destroy(): Unit = ...
+```
+
+> Force-destroys the subprocess, via the underlying JVM APIs
+
+```scala
+def destroyForcibly(): Unit = ...
+```
+
+> Alias for [[destroy]]
+
+```scala
+def close() = ...
+```
+
+> Wait up to `millis` for the subprocess to terminate, by default waits
+> indefinitely. Returns `true` if the subprocess has terminated by the time
+> this method returns.
+
+```scala
+def waitFor(timeout: Long = -1): Boolean = ...
+```
+
+> Wait up to `millis` for the subprocess to terminate and all stdout and stderr
+> from the subprocess to be handled. By default waits indefinitely; if a time
+> limit is given, explicitly destroys the subprocess if it has not completed by
+> the time the timeout has occurred
+
+```scala
+def join(timeout: Long = -1): Boolean = ...
+```
+
+```scala
+object SubProcess
+```
+
+> A [[BufferedWriter]] with the underlying [[java.io.OutputStream]] exposed
+>
+> Note that all writes that occur through this class are thread-safe and
+> synchronized. If you wish to perform writes without the synchronization
+> overhead, you can use the underlying [[wrapped]] stream directly
+
+```scala
+class InputStream(val wrapped: java.io.OutputStream)
+```
+
+```scala
+val data = ...
+```
+
+```scala
+val buffered = ...
+```
+
+```scala
+def write(b: Int) = ...
+```
+
+```scala
+override def write(b: Array[Byte]): Unit = ...
+```
+
+```scala
+override def write(b: Array[Byte], off: Int, len: Int): Unit = ...
+```
+
+```scala
+def writeBoolean(v: Boolean) = ...
+```
+
+```scala
+def writeByte(v: Int) = ...
+```
+
+```scala
+def writeShort(v: Int) = ...
+```
+
+```scala
+def writeChar(v: Int) = ...
+```
+
+```scala
+def writeInt(v: Int) = ...
+```
+
+```scala
+def writeLong(v: Long) = ...
+```
+
+```scala
+def writeFloat(v: Float) = ...
+```
+
+```scala
+def writeDouble(v: Double) = ...
+```
+
+```scala
+def writeBytes(s: String) = ...
+```
+
+```scala
+def writeChars(s: String) = ...
+```
+
+```scala
+def writeUTF(s: String) = ...
+```
+
+```scala
+def writeLine(s: String) = ...
+```
+
+```scala
+def write(s: String) = ...
+```
+
+```scala
+def write(s: Array[Char]) = ...
+```
+
+```scala
+override def flush() = ...
+```
+
+```scala
+override def close() = ...
+```
+
+> A combination [[BufferedReader]] and [[java.io.InputStream]], this allows
+> you to read both bytes and lines, without worrying about the buffer used
+> for reading lines messing up your reading of bytes.
+>
+> Note that all reads that occur through this class are thread-safe and
+> synchronized. If you wish to perform writes without the synchronization
+> overhead, you can use the underlying [[wrapped]] stream directly
+
+```scala
+class OutputStream(val wrapped: java.io.InputStream)
+```
+
+```scala
+val data = ...
+```
+
+```scala
+val buffered = ...
+```
+
+```scala
+def read() = ...
+```
+
+```scala
+override def read(b: Array[Byte]) = ...
+```
+
+```scala
+override def read(b: Array[Byte], off: Int, len: Int) = ...
+```
+
+```scala
+def readFully(b: Array[Byte]) = ...
+```
+
+```scala
+def readFully(b: Array[Byte], off: Int, len: Int) = ...
+```
+
+```scala
+def skipBytes(n: Int) = ...
+```
+
+```scala
+def readBoolean() = ...
+```
+
+```scala
+def readByte() = ...
+```
+
+```scala
+def readUnsignedByte() = ...
+```
+
+```scala
+def readShort() = ...
+```
+
+```scala
+def readUnsignedShort() = ...
+```
+
+```scala
+def readChar() = ...
+```
+
+```scala
+def readInt() = ...
+```
+
+```scala
+def readLong() = ...
+```
+
+```scala
+def readFloat() = ...
+```
+
+```scala
+def readDouble() = ...
+```
+
+```scala
+def readUTF() = ...
+```
+
+```scala
+def readLine() = ...
+```
+
+```scala
+def bytes: Array[Byte] = ...
+```
+
+```scala
+override def close() = ...
+```
+
+```scala
+class ProcessPipeline(
+    val processes: Seq[SubProcess],
+    pipefail: Boolean,
+    brokenPipeQueue: Option[LinkedBlockingQueue[Int]] // to emulate pipeline behavior in jvm < 9
+) extends ProcessLike
+```
+
+> String representation of the pipeline.
+
+```scala
+def commandString = ...
+```
+
+> The exit code of this [[ProcessPipeline]]. Conventionally, 0 exit code represents a
+> successful termination, and non-zero exit code indicates a failure. Throws an exception
+> if the subprocess has not terminated.
+>
+> If pipefail is set, the exit code is the first non-zero exit code of the pipeline. If no
+> process in the pipeline has a non-zero exit code, the exit code is 0.
+
+```scala
+override def exitCode(): Int = ...
+```
+
+> Returns `true` if the [[ProcessPipeline]] is still running and has not terminated.
+> Any process in the pipeline can be alive for the pipeline to be alive.
+
+```scala
+override def isAlive(): Boolean = ...
+```
+
+> Attempt to destroy the [[ProcessPipeline]] (gently), via the underlying JVM APIs.
+> All processes in the pipeline are destroyed.
+
+```scala
+override def destroy(): Unit = ...
+```
+
+> Force-destroys the [[ProcessPipeline]], via the underlying JVM APIs.
+> All processes in the pipeline are force-destroyed.
+
+```scala
+override def destroyForcibly(): Unit = ...
+```
+
+> Alias for [[destroy]], implemented for [[java.lang.AutoCloseable]].
+
+```scala
+override def close(): Unit = ...
+```
+
+> Wait up to `millis` for the [[ProcessPipeline]] to terminate, by default waits
+> indefinitely. Returns `true` if the [[ProcessPipeline]] has terminated by the time
+> this method returns.
+>
+> Waits for each process one by one, while aggregating the total time waited. If
+> [[timeout]] has passed before all processes have terminated, returns `false`.
+
+```scala
+override def waitFor(timeout: Long = -1): Boolean = ...
+```
+
+> Wait up to `millis` for the [[ProcessPipeline]] to terminate all the processes
+> in pipeline. By default waits indefinitely; if a time limit is given, explicitly
+> destroys each process if it has not completed by the time the timeout has occurred.
+
+```scala
+override def join(timeout: Long = -1): Boolean = ...
+```
+
+> Represents the configuration of a SubProcess's input stream. Can either be
+> [[os.Inherit]], [[os.Pipe]], [[os.Path]] or a [[os.Source]]
+
+```scala
+trait ProcessInput
+```
+
+```scala
+def redirectFrom: ProcessBuilder.Redirect
+```
+
+```scala
+def processInput(stdin: => SubProcess.InputStream): Option[Runnable]
+```
+
+```scala
+object ProcessInput
+```
+
+```scala
+implicit def makeSourceInput[T](r: T)(implicit f: T => Source): ProcessInput = ...
+```
+
+```scala
+implicit def makePathRedirect(p: Path): ProcessInput = ...
+```
+
+```scala
+case class SourceInput(r: Source) extends ProcessInput
+```
+
+```scala
+def redirectFrom = ...
+```
+
+```scala
+def processInput(stdin: => SubProcess.InputStream): Option[Runnable] = ...
+```
+
+> Represents the configuration of a SubProcess's output or error stream. Can
+> either be [[os.Inherit]], [[os.Pipe]], [[os.Path]] or a [[os.ProcessOutput]]
+
+```scala
+trait ProcessOutput
+```
+
+```scala
+def redirectTo: ProcessBuilder.Redirect
+```
+
+```scala
+def processOutput(out: => SubProcess.OutputStream): Option[Runnable]
+```
+
+```scala
+object ProcessOutput
+```
+
+```scala
+implicit def makePathRedirect(p: Path): ProcessOutput = ...
+```
+
+```scala
+def apply(f: (Array[Byte], Int) => Unit) = ...
+```
+
+```scala
+case class ReadBytes(f: (Array[Byte], Int) => Unit)
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def processOutput(out: => SubProcess.OutputStream) = ...
+```
+
+```scala
+case class Readlines(f: String => Unit)
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def processOutput(out: => SubProcess.OutputStream) = ...
+```
+
+> Inherit the input/output stream from the current process
+
+```scala
+object Inherit extends ProcessInput with ProcessOutput
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def redirectFrom = ...
+```
+
+```scala
+def processInput(stdin: => SubProcess.InputStream) = ...
+```
+
+```scala
+def processOutput(stdin: => SubProcess.OutputStream) = ...
+```
+
+> Pipe the input/output stream to the current process to be used via
+> `java.lang.Process#{getInputStream,getOutputStream,getErrorStream}`
+
+```scala
+object Pipe extends ProcessInput with ProcessOutput
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def redirectFrom = ...
+```
+
+```scala
+def processInput(stdin: => SubProcess.InputStream) = ...
+```
+
+```scala
+def processOutput(stdin: => SubProcess.OutputStream) = ...
+```
+
+```scala
+case class PathRedirect(p: Path) extends ProcessInput with ProcessOutput
+```
+
+```scala
+def redirectFrom = ...
+```
+
+```scala
+def processInput(stdin: => SubProcess.InputStream) = ...
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def processOutput(out: => SubProcess.OutputStream) = ...
+```
+
+```scala
+case class PathAppendRedirect(p: Path) extends ProcessOutput
+```
+
+```scala
+def redirectTo = ...
+```
+
+```scala
+def processOutput(out: => SubProcess.OutputStream) = ...
+```
+
+#### `TempOps.scala`
+
+> Alias for `java.nio.file.Files.createTempFile` and
+> `java.io.File.deleteOnExit`. Pass in `deleteOnExit = false` if you want
+> the temp file to stick around.
+
+```scala
+object temp
+```
+
+> Creates a temporary file. You can optionally provide a `dir` to specify where
+> this file lives, file-`prefix` and file-`suffix` to customize what it looks
+> like, and a [[PermSet]] to customize its filesystem permissions.
+>
+> Passing in a [[os.Source]] will initialize the contents of that file to
+> the provided data; otherwise it is created empty.
+>
+> By default, temporary files are deleted on JVM exit. You can disable that
+> behavior by setting `deleteOnExit = false`
+
+```scala
+def apply(
+      contents: Source = null,
+      dir: Path = null,
+      prefix: String = null,
+      suffix: String = null,
+      deleteOnExit: Boolean = true,
+      perms: PermSet = null
+  ): Path = ...
+```
+
+> Creates a temporary directory. You can optionally provide a `dir` to specify
+> where this file lives, a `prefix` to customize what it looks like, and a
+> [[PermSet]] to customize its filesystem permissions.
+>
+> By default, temporary directories are deleted on JVM exit. You can disable that
+> behavior by setting `deleteOnExit = false`
+
+```scala
+def dir(
+      dir: Path = null,
+      prefix: String = null,
+      deleteOnExit: Boolean = true,
+      perms: PermSet = null
+  ): Path = ...
+```
+
+#### `package.scala`
+
+```scala
+package object os
+```
+
+```scala
+type Generator[+T] = ...
+```
+
+```scala
+val Generator = ...
+```
+
+```scala
+implicit def GlobSyntax(s: StringContext): GlobInterpolator = ...
+```
+
+> The root of the filesystem
+
+```scala
+val root: Path = ...
+```
+
+```scala
+def root(root: String, fileSystem: FileSystem = FileSystems.getDefault()): Path = ...
+```
+
+```scala
+def resource(implicit resRoot: ResourceRoot = Thread.currentThread().getContextClassLoader) = ...
+```
+
+> The user's home directory
+
+```scala
+def home: Path = ...
+```
+
+> The current working directory for this process.
+
+```scala
+val pwd: Path = ...
+```
+
+```scala
+val up: RelPath = ...
+```
+
+```scala
+val rel: RelPath = ...
+```
+
+```scala
+val sub: SubPath = ...
+```
+
+> Extractor to let you easily pattern match on [[os.Path]]s. Lets you do
+>
+> {{{
+> @ val base/segment/filename = pwd
+> base: Path = Path(Vector("Users", "haoyi", "Dropbox (Personal)"))
+> segment: String = "Workspace"
+> filename: String = "Ammonite"
+> }}}
+>
+> To break apart a path and extract various pieces of it.
+
+```scala
+object /
+```
+
+```scala
+def unapply(p: Path): Option[(Path, String)] = ...
+```
+

--- a/docs/requests-0.9.2.md
+++ b/docs/requests-0.9.2.md
@@ -1,0 +1,899 @@
+# requests-scala 0.9.2 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `150` non-private declaration signatures from `7` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::requests:0.9.2`
+- Upstream docs: https://com-lihaoyi.github.io/requests-scala/
+- Source artifacts included:
+  - `com.lihaoyi:requests_3:0.9.2`
+
+## Common imports
+
+```scala
+import requests.*
+```
+
+## Usage notes
+
+Synchronous HTTP client used by the relay for upstream requests. APIs include one-shot methods, sessions, streaming, multipart, proxy, and response wrappers.
+
+```scala
+val session = requests.Session(
+  headers = Map("User-Agent" -> "mif/0.3.0", "Accept" -> "*/*"),
+  readTimeout = 120000,
+  connectTimeout = 30000
+)
+
+val response: requests.Response =
+  session.get("https://repo1.maven.org/maven2/com/example/app/maven-metadata.xml")
+
+if response.statusCode == 200 then
+  val bytes: Array[Byte] = response.bytes
+  println(response.text())
+
+val tmp = os.temp(prefix = "download")
+session.get
+  .stream(
+    "https://example.com/file.jar",
+    onHeadersReceived = headers => println(headers.statusCode)
+  )
+  .readBytesThrough(input => os.write.over(tmp, input))
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:requests_3:0.9.2`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/requests_3/0.9.2/requests_3-0.9.2-sources.jar
+
+#### `requests/Exceptions.scala`
+
+```scala
+class RequestsException(
+    val message: String,
+    val cause: Option[Throwable] = None,
+) extends Exception(message, cause.getOrElse(null))
+```
+
+```scala
+class TimeoutException(
+    val url: String,
+    val readTimeout: Int,
+    val connectTimeout: Int,
+) extends RequestsException(
+      s"Request to $url timed out. (readTimeout: $readTimeout, connectTimout: $connectTimeout)",
+    )
+```
+
+```scala
+class UnknownHostException(val url: String, val host: String)
+```
+
+```scala
+class InvalidCertException(val url: String, cause: Throwable)
+```
+
+```scala
+class RequestFailedException(val response: Response)
+```
+
+#### `requests/Model.scala`
+
+> Mechanisms for compressing the upload stream; supports Gzip and Deflate by default
+
+```scala
+trait Compress
+```
+
+```scala
+def headers: Seq[(String, String)]
+```
+
+```scala
+def wrap(x: OutputStream): OutputStream
+```
+
+```scala
+object Compress
+```
+
+```scala
+object Gzip extends Compress
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+def wrap(x: OutputStream) = ...
+```
+
+```scala
+object Deflate extends Compress
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+def wrap(x: OutputStream) = ...
+```
+
+```scala
+object None extends Compress
+```
+
+```scala
+def headers = ...
+```
+
+```scala
+def wrap(x: OutputStream) = ...
+```
+
+> The equivalent of configuring a [[Requester.apply]] or [[Requester.stream]] call, but without
+> invoking it. Useful if you want to further customize it and make the call later via the overloads
+> of `apply`/`stream` that take a [[Request]].
+
+```scala
+case class Request(
+    url: String,
+    auth: RequestAuth = RequestAuth.Empty,
+    params: Iterable[(String, String)] = Nil,
+    headers: Iterable[(String, String)] = Nil,
+    readTimeout: Int = 0,
+    connectTimeout: Int = 0,
+    proxy: (String, Int) = null,
+    cert: Cert = null,
+    sslContext: SSLContext = null,
+    cookies: Map[String, HttpCookie] = Map(),
+    cookieValues: Map[String, String] = Map(),
+    maxRedirects: Int = 5,
+    verifySslCerts: Boolean = true,
+    autoDecompress: Boolean = true,
+    compress: Compress = Compress.None,
+    keepAlive: Boolean = true,
+    check: Boolean = true,
+)
+```
+
+> Represents the different things you can upload in the body of a HTTP request. By default, allows
+> form-encoded key-value pairs, arrays of bytes, strings, files, and InputStreams. These types can
+> be passed directly to the `data` parameter of [[Requester.apply]] and will be wrapped
+> automatically by the implicit constructors.
+
+```scala
+trait RequestBlob
+```
+
+```scala
+def headers: Seq[(String, String)] = ...
+```
+
+```scala
+def write(out: java.io.OutputStream): Unit
+```
+
+```scala
+object RequestBlob
+```
+
+```scala
+object EmptyRequestBlob extends RequestBlob
+```
+
+```scala
+def write(out: java.io.OutputStream): Unit = ...
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+implicit class ByteSourceRequestBlob[T](x: T)(implicit f: T => geny.Writable)
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+def write(out: java.io.OutputStream) = ...
+```
+
+```scala
+implicit class FileRequestBlob(x: java.io.File) extends RequestBlob
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+def write(out: java.io.OutputStream) = ...
+```
+
+```scala
+implicit class NioFileRequestBlob(x: java.nio.file.Path) extends RequestBlob
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+def write(out: java.io.OutputStream) = ...
+```
+
+```scala
+implicit class FormEncodedRequestBlob(val x: Iterable[(String, String)]) extends RequestBlob
+```
+
+```scala
+val serialized = ...
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+def write(out: java.io.OutputStream) = ...
+```
+
+```scala
+implicit class MultipartFormRequestBlob(val parts: Iterable[MultiItem]) extends RequestBlob
+```
+
+```scala
+val boundary = ...
+```
+
+```scala
+val crlf = ...
+```
+
+```scala
+val pref = ...
+```
+
+```scala
+val ContentDisposition = ...
+```
+
+```scala
+val filenameSnippet = ...
+```
+
+```scala
+val partBytes = ...
+```
+
+```scala
+override def headers = ...
+```
+
+```scala
+def write(out: java.io.OutputStream) = ...
+```
+
+```scala
+case class MultiPart(items: MultiItem*) extends RequestBlob.MultipartFormRequestBlob(items)
+```
+
+```scala
+case class MultiItem(name: String, data: RequestBlob, filename: String = null)
+```
+
+> Wraps the array of bytes returned in the body of a HTTP response
+
+```scala
+class ResponseBlob(val bytes: Array[Byte])
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+def text = ...
+```
+
+```scala
+override def hashCode() = ...
+```
+
+```scala
+override def equals(obj: scala.Any) = ...
+```
+
+> Represents a HTTP response
+>
+> @param url
+> the URL that the original request was made to
+> @param statusCode
+> the status code of the response
+> @param statusMessage
+> a string that describes the status code. This is not the reason phrase sent by the server, but
+> a string describing [[statusCode]], as hardcoded in this library
+> @param headers
+> the raw headers the server sent back with the response
+> @param data
+> the response body; may contain HTML, JSON, or binary or textual data
+> @param history
+> the response of any redirects that were performed before arriving at the current response
+
+```scala
+case class Response(
+    url: String,
+    statusCode: Int,
+    @deprecated("Value is inferred from `statusCode`", "0.9.0")
+    statusMessage: String,
+    data: geny.Bytes,
+    headers: Map[String, Seq[String]],
+    history: Option[Response],
+) extends geny.ByteData
+    with geny.Readable
+```
+
+```scala
+def bytes = ...
+```
+
+```scala
+  @deprecated("Use `.bytes`")
+def contents = ...
+```
+
+> Returns the cookies set by this response, and by any redirects that lead up to it
+
+```scala
+val cookies: Map[String, HttpCookie] = ...
+```
+
+```scala
+def contentType = ...
+```
+
+```scala
+def location = ...
+```
+
+```scala
+def is2xx = ...
+```
+
+```scala
+def is3xx = ...
+```
+
+```scala
+def is4xx = ...
+```
+
+```scala
+def is5xx = ...
+```
+
+```scala
+def readBytesThrough[T](f: java.io.InputStream => T): T = ...
+```
+
+```scala
+override def httpContentType: Option[String] = ...
+```
+
+```scala
+override def contentLength: Option[Long] = ...
+```
+
+```scala
+case class StreamHeaders(
+    url: String,
+    statusCode: Int,
+    @deprecated("Value is inferred from `statusCode`", "0.9.0")
+    statusMessage: String,
+    headers: Map[String, Seq[String]],
+    history: Option[Response],
+)
+```
+
+```scala
+def is2xx = ...
+```
+
+```scala
+def is3xx = ...
+```
+
+```scala
+def is4xx = ...
+```
+
+```scala
+def is5xx = ...
+```
+
+> Different ways you can authorize a HTTP request; by default, HTTP Basic auth and Proxy auth are
+> supported
+
+```scala
+trait RequestAuth
+```
+
+```scala
+def header: Option[String]
+```
+
+```scala
+object RequestAuth
+```
+
+```scala
+object Empty extends RequestAuth
+```
+
+```scala
+def header = ...
+```
+
+```scala
+implicit def implicitBasic(x: (String, String)): Basic = ...
+```
+
+```scala
+class Basic(username: String, password: String) extends RequestAuth
+```
+
+```scala
+def header = ...
+```
+
+```scala
+case class Proxy(username: String, password: String) extends RequestAuth
+```
+
+```scala
+def header = ...
+```
+
+```scala
+case class Bearer(token: String) extends RequestAuth
+```
+
+```scala
+def header = ...
+```
+
+```scala
+sealed trait Cert
+```
+
+```scala
+object Cert
+```
+
+```scala
+implicit def implicitP12(path: String): P12 = ...
+```
+
+```scala
+implicit def implicitP12(x: (String, String)): P12 = ...
+```
+
+```scala
+case class P12(p12: String, pwd: Option[String] = None) extends Cert
+```
+
+#### `requests/Requester.scala`
+
+```scala
+trait BaseSession extends AutoCloseable
+```
+
+```scala
+def headers: Map[String, String]
+```
+
+```scala
+def cookies: mutable.Map[String, HttpCookie]
+```
+
+```scala
+def readTimeout: Int
+```
+
+```scala
+def connectTimeout: Int
+```
+
+```scala
+def auth: RequestAuth
+```
+
+```scala
+def proxy: (String, Int)
+```
+
+```scala
+def cert: Cert
+```
+
+```scala
+def sslContext: SSLContext
+```
+
+```scala
+def maxRedirects: Int
+```
+
+```scala
+def persistCookies: Boolean
+```
+
+```scala
+def verifySslCerts: Boolean
+```
+
+```scala
+def autoDecompress: Boolean
+```
+
+```scala
+def compress: Compress
+```
+
+```scala
+def chunkedUpload: Boolean
+```
+
+```scala
+def check: Boolean
+```
+
+```scala
+lazy val get = ...
+```
+
+```scala
+lazy val post = ...
+```
+
+```scala
+lazy val put = ...
+```
+
+```scala
+lazy val delete = ...
+```
+
+```scala
+lazy val head = ...
+```
+
+```scala
+lazy val options = ...
+```
+
+```scala
+lazy val patch = ...
+```
+
+```scala
+def send(method: String) = ...
+```
+
+```scala
+lazy val executor: ExecutorService = ...
+```
+
+```scala
+lazy val sharedHttpClient: HttpClient = ...
+```
+
+> Closes the shared HttpClient and its executor. Call this when you're done
+> with the session to release resources and prevent thread leaks.
+
+```scala
+def close(): Unit = ...
+```
+
+```scala
+object BaseSession
+```
+
+```scala
+val defaultHeaders = ...
+```
+
+```scala
+def buildHttpClient(
+    proxy: (String, Int),
+    cert: Cert,
+    sslContext: SSLContext,
+    verifySslCerts: Boolean,
+    connectTimeout: Int,
+    executor: ExecutorService
+  ): HttpClient = ...
+```
+
+> Closes an HttpClient, using reflection to handle both Java 21+ (which has close())
+> and earlier versions (which require accessing internal selector).
+
+```scala
+def closeHttpClient(httpClient: HttpClient): Unit = ...
+```
+
+```scala
+object Requester
+```
+
+```scala
+val officialHttpMethods = ...
+```
+
+```scala
+case class Requester(verb: String, sess: BaseSession)
+```
+
+> Makes a single HTTP request, and returns a [[Response]] object. Requires all uploaded request
+> `data` to be provided up-front, and aggregates all downloaded response `data` before returning
+> it in the response. If you need streaming access to the upload and download, use the
+> [[Requester.stream]] function instead.
+>
+> @param url
+> The URL to which you want to make this HTTP request
+> @param auth
+> HTTP authentication you want to use with this request; defaults to none
+> @param params
+> URL params to pass to this request, for `GET`s and `DELETE`s
+> @param headers
+> Custom headers to use, in addition to the defaults
+> @param data
+> Body data to pass to this request, for POSTs and PUTs. Can be a Map[String, String] of form
+> data, bulk data as a String or Array[Byte], or MultiPart form data.
+> @param readTimeout
+> How many milliseconds to wait for data to be read before timing out
+> @param connectTimeout
+> How many milliseconds to wait for a connection before timing out
+> @param proxy
+> Host and port of a proxy you want to use
+> @param cert
+> Client certificate configuration
+> @param sslContext
+> Client sslContext configuration
+> @param cookies
+> Custom cookies to send up with this request
+> @param maxRedirects
+> How many redirects to automatically resolve; defaults to 5. You can also set it to 0 to
+> prevent Requests from resolving redirects for you
+> @param verifySslCerts
+> Set this to false to ignore problems with SSL certificates
+> @param check
+> Throw an exception on a 4xx or 5xx response code. Defaults to `true`
+
+```scala
+def apply(
+      url: String,
+      auth: RequestAuth = sess.auth,
+      params: Iterable[(String, String)] = Nil,
+      headers: Iterable[(String, String)] = Nil,
+      data: RequestBlob = RequestBlob.EmptyRequestBlob,
+      readTimeout: Int = sess.readTimeout,
+      connectTimeout: Int = sess.connectTimeout,
+      proxy: (String, Int) = sess.proxy,
+      cert: Cert = sess.cert,
+      sslContext: SSLContext = sess.sslContext,
+      cookies: Map[String, HttpCookie] = Map(),
+      cookieValues: Map[String, String] = Map(),
+      maxRedirects: Int = sess.maxRedirects,
+      verifySslCerts: Boolean = sess.verifySslCerts,
+      autoDecompress: Boolean = sess.autoDecompress,
+      compress: Compress = sess.compress,
+      keepAlive: Boolean = true,
+      check: Boolean = sess.check,
+      chunkedUpload: Boolean = sess.chunkedUpload,
+  ): Response = ...
+```
+
+> Performs a streaming HTTP request. Most of the parameters are the same as [[apply]], except
+> that the `data` parameter is missing, and no [[Response]] object is returned. Instead, the
+> caller gets access via three callbacks (described below). This provides a lower-level API than
+> [[Requester.apply]], allowing the caller fine-grained access to the upload/download streams so
+> they can direct them where-ever necessary without first aggregating all the data into memory.
+>
+> @param onHeadersReceived
+> the second callback to be called, this provides access to the response's status code, status
+> message, headers, and any previous re-direct responses.
+>
+> @return
+> a `Writable` that can be used to write the output data to any destination
+
+```scala
+def stream(
+      url: String,
+      auth: RequestAuth = sess.auth,
+      params: Iterable[(String, String)] = Nil,
+      blobHeaders: Iterable[(String, String)] = Nil,
+      headers: Iterable[(String, String)] = Nil,
+      data: RequestBlob = RequestBlob.EmptyRequestBlob,
+      readTimeout: Int = sess.readTimeout,
+      connectTimeout: Int = sess.connectTimeout,
+      proxy: (String, Int) = sess.proxy,
+      cert: Cert = sess.cert,
+      sslContext: SSLContext = sess.sslContext,
+      cookies: Map[String, HttpCookie] = Map(),
+      cookieValues: Map[String, String] = Map(),
+      maxRedirects: Int = sess.maxRedirects,
+      verifySslCerts: Boolean = sess.verifySslCerts,
+      autoDecompress: Boolean = sess.autoDecompress,
+      compress: Compress = sess.compress,
+      keepAlive: Boolean = true,
+      check: Boolean = true,
+      chunkedUpload: Boolean = false,
+      redirectedFrom: Option[Response] = None,
+      onHeadersReceived: StreamHeaders => Unit = null,
+  ): geny.Readable = ...
+```
+
+> Overload of [[Requester.apply]] that takes a [[Request]] object as configuration
+
+```scala
+def apply(r: Request, data: RequestBlob, chunkedUpload: Boolean): Response = ...
+```
+
+> Overload of [[Requester.stream]] that takes a [[Request]] object as configuration
+
+```scala
+def stream(
+      r: Request,
+      data: RequestBlob,
+      chunkedUpload: Boolean,
+      onHeadersReceived: StreamHeaders => Unit,
+  ): geny.Writable = ...
+```
+
+#### `requests/Session.scala`
+
+> A long-lived session; this can be used to automatically persist cookies from one request to the
+> next, or to set default configuration that will be shared between requests. These configuration
+> flags can all be over-ridden by the parameters on [[Requester.apply]] or [[Requester.stream]]
+>
+> @param auth
+> HTTP authentication you want to use with this request; defaults to none
+> @param headers
+> Custom headers to use, in addition to the defaults
+> @param readTimeout
+> How long to wait for data to be read before timing out
+> @param connectTimeout
+> How long to wait for a connection before timing out
+> @param proxy
+> Host and port of a proxy you want to use
+> @param cookies
+> Custom cookies to send up with this request
+> @param maxRedirects
+> How many redirects to automatically resolve; defaults to 5. You can also set it to 0 to prevent
+> Requests from resolving redirects for you
+> @param verifySslCerts
+> Set this to false to ignore problems with SSL certificates
+
+```scala
+case class Session(
+    headers: Map[String, String] = BaseSession.defaultHeaders,
+    cookieValues: Map[String, String] = Map(),
+    cookies: mutable.Map[String, HttpCookie] = mutable.LinkedHashMap.empty[String, HttpCookie],
+    auth: RequestAuth = RequestAuth.Empty,
+    proxy: (String, Int) = null,
+    cert: Cert = null,
+    sslContext: SSLContext = null,
+    persistCookies: Boolean = true,
+    maxRedirects: Int = 5,
+    readTimeout: Int = 10 * 1000,
+    connectTimeout: Int = 10 * 1000,
+    verifySslCerts: Boolean = true,
+    autoDecompress: Boolean = true,
+    compress: Compress = Compress.None,
+    chunkedUpload: Boolean = false,
+    check: Boolean = true,
+) extends BaseSession
+```
+
+#### `requests/StatusMessages.scala`
+
+```scala
+object StatusMessages
+```
+
+```scala
+val byStatusCode: Map[Int, String] = ...
+```
+
+#### `requests/Util.scala`
+
+```scala
+object Util
+```
+
+```scala
+def transferTo(
+      is: InputStream,
+      os: OutputStream,
+      bufferSize: Int = 8 * 1024,
+  ) = ...
+```
+
+```scala
+def urlEncode(x: Iterable[(String, String)]) = ...
+```
+
+#### `requests/package.scala`
+
+```scala
+package object requests extends _root_.requests.BaseSession
+```
+
+```scala
+def cookies = ...
+```
+
+```scala
+val headers = ...
+```
+
+```scala
+def auth = ...
+```
+
+```scala
+def proxy = ...
+```
+
+```scala
+def cert: Cert = ...
+```
+
+```scala
+def sslContext: SSLContext = ...
+```
+
+```scala
+def maxRedirects: Int = ...
+```
+
+```scala
+def persistCookies = ...
+```
+
+```scala
+def readTimeout: Int = ...
+```
+
+```scala
+def connectTimeout: Int = ...
+```
+
+```scala
+def verifySslCerts: Boolean = ...
+```
+
+```scala
+def autoDecompress: Boolean = ...
+```
+
+```scala
+def compress: Compress = ...
+```
+
+```scala
+def chunkedUpload: Boolean = ...
+```
+
+```scala
+def check: Boolean = ...
+```
+

--- a/docs/scalasql-0.3.1.md
+++ b/docs/scalasql-0.3.1.md
@@ -1,0 +1,7637 @@
+# ScalaSql 0.3.1 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `1367` non-private declaration signatures from `80` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::scalasql:0.3.1`
+- Upstream docs: https://com-lihaoyi.github.io/scalasql/
+- Source artifacts included:
+  - `com.lihaoyi:scalasql_3:0.3.1`
+  - `com.lihaoyi:scalasql-core_3:0.3.1`
+  - `com.lihaoyi:scalasql-query_3:0.3.1`
+  - `com.lihaoyi:scalasql-operations_3:0.3.1`
+
+## Common imports
+
+```scala
+import scalasql.*
+import scalasql.SqliteDialect.*
+import scalasql.core.SqlStr.SqlStringSyntax
+```
+
+## Usage notes
+
+Type-safe SQL query/update DSL. This doc includes the direct dialect façade plus core/query/operations modules where `DbClient`, `Table`, `Column`, `Expr`, `SqlStr`, and query operations are defined.
+
+```scala
+import scalasql.*
+import scalasql.SqliteDialect.*
+import scalasql.core.SqlStr.SqlStringSyntax
+
+case class CachedArtifact[T[_]](
+    mavenPath: T[String],
+    sha256: T[String],
+    size: T[Long]
+)
+object CachedArtifact extends Table[CachedArtifact]:
+  override def tableName = "cached_artifacts"
+
+val dataSource = new org.sqlite.SQLiteDataSource()
+dataSource.setUrl("jdbc:sqlite:/tmp/repository.sqlite")
+
+val dbClient = new scalasql.DbClient.DataSource(
+  dataSource,
+  config = new scalasql.Config {}
+)
+
+dbClient.transaction: db =>
+  db.updateRaw("CREATE TABLE IF NOT EXISTS cached_artifacts (maven_path TEXT PRIMARY KEY, sha256 TEXT, size INTEGER)")
+  db.updateSql(sql"""
+    INSERT INTO cached_artifacts (maven_path, sha256, size)
+    VALUES (${"com/example/app/1.0.0/app.pom"}, ${"sha256-..."}, ${123L})
+  """)
+  db.run(CachedArtifact.select.sortBy(_.mavenPath).asc)
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:scalasql_3:0.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/scalasql_3/0.3.1/scalasql_3-0.3.1-sources.jar
+
+#### `dialects/CompoundSelectRendererForceLimit.scala`
+
+```scala
+object CompoundSelectRendererForceLimit
+```
+
+```scala
+def limitToSqlStr(limit: Option[Int], offset: Option[Int])(implicit tm: TypeMapper[Int]) = ...
+```
+
+#### `dialects/DbApiQueryOps.scala`
+
+```scala
+class DbApiQueryOps(dialect: DialectTypeMappers)
+```
+
+> Creates a SQL `VALUES` clause
+
+```scala
+def values[Q, R](ts: Seq[R])(implicit qr: Queryable.Row[Q, R]): Values[Q, R] = ...
+```
+
+> Generates a SQL `WITH` common table expression clause
+
+```scala
+def withCte[Q, Q2, R, R2](
+      lhs: Select[Q, R]
+  )(block: Select[Q, R] => Select[Q2, R2])(implicit qr: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+#### `dialects/Dialect.scala`
+
+> Base type for all SQL dialects. A Dialect proides extension methods, extension operators,
+> and custom implementations of various query classes that may differ between databases
+
+```scala
+trait Dialect extends DialectTypeMappers
+```
+
+```scala
+implicit val dialectSelf: Dialect = ...
+```
+
+```scala
+implicit def StringType: TypeMapper[String] = ...
+```
+
+```scala
+class StringType extends TypeMapper[String]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: String) = ...
+```
+
+```scala
+implicit def ByteType: TypeMapper[Byte] = ...
+```
+
+```scala
+class ByteType extends TypeMapper[Byte]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Byte) = ...
+```
+
+```scala
+implicit def ShortType: TypeMapper[Short] = ...
+```
+
+```scala
+class ShortType extends TypeMapper[Short]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Short) = ...
+```
+
+```scala
+implicit def IntType: TypeMapper[Int] = ...
+```
+
+```scala
+class IntType extends TypeMapper[Int]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Int) = ...
+```
+
+```scala
+implicit def LongType: TypeMapper[Long] = ...
+```
+
+```scala
+class LongType extends TypeMapper[Long]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Long) = ...
+```
+
+```scala
+implicit def FloatType: TypeMapper[Float] = ...
+```
+
+```scala
+class FloatType extends TypeMapper[Float]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Float) = ...
+```
+
+```scala
+implicit def DoubleType: TypeMapper[Double] = ...
+```
+
+```scala
+class DoubleType extends TypeMapper[Double]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Double) = ...
+```
+
+```scala
+implicit def BigDecimalType: TypeMapper[scala.math.BigDecimal] = ...
+```
+
+```scala
+class BigDecimalType extends TypeMapper[scala.math.BigDecimal]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: scala.math.BigDecimal) = ...
+```
+
+```scala
+implicit def BooleanType: TypeMapper[Boolean] = ...
+```
+
+```scala
+class BooleanType extends TypeMapper[Boolean]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Boolean) = ...
+```
+
+```scala
+implicit def UuidType: TypeMapper[UUID] = ...
+```
+
+```scala
+class UuidType extends TypeMapper[UUID]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: UUID) = ...
+```
+
+```scala
+implicit def BytesType: TypeMapper[geny.Bytes] = ...
+```
+
+```scala
+class BytesType extends TypeMapper[geny.Bytes]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: geny.Bytes) = ...
+```
+
+```scala
+implicit def UtilDateType: TypeMapper[java.util.Date] = ...
+```
+
+```scala
+class UtilDateType extends TypeMapper[java.util.Date]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: java.util.Date) = ...
+```
+
+```scala
+implicit def LocalDateType: TypeMapper[LocalDate] = ...
+```
+
+```scala
+class LocalDateType extends TypeMapper[LocalDate]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: LocalDate) = ...
+```
+
+```scala
+implicit def LocalTimeType: TypeMapper[LocalTime] = ...
+```
+
+```scala
+class LocalTimeType extends TypeMapper[LocalTime]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: LocalTime) = ...
+```
+
+```scala
+implicit def LocalDateTimeType: TypeMapper[LocalDateTime] = ...
+```
+
+```scala
+class LocalDateTimeType extends TypeMapper[LocalDateTime]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: LocalDateTime) = ...
+```
+
+```scala
+implicit def ZonedDateTimeType: TypeMapper[ZonedDateTime] = ...
+```
+
+```scala
+class ZonedDateTimeType extends TypeMapper[ZonedDateTime]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: ZonedDateTime) = ...
+```
+
+```scala
+implicit def InstantType: TypeMapper[Instant] = ...
+```
+
+```scala
+class InstantType extends TypeMapper[Instant]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: Instant) = ...
+```
+
+```scala
+implicit def OffsetTimeType: TypeMapper[OffsetTime] = ...
+```
+
+```scala
+class OffsetTimeType extends TypeMapper[OffsetTime]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: OffsetTime) = ...
+```
+
+```scala
+implicit def OffsetDateTimeType: TypeMapper[OffsetDateTime] = ...
+```
+
+```scala
+class OffsetDateTimeType extends TypeMapper[OffsetDateTime]
+```
+
+```scala
+def jdbcType = ...
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: OffsetDateTime) = ...
+```
+
+```scala
+implicit def EnumType[T <: Enumeration#Value](implicit constructor: String => T): TypeMapper[T] = ...
+```
+
+```scala
+class EnumType[T](implicit constructor: String => T) extends TypeMapper[T]
+```
+
+```scala
+def jdbcType: JDBCType = ...
+```
+
+```scala
+def get(r: ResultSet, idx: Int): T = ...
+```
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: T) = ...
+```
+
+```scala
+implicit def from(x: Byte): Expr[Byte] = ...
+```
+
+```scala
+implicit def from(x: Short): Expr[Short] = ...
+```
+
+```scala
+implicit def from(x: Int): Expr[Int] = ...
+```
+
+```scala
+implicit def from(x: Long): Expr[Long] = ...
+```
+
+```scala
+implicit def from(x: Boolean): Expr[Boolean] = ...
+```
+
+```scala
+implicit def from(x: Float): Expr[Float] = ...
+```
+
+```scala
+implicit def from(x: Double): Expr[Double] = ...
+```
+
+```scala
+implicit def from(x: scala.math.BigDecimal): Expr[scala.math.BigDecimal] = ...
+```
+
+```scala
+implicit def from(x: String): Expr[String] = ...
+```
+
+```scala
+implicit def OptionType[T](implicit inner: TypeMapper[T]): TypeMapper[Option[T]] = ...
+```
+
+```scala
+implicit def ExprBooleanOpsConv(v: Expr[Boolean]): operations.ExprBooleanOps = ...
+```
+
+```scala
+implicit def ExprNumericOpsConv[T: Numeric: TypeMapper](
+      v: Expr[T]
+  ): operations.ExprNumericOps[T] = ...
+```
+
+```scala
+implicit def ExprOpsConv[T](v: Expr[T]): operations.ExprOps[T] = ...
+```
+
+```scala
+implicit def ExprTypedOpsConv[T: ClassTag](v: Expr[T]): operations.ExprTypedOps[T] = ...
+```
+
+```scala
+implicit def ExprOptionOpsConv[T: TypeMapper](v: Expr[Option[T]]): operations.ExprOptionOps[T] = ...
+```
+
+```scala
+implicit def JoinNullableOpsConv[T: TypeMapper](
+      v: JoinNullable[Expr[T]]
+  ): operations.ExprOps[Option[T]] = ...
+```
+
+```scala
+implicit def JoinNullableOptionOpsConv[T: TypeMapper](
+      v: JoinNullable[Expr[T]]
+  ): operations.ExprOptionOps[T] = ...
+```
+
+```scala
+implicit def ExprStringOpsConv(
+      v: Expr[String]
+  ): operations.ExprStringLikeOps[String] & operations.ExprStringOps[String]
+```
+
+```scala
+implicit def ExprBlobOpsConv(v: Expr[geny.Bytes]): operations.ExprStringLikeOps[geny.Bytes]
+```
+
+```scala
+implicit def AggNumericOpsConv[V: Numeric: TypeMapper](v: Aggregatable[Expr[V]])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): operations.AggNumericOps[V] = ...
+```
+
+```scala
+implicit def AggOpsConv[T](v: Aggregatable[T])(
+      implicit qr: Queryable.Row[T, ?]
+  ): operations.AggOps[T] = ...
+```
+
+```scala
+implicit def AggAnyOpsConv[T: TypeMapper](v: Aggregatable[Expr[T]])(
+      implicit qrInt: Queryable.Row[Expr[Int], Int]
+  ): operations.AggAnyOps[T] = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T]
+```
+
+```scala
+implicit def TableOpsConv[V[_[_]]](t: Table[V]): TableOps[V] = ...
+```
+
+```scala
+implicit def DbApiQueryOpsConv(db: => DbApi): DbApiQueryOps = ...
+```
+
+```scala
+implicit def DbApiOpsConv(db: => DbApi): DbApiOps = ...
+```
+
+```scala
+implicit class WindowExtensions[T](e: Expr[T])
+```
+
+```scala
+def over = ...
+```
+
+```scala
+implicit def ExprQueryable[T](implicit mt: TypeMapper[T]): Queryable.Row[Expr[T], T] = ...
+```
+
+#### `dialects/H2Dialect.scala`
+
+```scala
+trait H2Dialect extends Dialect
+```
+
+```scala
+def castParams = ...
+```
+
+```scala
+def escape(str: String) = ...
+```
+
+```scala
+def supportSavepointRelease = ...
+```
+
+```scala
+override implicit def EnumType[T <: Enumeration#Value](
+      implicit constructor: String => T
+  ): TypeMapper[T] = ...
+```
+
+```scala
+class H2EnumType[T](implicit constructor: String => T) extends EnumType[T]
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: T): Unit = ...
+```
+
+```scala
+override implicit def ExprStringOpsConv(v: Expr[String]): H2Dialect.ExprStringOps[String] = ...
+```
+
+```scala
+override implicit def ExprBlobOpsConv(
+      v: Expr[geny.Bytes]
+  ): H2Dialect.ExprStringLikeOps[geny.Bytes] = ...
+```
+
+```scala
+override implicit def ExprNumericOpsConv[T: Numeric: TypeMapper](
+      v: Expr[T]
+  ): H2Dialect.ExprNumericOps[T] = ...
+```
+
+```scala
+override implicit def TableOpsConv[V[_[_]]](t: Table[V]): scalasql.dialects.TableOps[V] = ...
+```
+
+```scala
+override implicit def DbApiQueryOpsConv(db: => DbApi): DbApiQueryOps = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T] = ...
+```
+
+```scala
+override implicit def DbApiOpsConv(db: => DbApi): H2Dialect.DbApiOps = ...
+```
+
+```scala
+object H2Dialect extends H2Dialect
+```
+
+```scala
+override def supportSavepointRelease: Boolean = ...
+```
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers)
+```
+
+```scala
+class ExprAggOps[T](v: Aggregatable[Expr[T]]) extends scalasql.operations.ExprAggOps[T](v)
+```
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String] = ...
+```
+
+```scala
+class ExprStringOps[T](v: Expr[T]) extends ExprStringLikeOps(v) with operations.ExprStringOps[T]
+```
+
+```scala
+class ExprStringLikeOps[T](protected val v: Expr[T])
+```
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int] = ...
+```
+
+```scala
+class ExprNumericOps[T: Numeric: TypeMapper](protected val v: Expr[T])
+```
+
+```scala
+def power(y: Expr[T]): Expr[T] = ...
+```
+
+```scala
+class TableOps[V[_[_]]](t: Table[V]) extends scalasql.dialects.TableOps[V](t)
+```
+
+```scala
+trait Select[Q, R] extends scalasql.query.Select[Q, R]
+```
+
+```scala
+override def newCompoundSelect[Q, R](
+        lhs: scalasql.query.SimpleSelect[Q, R],
+        compoundOps: Seq[CompoundSelect.Op[Q, R]],
+        orderBy: Seq[OrderBy],
+        limit: Option[Int],
+        offset: Option[Int]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.CompoundSelect[Q, R] = ...
+```
+
+```scala
+override def newSimpleSelect[Q, R](
+        expr: Q,
+        exprPrefix: Option[Context => SqlStr],
+        exprSuffix: Option[Context => SqlStr],
+        preserveAll: Boolean,
+        from: Seq[Context.From],
+        joins: Seq[Join],
+        where: Seq[Expr[?]],
+        groupBy0: Option[GroupBy]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.SimpleSelect[Q, R] = ...
+```
+
+```scala
+class SimpleSelect[Q, R](
+      expr: Q,
+      exprPrefix: Option[Context => SqlStr],
+      exprSuffix: Option[Context => SqlStr],
+      preserveAll: Boolean,
+      from: Seq[Context.From],
+      joins: Seq[Join],
+      where: Seq[Expr[?]],
+      groupBy0: Option[GroupBy]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+override def outerJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+        implicit joinQr: Queryable.Row[Q2, R2]
+    ): scalasql.query.Select[(JoinNullable[Q], JoinNullable[Q2]), (Option[R], Option[R2])] = ...
+```
+
+```scala
+class CompoundSelect[Q, R](
+      lhs: scalasql.query.SimpleSelect[Q, R],
+      compoundOps: Seq[scalasql.query.CompoundSelect.Op[Q, R]],
+      orderBy: Seq[OrderBy],
+      limit: Option[Int],
+      offset: Option[Int]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class Values[Q, R](ts: Seq[R])(implicit qr: Queryable.Row[Q, R])
+```
+
+#### `dialects/MsSqlDialect.scala`
+
+```scala
+trait MsSqlDialect extends Dialect
+```
+
+```scala
+def castParams = ...
+```
+
+```scala
+def escape(str: String): String = ...
+```
+
+```scala
+def supportSavepointRelease = ...
+```
+
+```scala
+override implicit def IntType: TypeMapper[Int] = ...
+```
+
+```scala
+class MsSqlIntType extends IntType
+```
+
+```scala
+override implicit def StringType: TypeMapper[String] = ...
+```
+
+```scala
+class MsSqlStringType extends StringType
+```
+
+```scala
+override implicit def BooleanType: TypeMapper[Boolean] = ...
+```
+
+```scala
+class MsSqlBooleanType extends BooleanType
+```
+
+```scala
+override implicit def ExprOptionOpsConv[T: TypeMapper](
+      v: Expr[Option[T]]
+  ): operations.ExprOptionOps[T] = ...
+```
+
+```scala
+class MsSqlBooleanExprOptionOps(v: Expr[Option[Boolean]])
+```
+
+```scala
+override def getOrElse(other: Expr[Boolean]): Expr[Boolean] = ...
+```
+
+```scala
+override implicit def from(x: Boolean): Expr[Boolean] = ...
+```
+
+```scala
+override implicit def DoubleType: TypeMapper[Double] = ...
+```
+
+```scala
+class MsDoubleType extends DoubleType
+```
+
+```scala
+override implicit def OptionType[T](implicit inner: TypeMapper[T]): TypeMapper[Option[T]] = ...
+```
+
+```scala
+override implicit def UtilDateType: TypeMapper[java.util.Date] = ...
+```
+
+```scala
+class MsSqlUtilDateType extends UtilDateType
+```
+
+```scala
+override implicit def LocalDateTimeType: TypeMapper[LocalDateTime] = ...
+```
+
+```scala
+class MsSqlLocalDateTimeType extends LocalDateTimeType
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+override implicit def InstantType: TypeMapper[Instant] = ...
+```
+
+```scala
+class MsSqlInstantType extends InstantType
+```
+
+```scala
+override implicit def ZonedDateTimeType: TypeMapper[ZonedDateTime] = ...
+```
+
+```scala
+class MsSqlZonedDateTimeType extends ZonedDateTimeType
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+override def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: ZonedDateTime) = ...
+```
+
+```scala
+override implicit def OffsetDateTimeType: TypeMapper[OffsetDateTime] = ...
+```
+
+```scala
+class MsSqlOffsetDateTimeType extends OffsetDateTimeType
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+override def get(r: ResultSet, idx: Int) = ...
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: OffsetDateTime) = ...
+```
+
+```scala
+override implicit def EnumType[T <: Enumeration#Value](
+      implicit constructor: String => T
+  ): TypeMapper[T] = ...
+```
+
+```scala
+class MsSqlEnumType[T](implicit constructor: String => T) extends EnumType[T]
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: T): Unit = ...
+```
+
+```scala
+override implicit def ExprStringOpsConv(v: Expr[String]): MsSqlDialect.ExprStringOps[String] = ...
+```
+
+```scala
+override implicit def ExprBlobOpsConv(
+      v: Expr[geny.Bytes]
+  ): MsSqlDialect.ExprStringLikeOps[geny.Bytes] = ...
+```
+
+```scala
+override implicit def ExprNumericOpsConv[T: Numeric: TypeMapper](
+      v: Expr[T]
+  ): MsSqlDialect.ExprNumericOps[T] = ...
+```
+
+```scala
+override implicit def TableOpsConv[V[_[_]]](t: Table[V]): scalasql.dialects.TableOps[V] = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T] = ...
+```
+
+```scala
+override implicit def DbApiOpsConv(db: => DbApi): MsSqlDialect.DbApiOps = ...
+```
+
+```scala
+override implicit def ExprQueryable[T](implicit mt: TypeMapper[T]): Queryable.Row[Expr[T], T] = ...
+```
+
+```scala
+object MsSqlDialect extends MsSqlDialect
+```
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers)
+```
+
+```scala
+override def ln[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+```scala
+override def atan2[T: Numeric](v: Expr[T], y: Expr[T]): Expr[Double] = ...
+```
+
+```scala
+class ExprAggOps[T](v: Aggregatable[Expr[T]]) extends scalasql.operations.ExprAggOps[T](v)
+```
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String] = ...
+```
+
+```scala
+class ExprStringOps[T](v: Expr[T]) extends ExprStringLikeOps(v) with operations.ExprStringOps[T]
+```
+
+```scala
+class ExprStringLikeOps[T](protected val v: Expr[T])
+```
+
+```scala
+override def +(x: Expr[T]): Expr[T] = ...
+```
+
+```scala
+override def startsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+override def endsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+override def contains(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+override def length: Expr[Int] = ...
+```
+
+```scala
+override def octetLength: Expr[Int] = ...
+```
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int] = ...
+```
+
+```scala
+def reverse: Expr[T] = ...
+```
+
+```scala
+class ExprNumericOps[T: Numeric: TypeMapper](protected val v: Expr[T])
+```
+
+```scala
+override def %[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+```scala
+override def mod[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+```scala
+override def ceil: Expr[T] = ...
+```
+
+```scala
+class TableOps[V[_[_]]](t: Table[V]) extends scalasql.dialects.TableOps[V](t)
+```
+
+```scala
+trait Select[Q, R] extends scalasql.query.Select[Q, R]
+```
+
+```scala
+override def newCompoundSelect[Q, R](
+        lhs: scalasql.query.SimpleSelect[Q, R],
+        compoundOps: Seq[scalasql.query.CompoundSelect.Op[Q, R]],
+        orderBy: Seq[OrderBy],
+        limit: Option[Int],
+        offset: Option[Int]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.CompoundSelect[Q, R] = ...
+```
+
+```scala
+override def newSimpleSelect[Q, R](
+        expr: Q,
+        exprPrefix: Option[Context => SqlStr],
+        exprSuffix: Option[Context => SqlStr],
+        preserveAll: Boolean,
+        from: Seq[Context.From],
+        joins: Seq[Join],
+        where: Seq[Expr[?]],
+        groupBy0: Option[GroupBy]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.SimpleSelect[Q, R] = ...
+```
+
+```scala
+class SimpleSelect[Q, R](
+      expr: Q,
+      exprPrefix: Option[Context => SqlStr],
+      exprSuffix: Option[Context => SqlStr],
+      preserveAll: Boolean,
+      from: Seq[Context.From],
+      joins: Seq[Join],
+      where: Seq[Expr[?]],
+      groupBy0: Option[GroupBy]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+override def take(n: Int): scalasql.query.Select[Q, R] = ...
+```
+
+```scala
+override def drop(n: Int): scalasql.query.Select[Q, R] = ...
+```
+
+```scala
+class CompoundSelect[Q, R](
+      lhs: scalasql.query.SimpleSelect[Q, R],
+      compoundOps: Seq[scalasql.query.CompoundSelect.Op[Q, R]],
+      orderBy: Seq[OrderBy],
+      limit: Option[Int],
+      offset: Option[Int]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+override def take(n: Int): scalasql.query.Select[Q, R] = ...
+```
+
+```scala
+class CompoundSelectRenderer[Q, R](
+      query: scalasql.query.CompoundSelect[Q, R],
+      prevContext: Context
+  ) extends scalasql.query.CompoundSelect.Renderer(query, prevContext)
+```
+
+```scala
+override lazy val limitOpt = ...
+```
+
+```scala
+override lazy val offsetOpt = ...
+```
+
+```scala
+override def render(liveExprs: LiveExprs): SqlStr = ...
+```
+
+```scala
+override def orderToSqlStr(newCtx: Context) = ...
+```
+
+```scala
+class ExprQueryable[E[_] <: Expr[?], T](
+      implicit tm: TypeMapper[T]
+  ) extends Expr.ExprQueryable[E, T]
+```
+
+```scala
+override def walkExprs(q: E[T]): Seq[Expr[?]] = ...
+```
+
+#### `dialects/MySqlDialect.scala`
+
+```scala
+trait MySqlDialect extends Dialect
+```
+
+```scala
+def castParams = ...
+```
+
+```scala
+def escape(str: String) = ...
+```
+
+```scala
+def supportSavepointRelease = ...
+```
+
+```scala
+override implicit def ByteType: TypeMapper[Byte] = ...
+```
+
+```scala
+class MySqlByteType extends ByteType
+```
+
+```scala
+override implicit def ShortType: TypeMapper[Short] = ...
+```
+
+```scala
+class MySqlShortType extends ShortType
+```
+
+```scala
+override implicit def IntType: TypeMapper[Int] = ...
+```
+
+```scala
+class MySqlIntType extends IntType
+```
+
+```scala
+override implicit def LongType: TypeMapper[Long] = ...
+```
+
+```scala
+class MySqlLongType extends LongType
+```
+
+```scala
+override implicit def StringType: TypeMapper[String] = ...
+```
+
+```scala
+class MySqlStringType extends StringType
+```
+
+```scala
+override implicit def LocalDateTimeType: TypeMapper[LocalDateTime] = ...
+```
+
+```scala
+class MySqlLocalDateTimeType extends LocalDateTimeType
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+override implicit def InstantType: TypeMapper[Instant] = ...
+```
+
+```scala
+class MySqlInstantType extends InstantType
+```
+
+```scala
+override implicit def UtilDateType: TypeMapper[java.util.Date] = ...
+```
+
+```scala
+class MySqlUtilDateType extends UtilDateType
+```
+
+```scala
+override implicit def UuidType: TypeMapper[UUID] = ...
+```
+
+```scala
+class MySqlUuidType extends UuidType
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: UUID) = ...
+```
+
+```scala
+override implicit def EnumType[T <: Enumeration#Value](
+      implicit constructor: String => T
+  ): TypeMapper[T] = ...
+```
+
+```scala
+class MySqlEnumType[T](implicit constructor: String => T) extends EnumType[T]
+```
+
+```scala
+override def put(r: PreparedStatement, idx: Int, v: T): Unit = ...
+```
+
+```scala
+override implicit def ExprTypedOpsConv[T: ClassTag](v: Expr[T]): operations.ExprTypedOps[T] = ...
+```
+
+```scala
+override implicit def ExprStringOpsConv(v: Expr[String]): MySqlDialect.ExprStringOps[String] = ...
+```
+
+```scala
+override implicit def ExprBlobOpsConv(
+      v: Expr[geny.Bytes]
+  ): MySqlDialect.ExprStringLikeOps[geny.Bytes] = ...
+```
+
+```scala
+override implicit def TableOpsConv[V[_[_]]](t: Table[V]): scalasql.dialects.TableOps[V] = ...
+```
+
+```scala
+implicit def OnConflictableUpdate[V[_[_]], R](
+      query: InsertColumns[V, R]
+  ): MySqlDialect.OnConflictable[V[Column], Int] = ...
+```
+
+```scala
+override implicit def DbApiQueryOpsConv(db: => DbApi): DbApiQueryOps = ...
+```
+
+```scala
+implicit def LateralJoinOpsConv[C[_, _], Q, R](wrapped: JoinOps[C, Q, R] & Joinable[Q, R])(
+      implicit qr: Queryable.Row[Q, R]
+  ): LateralJoinOps[C, Q, R] = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T] = ...
+```
+
+```scala
+implicit class SelectForUpdateConv[Q, R](r: Select[Q, R])
+```
+
+> SELECT .. FOR UPDATE acquires an exclusive lock, blocking other transactions from
+> modifying or locking the selected rows, which is for managing concurrent transactions
+> and ensuring data consistency in multi-step operations.
+
+```scala
+def forUpdate: Select[Q, R] = ...
+```
+
+> SELECT ... FOR SHARE: Locks the selected rows for reading, allowing other transactions
+> to read but not modify the locked rows
+
+```scala
+def forShare: Select[Q, R] = ...
+```
+
+> SELECT ... FOR UPDATE NOWAIT: Immediately returns an error if the selected rows are
+> already locked, instead of waiting
+
+```scala
+def forUpdateNoWait: Select[Q, R] = ...
+```
+
+> SELECT ... FOR UPDATE SKIP LOCKED: Skips any rows that are already locked by other
+> transactions, instead of waiting
+
+```scala
+def forUpdateSkipLocked: Select[Q, R] = ...
+```
+
+```scala
+override implicit def DbApiOpsConv(db: => DbApi): MySqlDialect.DbApiOps = ...
+```
+
+```scala
+object MySqlDialect extends MySqlDialect
+```
+
+```scala
+override def supportSavepointRelease: Boolean = ...
+```
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers)
+```
+
+> Returns a random value in the range 0.0 <= x < 1.0
+
+```scala
+def rand: Expr[Double] = ...
+```
+
+```scala
+class ExprAggOps[T](v: Aggregatable[Expr[T]]) extends scalasql.operations.ExprAggOps[T](v)
+```
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String] = ...
+```
+
+```scala
+class ExprTypedOps[T: ClassTag](v: Expr[T]) extends operations.ExprTypedOps(v)
+```
+
+> Equals to
+
+```scala
+override def = ...
+```
+
+> Not equal to
+
+```scala
+override def ! = ...
+```
+
+```scala
+class ExprStringOps[T](v: Expr[T]) extends ExprStringLikeOps(v) with operations.ExprStringOps[T]
+```
+
+```scala
+class ExprStringLikeOps[T](protected val v: Expr[T])
+```
+
+```scala
+override def +(x: Expr[T]): Expr[T] = ...
+```
+
+```scala
+override def startsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+override def endsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+override def contains(other: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int] = ...
+```
+
+```scala
+def reverse: Expr[T] = ...
+```
+
+```scala
+class TableOps[V[_[_]]](t: Table[V]) extends scalasql.dialects.TableOps[V](t)
+```
+
+```scala
+override def update(
+        filter: V[Column] => Expr[Boolean]
+    ): Update[V[Column], V[Sc]] = ...
+```
+
+```scala
+class Update[Q, R](
+      expr: Q,
+      table: TableRef,
+      set0: Seq[Column.Assignment[?]],
+      joins: Seq[Join],
+      where: Seq[Expr[?]]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class UpdateRenderer(
+      joins0: Seq[Join],
+      table: TableRef,
+      set0: Seq[Column.Assignment[?]],
+      where0: Seq[Expr[?]],
+      prevContext: Context
+  ) extends scalasql.query.Update.Renderer(joins0, table, set0, where0, prevContext)
+```
+
+```scala
+override lazy val updateList = ...
+```
+
+```scala
+lazy val whereAll = ...
+```
+
+```scala
+override lazy val joinOns = ...
+```
+
+```scala
+override lazy val joins = ...
+```
+
+```scala
+override def render() = ...
+```
+
+```scala
+class OnConflictable[Q, R](val query: Query[R], expr: Q, table: TableRef)
+```
+
+```scala
+def onConflictUpdate(c2: Q => Column.Assignment[?]*): OnConflictUpdate[Q, R] = ...
+```
+
+```scala
+class OnConflictUpdate[Q, R](
+      insert: OnConflictable[Q, R],
+      updates: Seq[Column.Assignment[?]],
+      table: TableRef
+  ) extends Query.DelegateQuery[R]
+```
+
+```scala
+override def queryIsExecuteUpdate = ...
+```
+
+```scala
+trait Select[Q, R] extends scalasql.query.Select[Q, R]
+```
+
+```scala
+override def newCompoundSelect[Q, R](
+        lhs: scalasql.query.SimpleSelect[Q, R],
+        compoundOps: Seq[CompoundSelect.Op[Q, R]],
+        orderBy: Seq[OrderBy],
+        limit: Option[Int],
+        offset: Option[Int]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.CompoundSelect[Q, R] = ...
+```
+
+```scala
+override def newSimpleSelect[Q, R](
+        expr: Q,
+        exprPrefix: Option[Context => SqlStr],
+        exprSuffix: Option[Context => SqlStr],
+        preserveAll: Boolean,
+        from: Seq[Context.From],
+        joins: Seq[Join],
+        where: Seq[Expr[?]],
+        groupBy0: Option[GroupBy]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.SimpleSelect[Q, R] = ...
+```
+
+```scala
+class SimpleSelect[Q, R](
+      expr: Q,
+      exprPrefix: Option[Context => SqlStr],
+      exprSuffix: Option[Context => SqlStr],
+      preserveAll: Boolean,
+      from: Seq[Context.From],
+      joins: Seq[Join],
+      where: Seq[Expr[?]],
+      groupBy0: Option[GroupBy]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+override def outerJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+        implicit joinQr: Queryable.Row[Q2, R2]
+    ): scalasql.query.Select[(JoinNullable[Q], JoinNullable[Q2]), (Option[R], Option[R2])] = ...
+```
+
+```scala
+class CompoundSelect[Q, R](
+      lhs: scalasql.query.SimpleSelect[Q, R],
+      compoundOps: Seq[scalasql.query.CompoundSelect.Op[Q, R]],
+      orderBy: Seq[OrderBy],
+      limit: Option[Int],
+      offset: Option[Int]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class CompoundSelectRenderer[Q, R](
+      query: scalasql.query.CompoundSelect[Q, R],
+      prevContext: Context
+  ) extends scalasql.query.CompoundSelect.Renderer(query, prevContext)
+```
+
+```scala
+override lazy val limitOpt = ...
+```
+
+```scala
+override def orderToSqlStr(newCtx: Context) = ...
+```
+
+```scala
+class Values[Q, R](ts: Seq[R])(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class ValuesRenderer[Q, R](v: Values[Q, R])(implicit qr: Queryable.Row[Q, R], ctx: Context)
+```
+
+```scala
+override def wrapRow(t: R): SqlStr = ...
+```
+
+#### `dialects/OnConflictOps.scala`
+
+```scala
+trait OnConflictOps
+```
+
+```scala
+implicit def OnConflictableInsertColumns[V[_[_]], R](
+      query: InsertColumns[V, R]
+  ): OnConflict[V[Column], Int] = ...
+```
+
+```scala
+implicit def OnConflictableInsertValues[V[_[_]], R](
+      query: InsertValues[V, R]
+  ): OnConflict[V[Column], Int] = ...
+```
+
+```scala
+implicit def OnConflictableInsertSelect[V[_[_]], C, R, R2](
+      query: InsertSelect[V, C, R, R2]
+  ): OnConflict[V[Column], Int] = ...
+```
+
+#### `dialects/PostgresDialect.scala`
+
+```scala
+trait PostgresDialect extends Dialect with ReturningDialect with OnConflictOps
+```
+
+```scala
+def castParams = ...
+```
+
+```scala
+def escape(str: String) = ...
+```
+
+```scala
+def supportSavepointRelease = ...
+```
+
+```scala
+override implicit def ByteType: TypeMapper[Byte] = ...
+```
+
+```scala
+class PostgresByteType extends ByteType
+```
+
+```scala
+override implicit def StringType: TypeMapper[String] = ...
+```
+
+```scala
+class PostgresStringType extends StringType
+```
+
+```scala
+override implicit def ExprStringOpsConv(v: Expr[String]): PostgresDialect.ExprStringOps[String] = ...
+```
+
+```scala
+override implicit def ExprBlobOpsConv(
+      v: Expr[geny.Bytes]
+  ): PostgresDialect.ExprStringLikeOps[geny.Bytes] = ...
+```
+
+```scala
+implicit def LateralJoinOpsConv[C[_, _], Q, R](wrapped: JoinOps[C, Q, R] & Joinable[Q, R])(
+      implicit qr: Queryable.Row[Q, R]
+  ): LateralJoinOps[C, Q, R] = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T] = ...
+```
+
+```scala
+implicit class SelectDistinctOnConv[Q, R](r: Select[Q, R])
+```
+
+> SELECT DISTINCT ON ( expression [, ...] ) keeps only the first row of each set of rows
+> where the given expressions evaluate to equal. The DISTINCT ON expressions are
+> interpreted using the same rules as for ORDER BY (see above). Note that the “first
+> row” of each set is unpredictable unless ORDER BY is used to ensure that the desired
+> row appears first. For example:
+
+```scala
+def distinctOn(one: Q => Expr[?], more: (Q => Expr[?])*): Select[Q, R] = ...
+```
+
+```scala
+implicit class SelectForUpdateConv[Q, R](r: Select[Q, R])
+```
+
+> SELECT .. FOR UPDATE acquires an exclusive lock, blocking other transactions from
+> modifying or locking the selected rows, which is for managing concurrent transactions
+> and ensuring data consistency in multi-step operations.
+
+```scala
+def forUpdate: Select[Q, R] = ...
+```
+
+> SELECT ... FOR NO KEY UPDATE: A weaker lock that doesn't block inserts into child
+> tables with foreign key references
+
+```scala
+def forNoKeyUpdate: Select[Q, R] = ...
+```
+
+> SELECT ... FOR SHARE: Locks the selected rows for reading, allowing other transactions
+> to read but not modify the locked rows.
+
+```scala
+def forShare: Select[Q, R] = ...
+```
+
+> SELECT ... FOR KEY SHARE: The weakest lock, only conflicts with FOR UPDATE
+
+```scala
+def forKeyShare: Select[Q, R] = ...
+```
+
+> SELECT ... FOR UPDATE NOWAIT: Immediately returns an error if the selected rows are
+> already locked, instead of waiting
+
+```scala
+def forUpdateNoWait: Select[Q, R] = ...
+```
+
+> SELECT ... FOR UPDATE SKIP LOCKED: Skips any rows that are already locked by other
+> transactions, instead of waiting
+
+```scala
+def forUpdateSkipLocked: Select[Q, R] = ...
+```
+
+```scala
+override implicit def DbApiOpsConv(db: => DbApi): PostgresDialect.DbApiOps = ...
+```
+
+```scala
+object PostgresDialect extends PostgresDialect
+```
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers)
+```
+
+> Formats arguments according to a format string. This function is similar to the C function sprintf.
+
+```scala
+def format(template: Expr[String], values: Expr[?]*): Expr[String] = ...
+```
+
+> Returns a random value in the range 0.0 <= x < 1.0
+
+```scala
+def random: Expr[Double] = ...
+```
+
+```scala
+class ExprAggOps[T](v: Aggregatable[Expr[T]]) extends scalasql.operations.ExprAggOps[T](v)
+```
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String] = ...
+```
+
+```scala
+class ExprStringOps[T](v: Expr[T]) extends ExprStringLikeOps(v) with operations.ExprStringOps[T]
+```
+
+```scala
+class ExprStringLikeOps[T](protected val v: Expr[T])
+```
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int] = ...
+```
+
+```scala
+def reverse: Expr[T] = ...
+```
+
+#### `dialects/ReturningDialect.scala`
+
+```scala
+trait ReturningDialect extends Dialect
+```
+
+```scala
+implicit class InsertReturningConv[Q](r: Returning.InsertBase[Q])
+```
+
+```scala
+def returning[Q2, R](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R]): Returning[Q2, R] = ...
+```
+
+```scala
+implicit class ReturningConv[Q](r: Returning.Base[Q])
+```
+
+```scala
+def returning[Q2, R](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R]): Returning[Q2, R] = ...
+```
+
+```scala
+implicit class OnConflictUpdateConv[Q, R](r: OnConflict.Update[Q, R])
+```
+
+```scala
+def returning[Q2, R](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R]): Returning[Q2, R] = ...
+```
+
+```scala
+implicit class OnConflictIgnoreConv[Q, R](r: OnConflict.Ignore[Q, R])
+```
+
+```scala
+def returning[Q2, R](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R]): Returning[Q2, R] = ...
+```
+
+#### `dialects/SqliteDialect.scala`
+
+```scala
+trait SqliteDialect extends Dialect with ReturningDialect with OnConflictOps
+```
+
+```scala
+def castParams = ...
+```
+
+```scala
+def escape(str: String) = ...
+```
+
+```scala
+def supportSavepointRelease = ...
+```
+
+```scala
+override implicit def LocalDateTimeType: TypeMapper[LocalDateTime] = ...
+```
+
+```scala
+class SqliteLocalDateTimeType extends LocalDateTimeType
+```
+
+```scala
+override def castTypeString = ...
+```
+
+```scala
+override implicit def LocalDateType: TypeMapper[LocalDate] = ...
+```
+
+```scala
+class SqliteLocalDateType extends LocalDateType
+```
+
+```scala
+override implicit def InstantType: TypeMapper[Instant] = ...
+```
+
+```scala
+class SqliteInstantType extends InstantType
+```
+
+```scala
+override implicit def UtilDateType: TypeMapper[java.util.Date] = ...
+```
+
+```scala
+class SqliteUtilDateType extends UtilDateType
+```
+
+```scala
+override implicit def ExprStringOpsConv(v: Expr[String]): SqliteDialect.ExprStringOps[String] = ...
+```
+
+```scala
+override implicit def ExprBlobOpsConv(
+      v: Expr[geny.Bytes]
+  ): SqliteDialect.ExprStringLikeOps[geny.Bytes] = ...
+```
+
+```scala
+override implicit def TableOpsConv[V[_[_]]](t: Table[V]): scalasql.dialects.TableOps[V] = ...
+```
+
+```scala
+implicit def ExprAggOpsConv[T](v: Aggregatable[Expr[T]]): operations.ExprAggOps[T] = ...
+```
+
+```scala
+override implicit def DbApiOpsConv(db: => DbApi): SqliteDialect.DbApiOps = ...
+```
+
+```scala
+object SqliteDialect extends SqliteDialect
+```
+
+```scala
+override def supportSavepointRelease: Boolean = ...
+```
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers) extends scalasql.operations.DbApiOps(dialect)
+```
+
+> The changes() function returns the number of database rows that were changed
+> or inserted or deleted by the most recently completed INSERT, DELETE, or
+> UPDATE statement, exclusive of statements in lower-level triggers. The
+> changes() SQL function is a wrapper around the sqlite3_changes64() C/C++
+> function and hence follows the same rules for counting changes.
+
+```scala
+def changes: Expr[Int] = ...
+```
+
+> The total_changes() function returns the number of row changes caused by
+> INSERT, UPDATE or DELETE statements since the current database connection
+> was opened. This function is a wrapper around the sqlite3_total_changes64()
+> C/C++ interface.
+
+```scala
+def totalChanges: Expr[Int] = ...
+```
+
+> The typeof(X) function returns a string that indicates the datatype of the
+> expression X: "null", "integer", "real", "text", or "blob".
+
+```scala
+def typeOf(v: Expr[?]): Expr[String] = ...
+```
+
+> The last_insert_rowid() function returns the ROWID of the last row insert
+> from the database connection which invoked the function. The
+> last_insert_rowid() SQL function is a wrapper around the
+> sqlite3_last_insert_rowid() C/C++ interface function.
+
+```scala
+def lastInsertRowId: Expr[Int] = ...
+```
+
+> The random() function returns a pseudo-random integer between
+> -9223372036854775808 and +9223372036854775807.
+
+```scala
+def random: Expr[Long] = ...
+```
+
+> The randomblob(N) function return an N-byte blob containing pseudo-random bytes.
+> If N is less than 1 then a 1-byte random blob is returned.
+>
+> Hint: applications can generate globally unique identifiers using this function
+> together with hex() and/or lower() like this:
+>
+> hex(randomblob(16))
+> lower(hex(randomblob(16)))
+
+```scala
+def randomBlob(n: Expr[Int]): Expr[geny.Bytes] = ...
+```
+
+> The char(X1,X2,...,XN) function returns a string composed of characters
+> having the unicode code point values of the given integers
+
+```scala
+def char(values: Expr[Int]*): Expr[String] = ...
+```
+
+> The format(FORMAT,...) SQL function works like the sqlite3_mprintf() C-language
+> function and the printf() function from the standard C library. The first
+> argument is a format string that specifies how to construct the output string
+> using values taken from subsequent arguments. If the FORMAT argument is missing
+> or NULL then the result is NULL. The %n format is silently ignored and does not
+> consume an argument. The %p format is an alias for %X. The %z format is
+> interchangeable with %s. If there are too few arguments in the argument list,
+> missing arguments are assumed to have a NULL value, which is translated into 0 or
+> 0.0 for numeric formats or an empty string for %s. See the built-in printf()
+> documentation for additional information.
+
+```scala
+def format(template: Expr[String], values: Expr[?]*): Expr[String] = ...
+```
+
+> The hex() function interprets its argument as a BLOB and returns a string which
+> is the upper-case hexadecimal rendering of the content of that blob.
+>
+> If the argument X in "hex(X)" is an integer or floating point number, then
+> "interprets its argument as a BLOB" means that the binary number is first converted
+> into a UTF8 text representation, then that text is interpreted as a BLOB. Hence,
+> "hex(12345678)" renders as "3132333435363738" not the binary representation of
+> the integer value "0000000000BC614E".
+
+```scala
+def hex(value: Expr[?]): Expr[String] = ...
+```
+
+> The unhex(X,Y) function returns a BLOB value which is the decoding of the
+> hexadecimal string X. If X contains any characters that are not hexadecimal
+> digits and which are not in Y, then unhex(X,Y) returns NULL. If Y is omitted,
+> it is understood to be an empty string and hence X must be a pure hexadecimal
+> string. All hexadecimal digits in X must occur in pairs, with both digits of
+> each pair beginning immediately adjacent to one another, or else unhex(X,Y)
+> returns NULL. If either parameter X or Y is NULL, then unhex(X,Y) returns NULL.
+> The X input may contain an arbitrary mix of upper and lower case hexadecimal
+> digits. Hexadecimal digits in Y have no affect on the translation of X. Only
+> characters in Y that are not hexadecimal digits are ignored in X.
+
+```scala
+def unhex(value: Expr[String]): Expr[geny.Bytes] = ...
+```
+
+> The unhex(X,Y) function returns a BLOB value which is the decoding of the
+> hexadecimal string X. If X contains any characters that are not hexadecimal
+> digits and which are not in Y, then unhex(X,Y) returns NULL. If Y is omitted,
+> it is understood to be an empty string and hence X must be a pure hexadecimal
+> string. All hexadecimal digits in X must occur in pairs, with both digits of
+> each pair beginning immediately adjacent to one another, or else unhex(X,Y)
+> returns NULL. If either parameter X or Y is NULL, then unhex(X,Y) returns NULL.
+> The X input may contain an arbitrary mix of upper and lower case hexadecimal
+> digits. Hexadecimal digits in Y have no affect on the translation of X. Only
+> characters in Y that are not hexadecimal digits are ignored in X.
+
+```scala
+def zeroBlob(n: Expr[Int]): Expr[geny.Bytes] = ...
+```
+
+```scala
+class AggExprOps[T](v: Aggregatable[Expr[T]]) extends scalasql.operations.ExprAggOps[T](v)
+```
+
+> TRUE if all values in a set are TRUE
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String] = ...
+```
+
+```scala
+class ExprStringOps[T](v: Expr[T]) extends ExprStringLikeOps(v) with operations.ExprStringOps[T]
+```
+
+```scala
+class ExprStringLikeOps[T](protected val v: Expr[T])
+```
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int] = ...
+```
+
+```scala
+def glob(x: Expr[T]): Expr[Boolean] = ...
+```
+
+```scala
+class TableOps[V[_[_]]](t: Table[V]) extends scalasql.dialects.TableOps[V](t)
+```
+
+```scala
+trait Select[Q, R] extends scalasql.query.Select[Q, R]
+```
+
+```scala
+override def newCompoundSelect[Q, R](
+        lhs: scalasql.query.SimpleSelect[Q, R],
+        compoundOps: Seq[CompoundSelect.Op[Q, R]],
+        orderBy: Seq[OrderBy],
+        limit: Option[Int],
+        offset: Option[Int]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.CompoundSelect[Q, R] = ...
+```
+
+```scala
+override def newSimpleSelect[Q, R](
+        expr: Q,
+        exprPrefix: Option[Context => SqlStr],
+        exprSuffix: Option[Context => SqlStr],
+        preserveAll: Boolean,
+        from: Seq[Context.From],
+        joins: Seq[Join],
+        where: Seq[Expr[?]],
+        groupBy0: Option[GroupBy]
+    )(
+        implicit qr: Queryable.Row[Q, R],
+        dialect: scalasql.core.DialectTypeMappers
+    ): scalasql.query.SimpleSelect[Q, R] = ...
+```
+
+```scala
+class SimpleSelect[Q, R](
+      expr: Q,
+      exprPrefix: Option[Context => SqlStr],
+      exprSuffix: Option[Context => SqlStr],
+      preserveAll: Boolean,
+      from: Seq[Context.From],
+      joins: Seq[Join],
+      where: Seq[Expr[?]],
+      groupBy0: Option[GroupBy]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class CompoundSelect[Q, R](
+      lhs: scalasql.query.SimpleSelect[Q, R],
+      compoundOps: Seq[scalasql.query.CompoundSelect.Op[Q, R]],
+      orderBy: Seq[OrderBy],
+      limit: Option[Int],
+      offset: Option[Int]
+  )(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class CompoundSelectRenderer[Q, R](
+      query: scalasql.query.CompoundSelect[Q, R],
+      prevContext: Context
+  ) extends scalasql.query.CompoundSelect.Renderer(query, prevContext)
+```
+
+```scala
+override lazy val limitOpt = ...
+```
+
+#### `dialects/TableOps.scala`
+
+```scala
+class TableOps[V[_[_]]](val t: Table[V])(implicit dialect: Dialect)
+```
+
+> Constructs a `SELECT` query
+
+```scala
+def select = ...
+```
+
+> Constructs a `UPDATE` query with the given [[filter]] to select the
+> rows you want to delete
+
+```scala
+def update(filter: V[Column] => Expr[Boolean]): Update[V[Column], V[Sc]] = ...
+```
+
+> Constructs a `INSERT` query
+
+```scala
+def insert: Insert[V, V[Sc]] = ...
+```
+
+> Constructs a `DELETE` query with the given [[filter]] to select the
+> rows you want to delete
+
+```scala
+def delete(filter: V[Column] => Expr[Boolean]): Delete[V[Column]] = ...
+```
+
+#### `package.scala`
+
+```scala
+package object scalasql
+```
+
+> Convenience alias for `geny.Bytes`
+
+```scala
+def Bytes(x: String): geny.Bytes = ...
+```
+
+> Convenience alias for `geny.Bytes`
+
+```scala
+def Bytes(x: Array[Byte]): geny.Bytes = ...
+```
+
+> Convenience alias for `geny.Bytes`
+
+```scala
+type Bytes = ...
+```
+
+```scala
+type Sc[T] = ...
+```
+
+```scala
+val Table = ...
+```
+
+```scala
+type Table[V[_[_]]] = ...
+```
+
+```scala
+val Column = ...
+```
+
+```scala
+type Column[T] = ...
+```
+
+```scala
+val DbClient = ...
+```
+
+```scala
+type DbClient = ...
+```
+
+```scala
+val DbApi = ...
+```
+
+```scala
+type DbApi = ...
+```
+
+```scala
+val Queryable = ...
+```
+
+```scala
+type Queryable[Q, R] = ...
+```
+
+```scala
+val Expr = ...
+```
+
+```scala
+type Expr[T] = ...
+```
+
+```scala
+type TypeMapper[T] = ...
+```
+
+```scala
+val TypeMapper = ...
+```
+
+```scala
+val Config = ...
+```
+
+```scala
+type Config = ...
+```
+
+```scala
+val SqlStr = ...
+```
+
+```scala
+type SqlStr = ...
+```
+
+```scala
+val MySqlDialect = ...
+```
+
+```scala
+type MySqlDialect = ...
+```
+
+```scala
+val PostgresDialect = ...
+```
+
+```scala
+type PostgresDialect = ...
+```
+
+```scala
+val H2Dialect = ...
+```
+
+```scala
+type H2Dialect = ...
+```
+
+```scala
+val SqliteDialect = ...
+```
+
+```scala
+type SqliteDialect = ...
+```
+
+```scala
+val MsSqlDialect = ...
+```
+
+```scala
+type MsSqlDialect = ...
+```
+
+### `com.lihaoyi:scalasql-core_3:0.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/scalasql-core_3/0.3.1/scalasql-core_3-0.3.1-sources.jar
+
+#### `Aggregatable.scala`
+
+> Something that supports aggregate operations. Most commonly a [[Select]], but
+> also could be a [[Aggregatable.Proxy]]
+
+```scala
+trait Aggregatable[Q] extends WithSqlExpr[Q]
+```
+
+```scala
+def aggregateExpr[V: TypeMapper](f: Q => Context => SqlStr)(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[V]
+```
+
+```scala
+object Aggregatable
+```
+
+> A reference that aggregations for usage within [[Select.aggregate]], to allow
+> the caller to perform multiple aggregations within a single query.
+
+```scala
+class Proxy[Q](val expr: Q) extends Aggregatable[Q]
+```
+
+```scala
+def aggregateExpr[V: TypeMapper](f: Q => Context => SqlStr)(
+        implicit qr: Queryable.Row[Expr[V], V]
+    ): Expr[V] = ...
+```
+
+#### `Config.scala`
+
+> Things you to do to configure ScalaSql
+
+```scala
+trait Config
+```
+
+> Render a sequence of tokens to a column label; used primarily for
+> making the generated queries more easily human readable.
+
+```scala
+def renderColumnLabel(tokens: Seq[String]): String = ...
+```
+
+> Configures the underlying JDBC connection's `setFetchSize`. Can be overriden
+> on a per-query basis by passing `fetchSize = n` to `db.run`
+
+```scala
+def defaultFetchSize: Int = ...
+```
+
+> Configures the underlying JDBC connection's `setQueryTimeout`. Can be overriden
+> on a per-query basis by passing `queryTimeoutSeconds = n` to `db.run`
+
+```scala
+def defaultQueryTimeoutSeconds: Int = ...
+```
+
+> Translates table and column names from Scala `object` names to SQL names.
+>
+> Use [[tableNameMapper]] and [[columnNameMapper]] if you want different
+> translations for table and column names
+
+```scala
+def nameMapper(v: String): String = ...
+```
+
+> Translates table names from Scala `object` names to SQL names.
+
+```scala
+def tableNameMapper(v: String): String = ...
+```
+
+> Translates column names from Scala `case class` field names to SQL names.
+
+```scala
+def columnNameMapper(v: String): String = ...
+```
+
+> Override this to log the executed SQL queries
+
+```scala
+def logSql(sql: String, file: String, line: Int): Unit = ...
+```
+
+```scala
+object Config
+```
+
+```scala
+def isNormalCharacter(c: Char) = ...
+```
+
+```scala
+def camelToSnake(s: String) = ...
+```
+
+#### `Context.scala`
+
+> The contextual information necessary for rendering a ScalaSql query or expression
+> into a SQL string
+
+```scala
+trait Context
+```
+
+> Any [[From]]/`FROM` clauses that are in scope, and the aliases those clauses are given
+
+```scala
+def fromNaming: Map[Context.From, String]
+```
+
+> Any [[Expr]]s/SQL-expressions that are present in [[fromNaming]], and what those
+> expressions are named in SQL
+
+```scala
+def exprNaming: Map[Expr.Identity, SqlStr]
+```
+
+> Mark [[Expr]]s as a raw value for an INSERT or UPDATE context
+
+```scala
+def valueMarker: Boolean
+```
+
+> The ScalaSql configuration
+
+```scala
+def config: Config
+```
+
+```scala
+def dialectConfig: DialectConfig
+```
+
+```scala
+def withFromNaming(fromNaming: Map[Context.From, String]): Context
+```
+
+```scala
+def withExprNaming(exprNaming: Map[Expr.Identity, SqlStr]): Context
+```
+
+```scala
+def markAsValue: Context
+```
+
+```scala
+object Context
+```
+
+```scala
+trait From
+```
+
+> What alias to name this [[From]] for better readability
+
+```scala
+def fromRefPrefix(prevContext: Context): String
+```
+
+> A mapping of any aliased [[Expr]] that this [[From]] produces along
+> with their rendered [[SqlStr]]s
+
+```scala
+def fromExprAliases(prevContext: Context): Seq[(Expr.Identity, SqlStr)]
+```
+
+> How this [[From]] can be rendered into a [[SqlStr]] for embedding into
+> a larger query
+
+```scala
+def renderSql(
+        name: SqlStr,
+        prevContext: Context,
+        liveExprs: LiveExprs
+    ): SqlStr
+```
+
+```scala
+case class Impl(
+      fromNaming: Map[From, String],
+      exprNaming: Map[Expr.Identity, SqlStr],
+      valueMarker: Boolean,
+      config: Config,
+      dialectConfig: DialectConfig
+  ) extends Context
+```
+
+```scala
+def withFromNaming(fromNaming: Map[From, String]): Context = ...
+```
+
+```scala
+def withExprNaming(exprNaming: Map[Expr.Identity, SqlStr]): Context = ...
+```
+
+```scala
+def markAsValue: Context = ...
+```
+
+> Derives a new [[Context]] based on [[prevContext]] with additional [[prefixedFroms]]
+> and [[unPrefixedFroms]] added to the [[Context.fromNaming]] and [[Context.exprNaming]]
+> tables
+
+```scala
+def compute(prevContext: Context, prefixedFroms: Seq[From], unPrefixedFroms: Option[From]) = ...
+```
+
+#### `DbApi.scala`
+
+> An interface to the SQL database allowing you to run queries.
+
+```scala
+trait DbApi extends AutoCloseable
+```
+
+> Converts the given query [[Q]] into a string. Useful for debugging and logging
+
+```scala
+def renderSql[Q, R](query: Q, castParams: Boolean = false)(implicit qr: Queryable[Q, R]): String
+```
+
+> Runs the given query [[Q]] and returns a value of type [[R]]
+
+```scala
+def run[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit qr: Queryable[Q, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): R
+```
+
+> Runs the given [[SqlStr]] of the form `sql"..."` and returns a value of type [[R]]
+
+```scala
+def runSql[R](query: SqlStr, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): IndexedSeq[R]
+```
+
+> Runs the given query [[Q]] and returns a [[Generator]] of values of type [[R]].
+> allow you to process the results in a streaming fashion without materializing
+> the entire list of results in memory
+
+```scala
+def stream[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit qr: Queryable[Q, Seq[R]],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): Generator[R]
+```
+
+> A combination of [[stream]] and [[runSql]], [[streamSql]] allows you to pass in an
+> arbitrary [[SqlStr]] of the form `sql"..."` and  streams the results back to you
+
+```scala
+def streamSql[R](sql: SqlStr, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): Generator[R]
+```
+
+> Runs a `java.lang.String` (and any interpolated variables) and deserializes
+> the result set into a `Seq` of the given type [[R]]
+
+```scala
+def runRaw[R](
+      sql: String,
+      variables: Seq[Any] = Nil,
+      fetchSize: Int = -1,
+      queryTimeoutSeconds: Int = -1
+  )(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): IndexedSeq[R]
+```
+
+> Runs a `java.lang.String` (and any interpolated variables) and deserializes
+> the result set into a streaming `Generator` of the given type [[R]]
+
+```scala
+def streamRaw[R](
+      sql: String,
+      variables: Seq[Any] = Nil,
+      fetchSize: Int = -1,
+      queryTimeoutSeconds: Int = -1
+  )(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): Generator[R]
+```
+
+> Runs an [[SqlStr]] of the form `sql"..."` containing an `UPDATE` or `INSERT` query and returns the
+> number of rows affected
+
+```scala
+def updateSql(sql: SqlStr, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): Int
+```
+
+> Runs an `java.lang.String` (and any interpolated variables) containing an
+> `UPDATE` or `INSERT` query and returns the number of rows affected
+
+```scala
+def updateRaw(
+      sql: String,
+      variables: Seq[Any] = Nil,
+      fetchSize: Int = -1,
+      queryTimeoutSeconds: Int = -1
+  )(implicit fileName: sourcecode.FileName, lineNum: sourcecode.Line): Int
+```
+
+```scala
+def updateGetGeneratedKeysSql[R](sql: SqlStr, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): IndexedSeq[R]
+```
+
+```scala
+def updateGetGeneratedKeysRaw[R](
+      sql: String,
+      variables: Seq[Any] = Nil,
+      fetchSize: Int = -1,
+      queryTimeoutSeconds: Int = -1
+  )(
+      implicit qr: Queryable.Row[?, R],
+      fileName: sourcecode.FileName,
+      lineNum: sourcecode.Line
+  ): IndexedSeq[R]
+```
+
+```scala
+object DbApi
+```
+
+```scala
+def unpackQueryable[R, Q](
+      query: Q,
+      qr: Queryable[Q, R],
+      config: Config,
+      dialectConfig: DialectConfig
+  ) = ...
+```
+
+```scala
+def renderSql[Q, R](query: Q, config: Config, dialectConfig: DialectConfig)(
+      implicit qr: Queryable[Q, R]
+  ): String = ...
+```
+
+> A listener that can be added to a [[DbApi.Txn]] to be notified of commit and rollback events.
+>
+> The default implementations of these methods do nothing, but you can override them to
+> implement your own behavior.
+
+```scala
+trait TransactionListener
+```
+
+> Called when a new transaction is started.
+
+```scala
+def begin(): Unit = ...
+```
+
+> Called before the transaction is committed.
+>
+> If this method throws an exception, the transaction will be rolled back and the exception
+> will be propagated.
+
+```scala
+def beforeCommit(): Unit = ...
+```
+
+> Called after the transaction is committed.
+>
+> If this method throws an exception, it will be propagated.
+
+```scala
+def afterCommit(): Unit = ...
+```
+
+> Called before the transaction is rolled back.
+>
+> If this method throws an exception, the transaction will be rolled back and the exception
+> will be propagated to the caller of rollback().
+
+```scala
+def beforeRollback(): Unit = ...
+```
+
+> Called after the transaction is rolled back.
+>
+> If this method throws an exception, it will be propagated to the caller of rollback().
+
+```scala
+def afterRollback(): Unit = ...
+```
+
+> An interface to a SQL database *transaction*, allowing you to run queries,
+> create savepoints, or roll back the transaction.
+
+```scala
+trait Txn extends DbApi
+```
+
+> Returns a [[UseBlock]] that creates a SQL Savepoint that is active within the given block; automatically
+> releases the savepoint if the block completes successfully and rolls it back
+> if the block terminates with an exception, and allows you to roll back the
+> savepoint manually via the [[DbApi.Savepoint]] parameter passed to that block
+
+```scala
+def savepoint: UseBlock[DbApi.Savepoint]
+```
+
+> Rolls back any active Savepoints and then rolls back this Transaction
+
+```scala
+def rollback(): Unit
+```
+
+```scala
+def addTransactionListener(listener: TransactionListener): Unit
+```
+
+> A SQL `SAVEPOINT`, with an ID, name, and the ability to roll back to when it was created
+
+```scala
+trait Savepoint
+```
+
+```scala
+def savepointId: Int
+```
+
+```scala
+def savepointName: String
+```
+
+```scala
+def rollback(): Unit
+```
+
+```scala
+class Impl(
+      connection: java.sql.Connection,
+      config: Config,
+      dialect: DialectConfig,
+      defaultListeners: Iterable[TransactionListener],
+      autoCommit: Boolean
+  ) extends DbApi.Txn
+```
+
+```scala
+val listeners = ...
+```
+
+```scala
+override def addTransactionListener(listener: TransactionListener): Unit = ...
+```
+
+```scala
+def run[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+        implicit qr: Queryable[Q, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): R = ...
+```
+
+```scala
+def stream[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+        implicit qr: Queryable[Q, Seq[R]],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): Generator[R] = ...
+```
+
+```scala
+def runSql[R](
+        sql: SqlStr,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): IndexedSeq[R] = ...
+```
+
+```scala
+def streamSql[R](
+        sql: SqlStr,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): Generator[R] = ...
+```
+
+```scala
+def updateSql(sql: SqlStr, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
+        implicit fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): Int = ...
+```
+
+```scala
+def updateGetGeneratedKeysSql[R](
+        sql: SqlStr,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): IndexedSeq[R] = ...
+```
+
+```scala
+def runRaw[R](
+        sql: String,
+        variables: Seq[Any] = Nil,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): IndexedSeq[R] = ...
+```
+
+```scala
+def streamRaw[R](
+        sql: String,
+        variables: Seq[Any] = Nil,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): Generator[R] = ...
+```
+
+```scala
+def updateRaw(
+        sql: String,
+        variables: Seq[Any] = Nil,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(implicit fileName: sourcecode.FileName, lineNum: sourcecode.Line): Int = ...
+```
+
+```scala
+def updateGetGeneratedKeysRaw[R](
+        sql: String,
+        variables: Seq[Any] = Nil,
+        fetchSize: Int = -1,
+        queryTimeoutSeconds: Int = -1
+    )(
+        implicit qr: Queryable.Row[?, R],
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): IndexedSeq[R] = ...
+```
+
+```scala
+def streamFlattened0[R](
+        construct: Queryable.ResultSetIterator => R,
+        flattened: SqlStr.Flattened,
+        fetchSize: Int,
+        queryTimeoutSeconds: Int,
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ) = ...
+```
+
+```scala
+def streamRaw0[R](
+        construct: Queryable.ResultSetIterator => R,
+        sql: String,
+        variables: Seq[(PreparedStatement, Int) => Unit],
+        fetchSize: Int,
+        queryTimeoutSeconds: Int,
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ) = ...
+```
+
+```scala
+def runRawUpdate0(
+        sql: String,
+        variables: Seq[(PreparedStatement, Int) => Unit],
+        fetchSize: Int,
+        queryTimeoutSeconds: Int,
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    ): Int = ...
+```
+
+```scala
+def runRawUpdateGetGeneratedKeys0[R](
+        sql: String,
+        variables: Seq[(PreparedStatement, Int) => Unit],
+        fetchSize: Int,
+        queryTimeoutSeconds: Int,
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line,
+        qr: Queryable.Row[?, R]
+    ): IndexedSeq[R] = ...
+```
+
+```scala
+def configureRunCloseStatement[P <: Statement, T](
+        statement: P,
+        fetchSize: Int,
+        queryTimeoutSeconds: Int,
+        sql: String,
+        fileName: sourcecode.FileName,
+        lineNum: sourcecode.Line
+    )(f: P => T): T = ...
+```
+
+```scala
+def renderSql[Q, R](query: Q, castParams: Boolean = false)(
+        implicit qr: Queryable[Q, R]
+    ): String = ...
+```
+
+```scala
+lazy val savepoint: UseBlock[DbApi.Savepoint] = ...
+```
+
+```scala
+def rollback(): Unit = ...
+```
+
+> Attempts rollback, adding any exceptions as suppressed to the cause
+
+```scala
+def rollbackCause(cause: Throwable): Unit = ...
+```
+
+```scala
+def close() = ...
+```
+
+```scala
+class SavepointImpl(savepoint: java.sql.Savepoint, rollback0: () => Unit) extends Savepoint
+```
+
+```scala
+def savepointId = ...
+```
+
+```scala
+def savepointName = ...
+```
+
+```scala
+def rollback() = ...
+```
+
+#### `DbClient.scala`
+
+> A database client. Primarily allows you to access the database within a [[transaction]]
+> block or via [[getAutoCommitClientConnection]]
+
+```scala
+trait DbClient
+```
+
+> Converts the given query [[Q]] into a string. Useful for debugging and logging
+
+```scala
+def renderSql[Q, R](query: Q, castParams: Boolean = false)(implicit qr: Queryable[Q, R]): String
+```
+
+> Returns a [[UseBlock]] for database transaction, automatically committing it
+> if the block returns successfully and rolling it back if the blow fails with an uncaught
+> exception. Within the block, you provides a [[DbApi.Txn]] you can use to run queries, create
+> savepoints, or roll back the transaction.
+
+```scala
+def transaction: UseBlock[DbApi.Txn]
+```
+
+> Provides a [[DbApi]] that you can use to run queries in "auto-commit" mode, such
+> that every query runs in its own transaction and is committed automatically on-completion.
+>
+> This can be useful for interactive testing, but requires that you manually manage the
+> closing of the connection to avoid leaking connections (if using a connection pool like
+> HikariCP), and should be avoided in most production environments in favor of
+> `.transaction{...}` blocks.
+
+```scala
+def getAutoCommitClientConnection: DbApi
+```
+
+```scala
+object DbClient
+```
+
+```scala
+class Connection(
+      connection: java.sql.Connection,
+      config: Config = new Config {},
+      /** Listeners that are added to all transactions created by this connection */
+      listeners: Seq[DbApi.TransactionListener] = Seq.empty
+  )(implicit dialect: DialectConfig)
+```
+
+```scala
+def renderSql[Q, R](query: Q, castParams: Boolean = false)(
+        implicit qr: Queryable[Q, R]
+    ): String = ...
+```
+
+```scala
+lazy val transaction: UseBlock[DbApi.Txn] = ...
+```
+
+```scala
+def getAutoCommitClientConnection: DbApi = ...
+```
+
+```scala
+class DataSource(
+      dataSource: javax.sql.DataSource,
+      config: Config = new Config {},
+      /** Listeners that are added to all transactions created through the [[DataSource]] */
+      listeners: Seq[DbApi.TransactionListener] = Seq.empty
+  )(implicit dialect: DialectConfig)
+```
+
+> Returns a new [[DataSource]] with the given listener added
+
+```scala
+def withTransactionListener(listener: DbApi.TransactionListener): DbClient = ...
+```
+
+```scala
+def renderSql[Q, R](query: Q, castParams: Boolean = false)(
+        implicit qr: Queryable[Q, R]
+    ): String = ...
+```
+
+```scala
+lazy val withConnection: UseBlock[Connection] = ...
+```
+
+```scala
+lazy val transaction: UseBlock[DbApi.Txn] = ...
+```
+
+```scala
+def getAutoCommitClientConnection: DbApi = ...
+```
+
+#### `DialectConfig.scala`
+
+```scala
+trait DialectConfig
+```
+
+```scala
+def castParams: Boolean
+```
+
+```scala
+def escape(str: String): String
+```
+
+```scala
+def supportSavepointRelease: Boolean
+```
+
+```scala
+def withCastParams(params: Boolean) = ...
+```
+
+#### `DialectTypeMappers.scala`
+
+> A default set of data type mappers that need to be present in any ScalaSql dialect
+
+```scala
+trait DialectTypeMappers extends DialectConfig
+```
+
+```scala
+implicit val dialectSelf: DialectTypeMappers
+```
+
+```scala
+implicit def StringType: TypeMapper[String]
+```
+
+```scala
+implicit def ByteType: TypeMapper[Byte]
+```
+
+```scala
+implicit def ShortType: TypeMapper[Short]
+```
+
+```scala
+implicit def IntType: TypeMapper[Int]
+```
+
+```scala
+implicit def LongType: TypeMapper[Long]
+```
+
+```scala
+implicit def FloatType: TypeMapper[Float]
+```
+
+```scala
+implicit def DoubleType: TypeMapper[Double]
+```
+
+```scala
+implicit def BigDecimalType: TypeMapper[scala.math.BigDecimal]
+```
+
+```scala
+implicit def BooleanType: TypeMapper[Boolean]
+```
+
+```scala
+implicit def UuidType: TypeMapper[UUID]
+```
+
+```scala
+implicit def BytesType: TypeMapper[geny.Bytes]
+```
+
+```scala
+implicit def UtilDateType: TypeMapper[java.util.Date]
+```
+
+```scala
+implicit def LocalDateType: TypeMapper[LocalDate]
+```
+
+```scala
+implicit def LocalTimeType: TypeMapper[LocalTime]
+```
+
+```scala
+implicit def LocalDateTimeType: TypeMapper[LocalDateTime]
+```
+
+```scala
+implicit def ZonedDateTimeType: TypeMapper[ZonedDateTime]
+```
+
+```scala
+implicit def InstantType: TypeMapper[Instant]
+```
+
+```scala
+implicit def OffsetTimeType: TypeMapper[OffsetTime]
+```
+
+```scala
+implicit def OffsetDateTimeType: TypeMapper[OffsetDateTime]
+```
+
+```scala
+implicit def EnumType[T <: Enumeration#Value](implicit constructor: String => T): TypeMapper[T]
+```
+
+```scala
+implicit def OptionType[T](implicit inner: TypeMapper[T]): TypeMapper[Option[T]]
+```
+
+#### `Expr.scala`
+
+> A single "value" in your SQL query that can be mapped to and from
+> a Scala value of a particular type [[T]]
+
+```scala
+trait Expr[T] extends SqlStr.Renderable
+```
+
+```scala
+override def toString: String = ...
+```
+
+```scala
+override def equals(other: Any): Boolean = ...
+```
+
+```scala
+object Expr
+```
+
+```scala
+def isLiteralTrue[T](e: Expr[T]): Boolean = ...
+```
+
+```scala
+def toString[T](e: Expr[T]): String = ...
+```
+
+```scala
+def identity[T](e: Expr[T]): Identity = ...
+```
+
+```scala
+class Identity()
+```
+
+```scala
+implicit def ExprQueryable[E[_] <: Expr[?], T](
+      implicit mt: TypeMapper[T]
+  ): Queryable.Row[E[T], T] = ...
+```
+
+```scala
+class ExprQueryable[E[_] <: Expr[?], T](
+      implicit tm: TypeMapper[T]
+  ) extends Queryable.Row[E[T], T]
+```
+
+```scala
+def walkLabels(): Seq[List[String]] = ...
+```
+
+```scala
+def walkExprs(q: E[T]): Seq[Expr[?]] = ...
+```
+
+```scala
+override def construct(args: Queryable.ResultSetIterator): T = ...
+```
+
+```scala
+def deconstruct(r: T): E[T] = ...
+```
+
+```scala
+def apply[T](f: Context => SqlStr): Expr[T] = ...
+```
+
+```scala
+implicit def optionalize[T](e: Expr[T]): Expr[Option[T]] = ...
+```
+
+```scala
+class Simple[T](f: Context => SqlStr) extends Expr[T]
+```
+
+```scala
+def renderToSql0(implicit ctx: Context): SqlStr = ...
+```
+
+```scala
+implicit def apply[T](
+      x: T
+  )(implicit conv: T => SqlStr.Interp): Expr[T] = ...
+```
+
+```scala
+def apply0[T](
+      x: T,
+      exprIsLiteralTrue0: Boolean = false
+  )(implicit conv: T => SqlStr.Interp): Expr[T] = ...
+```
+
+#### `ExprsToSql.scala`
+
+```scala
+object ExprsToSql
+```
+
+```scala
+def apply(walked: Queryable.Walked, context: Context, prefix: SqlStr): SqlStr = ...
+```
+
+```scala
+def selectColumnSql(walked: Queryable.Walked, ctx: Context): Seq[(String, SqlStr)] = ...
+```
+
+```scala
+def selectColumnReferences(
+      walked: Queryable.Walked,
+      ctx: Context
+  ): Seq[(Expr.Identity, SqlStr)] = ...
+```
+
+```scala
+def booleanExprs(prefix: SqlStr, exprs: Seq[Expr[?]])(implicit ctx: Context) = ...
+```
+
+#### `FastAccumulator.scala`
+
+```scala
+class FastAccumulator[T: ClassTag](startSize: Int = 16)
+```
+
+```scala
+val arr = ...
+```
+
+#### `Generated.scala`
+
+```scala
+trait QueryableRow
+```
+
+```scala
+implicit def Tuple2Queryable[Q1, Q2, R1, R2](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2]
+  ): Queryable.Row[(Q1, Q2), (R1, R2)] = ...
+```
+
+```scala
+implicit def Tuple3Queryable[Q1, Q2, Q3, R1, R2, R3](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3]
+  ): Queryable.Row[(Q1, Q2, Q3), (R1, R2, R3)] = ...
+```
+
+```scala
+implicit def Tuple4Queryable[Q1, Q2, Q3, Q4, R1, R2, R3, R4](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4), (R1, R2, R3, R4)] = ...
+```
+
+```scala
+implicit def Tuple5Queryable[Q1, Q2, Q3, Q4, Q5, R1, R2, R3, R4, R5](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5), (R1, R2, R3, R4, R5)] = ...
+```
+
+```scala
+implicit def Tuple6Queryable[Q1, Q2, Q3, Q4, Q5, Q6, R1, R2, R3, R4, R5, R6](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6), (R1, R2, R3, R4, R5, R6)] = ...
+```
+
+```scala
+implicit def Tuple7Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, R1, R2, R3, R4, R5, R6, R7](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7), (R1, R2, R3, R4, R5, R6, R7)] = ...
+```
+
+```scala
+implicit def Tuple8Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, R1, R2, R3, R4, R5, R6, R7, R8](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8), (R1, R2, R3, R4, R5, R6, R7, R8)] = ...
+```
+
+```scala
+implicit def Tuple9Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, R1, R2, R3, R4, R5, R6, R7, R8, R9](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9), (R1, R2, R3, R4, R5, R6, R7, R8, R9)] = ...
+```
+
+```scala
+implicit def Tuple10Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10)] = ...
+```
+
+```scala
+implicit def Tuple11Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11)] = ...
+```
+
+```scala
+implicit def Tuple12Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12)] = ...
+```
+
+```scala
+implicit def Tuple13Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13)] = ...
+```
+
+```scala
+implicit def Tuple14Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14)] = ...
+```
+
+```scala
+implicit def Tuple15Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15)] = ...
+```
+
+```scala
+implicit def Tuple16Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16)] = ...
+```
+
+```scala
+implicit def Tuple17Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17)] = ...
+```
+
+```scala
+implicit def Tuple18Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18)] = ...
+```
+
+```scala
+implicit def Tuple19Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19)] = ...
+```
+
+```scala
+implicit def Tuple20Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20)] = ...
+```
+
+```scala
+implicit def Tuple21Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20], q21: Queryable.Row[Q21, R21]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21)] = ...
+```
+
+```scala
+implicit def Tuple22Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, Q22, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20], q21: Queryable.Row[Q21, R21], q22: Queryable.Row[Q22, R22]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, Q22), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22)] = ...
+```
+
+#### `JoinNullable.scala`
+
+> Represents a set of nullable columns that come from a `LEFT`/`RIGHT`/`OUTER` `JOIN`
+> clause.
+
+```scala
+trait JoinNullable[Q]
+```
+
+```scala
+def get: Q
+```
+
+```scala
+def isEmpty[T](f: Q => Expr[T])(implicit qr: Queryable[Q, ?]): Expr[Boolean]
+```
+
+```scala
+def nonEmpty[T](f: Q => Expr[T])(implicit qr: Queryable[Q, ?]): Expr[Boolean]
+```
+
+```scala
+def map[V](f: Q => V): JoinNullable[V]
+```
+
+```scala
+object JoinNullable
+```
+
+```scala
+implicit def toExpr[T](n: JoinNullable[Expr[T]])(implicit mt: TypeMapper[T]): Expr[Option[T]] = ...
+```
+
+```scala
+def apply[Q](t: Q): JoinNullable[Q] = ...
+```
+
+#### `LiveSqlExprs.scala`
+
+> Models a set of live [[Expr]] expressions which need to be rendered;
+> [[Expr]] expressions not in this set can be skipped during rendering
+> to improve the conciseness of the rendered SQL string.
+>
+> - `None` is used to indicate this is a top-level context and we want
+> all expressions to be rendered
+>
+> - `Some(set)` indicates that only the expressions present in the `set`
+> need to be rendered, and the rest can be elided.
+>
+> Typically downstream parts of a SQL query (e.g. the outer `SELECT`) are
+> rendered before the upstream parts (e.g. `FROM (SELECT ...)` subqueries),
+> so the [[LiveExprs]] from the downstream parts can be used to decide
+> which columns to skip when rendering the upstream parts. The outermost
+> `SELECT` is rendered using [[LiveExprs.none]] since we cannot know what
+> columns end up being used in the application code after the query has
+> finished running, and thus have to preserve all of them
+
+```scala
+class LiveExprs(val values: Option[Set[Expr.Identity]])
+```
+
+```scala
+def map(f: Set[Expr.Identity] => Set[Expr.Identity]) = ...
+```
+
+```scala
+def isLive(e: Expr.Identity) = ...
+```
+
+```scala
+object LiveExprs
+```
+
+```scala
+def some(v: Set[Expr.Identity]) = ...
+```
+
+```scala
+def none = ...
+```
+
+#### `Queryable.scala`
+
+> Typeclass to indicate that we are able to evaluate a query of type [[Q]] to
+> return a result of type [[R]]. Involves two operations: flattening a structured
+> query to a flat list of expressions via [[walkLabelsAndExprs]], and reading a JSON-ish
+> tree-shaped blob back into a return value via [[valueReader]]
+
+```scala
+trait Queryable[-Q, R]
+```
+
+> Whether this queryable value is executed using `java.sql.Statement.getGeneratedKeys`
+> instead of `.executeQuery`.
+
+```scala
+def isGetGeneratedKeys(q: Q): Option[Queryable.Row[?, ?]]
+```
+
+> Whether this queryable value is executed using `java.sql.Statement.executeUpdate`
+> instead of `.executeQuery`. Note that this needs to be known ahead of time, and
+> cannot be discovered by just calling `.execute`, because some JDBC drivers do not
+> properly handle updates in the `.execute` call
+
+```scala
+def isExecuteUpdate(q: Q): Boolean
+```
+
+> Returns a sequence of labels, each represented by a list of tokens, representing
+> the expressions created by this queryable value. Used to add `AS foo_bar` labels
+> to the generated queries, to aid in readability
+
+```scala
+def walkLabels(q: Q): Seq[List[String]]
+```
+
+> Returns a sequence of expressions created by this queryable value. Used to generate
+> the column list `SELECT` clauses, both for nested and top level `SELECT`s
+
+```scala
+def walkExprs(q: Q): Seq[Expr[?]]
+```
+
+```scala
+def walkLabelsAndExprs(q: Q): Queryable.Walked = ...
+```
+
+> Whether this query expects a single row to be returned, if so we can assert on
+> the number of rows and raise an error if 0 rows or 2+ rows are present
+
+```scala
+def isSingleRow(q: Q): Boolean
+```
+
+> Converts the given queryable value into a [[SqlStr]], that can then be executed
+> by the underlying SQL JDBC interface
+
+```scala
+def renderSql(q: Q, ctx: Context): SqlStr
+```
+
+> Construct a Scala return value from the [[Queryable.ResultSetIterator]] representing
+> the return value of this queryable value
+
+```scala
+def construct(q: Q, args: Queryable.ResultSetIterator): R
+```
+
+```scala
+object Queryable
+```
+
+```scala
+type Walked = ...
+```
+
+```scala
+class ResultSetIterator(r: ResultSet)
+```
+
+```scala
+var index = ...
+```
+
+```scala
+var nulls = ...
+```
+
+```scala
+var nonNulls = ...
+```
+
+```scala
+def consumeNulls(columnsCount: Int): Boolean = ...
+```
+
+```scala
+def get[T](mt: TypeMapper[T]) = ...
+```
+
+> A [[Queryable]] that represents a part of a single database row. [[Queryable.Row]]s
+> can be nested within other [[Queryable]]s, but [[Queryable]]s in general cannot. e.g.
+>
+> - `Select[Int]` is valid because `Select[Q]` takes a `Queryable.Row[Q]`, and
+> there is a `Queryable.Row[Int]` available
+>
+> - `Select[Select[Int]]` is invalid because although there is a `Queryable[Select[Q]]`
+> available, there is no `Queryable.Row[Select[Q]]`, as `Select[Q]` returns multiple rows
+
+```scala
+trait Row[Q, R] extends Queryable[Q, R]
+```
+
+```scala
+def isGetGeneratedKeys(q: Q): Option[Queryable.Row[?, ?]] = ...
+```
+
+```scala
+def isExecuteUpdate(q: Q): Boolean = ...
+```
+
+```scala
+def isSingleRow(q: Q): Boolean = ...
+```
+
+```scala
+def walkLabels(): Seq[List[String]]
+```
+
+```scala
+def walkLabels(q: Q): Seq[List[String]] = ...
+```
+
+```scala
+def renderSql(q: Q, ctx: Context): SqlStr = ...
+```
+
+```scala
+def construct(q: Q, args: ResultSetIterator): R = ...
+```
+
+```scala
+def construct(args: ResultSetIterator): R
+```
+
+> Takes the Scala-value of type [[R]] and converts it into a database-value of type [[Q]],
+> potentially representing multiple columns. Used for inserting Scala values into `INSERT`
+> or `VALUES` clauses
+
+```scala
+def deconstruct(r: R): Q
+```
+
+```scala
+object Row extends scalasql.core.generated.QueryableRow
+```
+
+```scala
+implicit def NullableQueryable[Q, R](
+        implicit qr: Queryable.Row[Q, R]
+    ): Queryable.Row[JoinNullable[Q], Option[R]] = ...
+```
+
+#### `SqlStr.scala`
+
+> A SQL query with interpolated `?`s expressions and the associated
+> interpolated values, of type [[Interp]]. Accumulates SQL snippets, parameters,
+> and referenced expressions in a tree structure to minimize copying overhead,
+> until [[SqlStr.flatten]] is called to convert it into a [[SqlStr.Flattened]]
+
+```scala
+class SqlStr(
+    private val queryParts: Array[CharSequence],
+    private val interps: Array[SqlStr.Interp],
+    val isCompleteQuery: Boolean,
+    private val referencedExprs: Array[Expr.Identity]
+) extends SqlStr.Renderable
+```
+
+```scala
+def +(other: SqlStr) = ...
+```
+
+```scala
+def withCompleteQuery(v: Boolean) = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+object SqlStr
+```
+
+> Represents a [[SqlStr]] that has been flattened out into a single set of
+> parallel arrays, allowing you to render it or otherwise make use of its data.
+
+```scala
+class Flattened(
+      val queryParts: Array[CharSequence],
+      val interps0: Array[Interp],
+      isCompleteQuery: Boolean,
+      val referencedExprs: Array[Expr.Identity]
+  ) extends SqlStr(queryParts, interps0, isCompleteQuery, referencedExprs)
+```
+
+```scala
+def interpsIterator = ...
+```
+
+```scala
+def renderSql(castParams: Boolean) = ...
+```
+
+> Helper method turn an `Option[T]` into a [[SqlStr]], returning
+> the empty string if the `Option` is `None`
+
+```scala
+def opt[T](t: Option[T])(f: T => SqlStr) = ...
+```
+
+> Helper method turn an `Seq[T]` into a [[SqlStr]], returning
+> the empty string if the `Seq` is empty
+
+```scala
+def optSeq[T](t: Seq[T])(f: Seq[T] => SqlStr) = ...
+```
+
+> Flattens out a [[SqlStr]] into a single flattened [[SqlStr.Flattened]] object,
+> at which point you can use its `queryParts`, `params`, `referencedExprs`, etc.
+
+```scala
+def flatten(self: SqlStr): Flattened = ...
+```
+
+> Provides the sql"..." syntax for constructing [[SqlStr]]s
+
+```scala
+implicit class SqlStringSyntax(sc: StringContext)
+```
+
+```scala
+def sql(args: Interp*) = ...
+```
+
+> Joins a `Seq` of [[SqlStr]]s into a single [[SqlStr]] using the given [[sep]] separator
+
+```scala
+def join(strs: IterableOnce[SqlStr], sep: SqlStr = empty): SqlStr = ...
+```
+
+```scala
+lazy val empty = ...
+```
+
+```scala
+lazy val commaSep = ...
+```
+
+> Converts a raw `String` into a [[SqlStr]]. Note that this must be used
+> carefully to avoid SQL injection attacks.
+
+```scala
+def raw(s: String, referencedExprs: Array[Expr.Identity] = emptyIdentityArray) = ...
+```
+
+```scala
+trait Renderable
+```
+
+```scala
+object Renderable
+```
+
+```scala
+def renderSql(x: Renderable)(implicit ctx: Context) = ...
+```
+
+> Something that can be interpolated into a [[SqlStr]].
+
+```scala
+sealed trait Interp
+```
+
+```scala
+object Interp
+```
+
+```scala
+implicit def renderableInterp(t: Renderable)(implicit ctx: Context): Interp = ...
+```
+
+```scala
+implicit def sqlStrInterp(s: SqlStr): Interp = ...
+```
+
+```scala
+case class SqlStrInterp(s: SqlStr) extends Interp
+```
+
+```scala
+implicit def typeInterp[T: TypeMapper](value: T): Interp = ...
+```
+
+```scala
+case class TypeInterp[T: TypeMapper](value: T) extends Interp
+```
+
+```scala
+def mappedType: TypeMapper[T] = ...
+```
+
+#### `TypeMapper.scala`
+
+> A mapping between a Scala type [[T]] and a JDBC type, defined by
+> it's [[jdbcType]], [[castTypeString]], and [[get]] and [[put]] operations.
+>
+> Defaults are provided for most common Scala primitives, but you can also provide
+> your own by defining an `implicit val foo: TypeMapper[T]`
+
+```scala
+trait TypeMapper[T]
+```
+
+> The JDBC type of this type.
+
+```scala
+def jdbcType: JDBCType
+```
+
+> What SQL string to use when you run `cast[T]` to a specific type
+
+```scala
+def castTypeString: String = ...
+```
+
+> How to extract a value of type [[T]] from a `ResultSet`
+
+```scala
+def get(r: ResultSet, idx: Int): T
+```
+
+> How to insert a value of type [[T]] into a `PreparedStatement`
+
+```scala
+def put(r: PreparedStatement, idx: Int, v: T): Unit
+```
+
+> Create a new `TypeMapper[V]` based on this `TypeMapper[T]` given the
+> two conversion functions `f: V => T`, `g: T => V`
+
+```scala
+def bimap[V](f: V => T, g: T => V): TypeMapper[V] = ...
+```
+
+```scala
+object TypeMapper
+```
+
+```scala
+def apply[T](implicit t: TypeMapper[T]): TypeMapper[T] = ...
+```
+
+#### `UseBlock.scala`
+
+> A block abstraction that wraps resource usage with proper acquiring and close/release.
+> Exposes lifecycle operations separately, which is useful for integration with FP effect libraries.
+> Should not be implemented outside of library code, so sealed.
+>
+> @tparam A The resource type provided during the `use` phase
+
+```scala
+sealed trait UseBlock[+A]
+```
+
+> Acquires the resource. Called once at the start of the block.
+> @return The acquired resource and release function.
+
+```scala
+def allocate(): (A, Option[Throwable] => Unit)
+```
+
+> Combines acquire, use, and release into a single operation.
+> Makes it friendly to traditional block-style API.
+
+```scala
+final def apply[T](use: A => T): T = ...
+```
+
+#### `WithSqlExpr.scala`
+
+```scala
+trait WithSqlExpr[Q]
+```
+
+```scala
+object WithSqlExpr
+```
+
+```scala
+def get[Q](v: WithSqlExpr[Q]) = ...
+```
+
+#### `package.scala`
+
+```scala
+package object core
+```
+
+```scala
+type Sc[T] = ...
+```
+
+### `com.lihaoyi:scalasql-query_3:0.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/scalasql-query_3/0.3.1/scalasql-query_3-0.3.1-sources.jar
+
+#### `Aggregate.scala`
+
+```scala
+class Aggregate[Q, R](
+    toSqlStr0: Context => SqlStr,
+    construct0: Queryable.ResultSetIterator => R,
+    protected val expr: Q,
+    protected val qr: Queryable[Q, R]
+) extends Query.DelegateQueryable[Q, R]
+```
+
+#### `Column.scala`
+
+> A variant of [[Expr]] representing a raw table column; allows assignment in updates
+> and inserts
+
+```scala
+class Column[T](tableRef: TableRef, val name: String)(implicit val mappedType: TypeMapper[T])
+```
+
+```scala
+def : = ...
+```
+
+```scala
+def renderToSql0(implicit ctx: Context) = ...
+```
+
+```scala
+object Column
+```
+
+```scala
+case class Assignment[T](column: Column[T], value: Expr[T])
+```
+
+#### `CompoundSelect.scala`
+
+> A SQL `SELECT` query, with
+> `ORDER BY`, `LIMIT`, `OFFSET`, or `UNION` clauses
+
+```scala
+class CompoundSelect[Q, R](
+    val lhs: SimpleSelect[Q, R],
+    val compoundOps: Seq[CompoundSelect.Op[Q, R]],
+    val orderBy: Seq[OrderBy],
+    val limit: Option[Int],
+    val offset: Option[Int]
+)(implicit val qr: Queryable.Row[Q, R], val dialect: DialectTypeMappers)
+```
+
+```scala
+override def map[Q2, R2](f: Q => Q2)(implicit qr2: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+```scala
+override def filter(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+override def sortBy(f: Q => Expr[?]) = ...
+```
+
+```scala
+override def asc: Select[Q, R] = ...
+```
+
+```scala
+override def desc: Select[Q, R] = ...
+```
+
+```scala
+override def nullsFirst: Select[Q, R] = ...
+```
+
+```scala
+override def nullsLast: Select[Q, R] = ...
+```
+
+```scala
+override def compound0(op: String, other: Select[Q, R]) = ...
+```
+
+```scala
+override def drop(n: Int): Select[Q, R] = ...
+```
+
+```scala
+override def take(n: Int): Select[Q, R] = ...
+```
+
+```scala
+object CompoundSelect
+```
+
+```scala
+case class Op[Q, R](op: String, rhs: SimpleSelect[Q, R])
+```
+
+```scala
+class Renderer[Q, R](query: CompoundSelect[Q, R], prevContext: Context)
+```
+
+```scala
+lazy val renderer = ...
+```
+
+```scala
+lazy val lhsExprAliases = ...
+```
+
+```scala
+lazy val context = ...
+```
+
+```scala
+lazy val sortOpt = ...
+```
+
+```scala
+lazy val limitOpt = ...
+```
+
+```scala
+lazy val offsetOpt = ...
+```
+
+```scala
+lazy val newReferencedExpressions = ...
+```
+
+```scala
+lazy val preserveAll = ...
+```
+
+```scala
+def render(liveExprs: LiveExprs) = ...
+```
+
+```scala
+def orderToSqlStr(newCtx: Context) = ...
+```
+
+```scala
+def orderToSqlStr(orderBys: Seq[OrderBy], newCtx: Context, gap: Boolean = false) = ...
+```
+
+#### `Delete.scala`
+
+> A SQL `DELETE` query
+
+```scala
+trait Delete[Q] extends Query.ExecuteUpdate[Int] with Returning.Base[Q]
+```
+
+```scala
+object Delete
+```
+
+```scala
+class Impl[Q](val expr: Q, filter: Expr[Boolean], val table: TableRef)(
+      implicit dialect: DialectTypeMappers
+  ) extends Delete[Q]
+```
+
+```scala
+class Renderer(table: TableRef, expr: Expr[Boolean], prevContext: Context)
+```
+
+```scala
+implicit val implicitCtx: Context = ...
+```
+
+```scala
+lazy val tableNameStr = ...
+```
+
+```scala
+lazy val filtersOpt = ...
+```
+
+```scala
+def render() = ...
+```
+
+#### `FlatJoin.scala`
+
+```scala
+object FlatJoin
+```
+
+```scala
+trait Rhs[Q2, R2]
+```
+
+```scala
+class MapResult[Q, Q2, R, R2](
+      val prefix: String,
+      val from: Context.From,
+      val on: Option[Expr[Boolean]],
+      val qr: Queryable.Row[Q2, R2],
+      val f: Q2,
+      val where: Seq[Expr[Boolean]]
+  ) extends Rhs[Q2, R2]
+```
+
+```scala
+class FlatMapResult[Q, Q2, R, R2](
+      val prefix: String,
+      val from: Context.From,
+      val on: Option[Expr[Boolean]],
+      val qr: Queryable.Row[Q2, R2],
+      val f: Rhs[Q2, R2],
+      val where: Seq[Expr[Boolean]]
+  ) extends Rhs[Q2, R2]
+```
+
+```scala
+class Mapper[Q, Q2, R, R2](
+      prefix: String,
+      from: Context.From,
+      expr: Q,
+      on: Option[Expr[Boolean]],
+      where: Seq[Expr[Boolean]]
+  )
+```
+
+```scala
+def map(f: Q => Q2)(implicit qr: Queryable.Row[Q2, R2]): MapResult[Q, Q2, R, R2] = ...
+```
+
+```scala
+def flatMap(
+        f: Q => Rhs[Q2, R2]
+    )(implicit qr: Queryable.Row[Q2, R2]): FlatMapResult[Q, Q2, R, R2] = ...
+```
+
+```scala
+def filter(x: Q => Expr[Boolean]): Mapper[Q, Q2, R, R2] = ...
+```
+
+```scala
+def withFilter(x: Q => Expr[Boolean]): Mapper[Q, Q2, R, R2] = ...
+```
+
+```scala
+class NullableMapper[Q, Q2, R, R2](
+      prefix: String,
+      from: Context.From,
+      expr: JoinNullable[Q],
+      on: Option[Expr[Boolean]],
+      where: Seq[Expr[Boolean]]
+  )
+```
+
+```scala
+def lateral = ...
+```
+
+```scala
+def map(
+        f: JoinNullable[Q] => Q2
+    )(implicit qr: Queryable.Row[Q2, R2]): MapResult[Q, Q2, R, R2] = ...
+```
+
+```scala
+def flatMap(
+        f: JoinNullable[Q] => Rhs[Q2, R2]
+    )(implicit qr: Queryable.Row[Q2, R2]): FlatMapResult[Q, Q2, R, R2] = ...
+```
+
+```scala
+def filter(x: JoinNullable[Q] => Expr[Boolean]): NullableMapper[Q, Q2, R, R2] = ...
+```
+
+```scala
+def withFilter(x: JoinNullable[Q] => Expr[Boolean]): NullableMapper[Q, Q2, R, R2] = ...
+```
+
+#### `From.scala`
+
+> Models a SQL `FROM` clause
+
+```scala
+class TableRef(val value: Table.Base) extends From
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+def fromRefPrefix(prevContext: Context) = ...
+```
+
+```scala
+def fromExprAliases(prevContext: Context): Seq[(Expr.Identity, SqlStr)] = ...
+```
+
+```scala
+def renderSql(name: SqlStr, prevContext: Context, liveExprs: LiveExprs) = ...
+```
+
+> Models a subquery: a `SELECT`, `VALUES`, nested `WITH`, etc.
+
+```scala
+class SubqueryRef(val value: SubqueryRef.Wrapped) extends From
+```
+
+```scala
+def fromRefPrefix(prevContext: Context): String = ...
+```
+
+```scala
+def fromExprAliases(prevContext: Context) = ...
+```
+
+```scala
+def renderSql(name: SqlStr, prevContext: Context, liveExprs: LiveExprs) = ...
+```
+
+```scala
+object SubqueryRef
+```
+
+```scala
+trait Wrapped
+```
+
+```scala
+object Wrapped
+```
+
+```scala
+def exprAliases(s: Wrapped, prevContext: Context) = ...
+```
+
+```scala
+def renderer(s: Wrapped, prevContext: Context) = ...
+```
+
+```scala
+trait Renderer
+```
+
+```scala
+def render(liveExprs: LiveExprs): SqlStr
+```
+
+```scala
+class WithCteRef(walked: Queryable.Walked) extends From
+```
+
+```scala
+def fromRefPrefix(prevContext: Context) = ...
+```
+
+```scala
+def fromExprAliases(prevContext: Context) = ...
+```
+
+```scala
+def renderSql(name: SqlStr, prevContext: Context, liveExprs: LiveExprs) = ...
+```
+
+#### `Generated.scala`
+
+```scala
+trait Insert[V[_[_]], R]
+```
+
+```scala
+def batched[T1, T2](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2])(
+      items: (Expr[T1], Expr[T2])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3])(
+      items: (Expr[T1], Expr[T2], Expr[T3])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20], f21: V[Column] => Column[T21])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20], Expr[T21])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20], f21: V[Column] => Column[T21], f22: V[Column] => Column[T22])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20], Expr[T21], Expr[T22])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+trait InsertImpl[V[_[_]], R] extends Insert[V, R]
+```
+
+```scala
+def newInsertValues[R](
+        insert: scalasql.query.Insert[V, R],
+        columns: Seq[Column[?]],
+        valuesLists: Seq[Seq[Expr[?]]]
+    )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R]
+```
+
+```scala
+def batched[T1, T2](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2])(
+      items: (Expr[T1], Expr[T2])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3])(
+      items: (Expr[T1], Expr[T2], Expr[T3])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20], f21: V[Column] => Column[T21])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20], Expr[T21])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f1: V[Column] => Column[T1], f2: V[Column] => Column[T2], f3: V[Column] => Column[T3], f4: V[Column] => Column[T4], f5: V[Column] => Column[T5], f6: V[Column] => Column[T6], f7: V[Column] => Column[T7], f8: V[Column] => Column[T8], f9: V[Column] => Column[T9], f10: V[Column] => Column[T10], f11: V[Column] => Column[T11], f12: V[Column] => Column[T12], f13: V[Column] => Column[T13], f14: V[Column] => Column[T14], f15: V[Column] => Column[T15], f16: V[Column] => Column[T16], f17: V[Column] => Column[T17], f18: V[Column] => Column[T18], f19: V[Column] => Column[T19], f20: V[Column] => Column[T20], f21: V[Column] => Column[T21], f22: V[Column] => Column[T22])(
+      items: (Expr[T1], Expr[T2], Expr[T3], Expr[T4], Expr[T5], Expr[T6], Expr[T7], Expr[T8], Expr[T9], Expr[T10], Expr[T11], Expr[T12], Expr[T13], Expr[T14], Expr[T15], Expr[T16], Expr[T17], Expr[T18], Expr[T19], Expr[T20], Expr[T21], Expr[T22])*
+  )(implicit qr: Queryable[V[Column], R]): scalasql.query.InsertColumns[V, R] = ...
+```
+
+```scala
+trait QueryableRow
+```
+
+```scala
+implicit def Tuple2Queryable[Q1, Q2, R1, R2](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2]
+  ): Queryable.Row[(Q1, Q2), (R1, R2)] = ...
+```
+
+```scala
+implicit def Tuple3Queryable[Q1, Q2, Q3, R1, R2, R3](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3]
+  ): Queryable.Row[(Q1, Q2, Q3), (R1, R2, R3)] = ...
+```
+
+```scala
+implicit def Tuple4Queryable[Q1, Q2, Q3, Q4, R1, R2, R3, R4](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4), (R1, R2, R3, R4)] = ...
+```
+
+```scala
+implicit def Tuple5Queryable[Q1, Q2, Q3, Q4, Q5, R1, R2, R3, R4, R5](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5), (R1, R2, R3, R4, R5)] = ...
+```
+
+```scala
+implicit def Tuple6Queryable[Q1, Q2, Q3, Q4, Q5, Q6, R1, R2, R3, R4, R5, R6](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6), (R1, R2, R3, R4, R5, R6)] = ...
+```
+
+```scala
+implicit def Tuple7Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, R1, R2, R3, R4, R5, R6, R7](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7), (R1, R2, R3, R4, R5, R6, R7)] = ...
+```
+
+```scala
+implicit def Tuple8Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, R1, R2, R3, R4, R5, R6, R7, R8](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8), (R1, R2, R3, R4, R5, R6, R7, R8)] = ...
+```
+
+```scala
+implicit def Tuple9Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, R1, R2, R3, R4, R5, R6, R7, R8, R9](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9), (R1, R2, R3, R4, R5, R6, R7, R8, R9)] = ...
+```
+
+```scala
+implicit def Tuple10Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10)] = ...
+```
+
+```scala
+implicit def Tuple11Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11)] = ...
+```
+
+```scala
+implicit def Tuple12Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12)] = ...
+```
+
+```scala
+implicit def Tuple13Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13)] = ...
+```
+
+```scala
+implicit def Tuple14Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14)] = ...
+```
+
+```scala
+implicit def Tuple15Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15)] = ...
+```
+
+```scala
+implicit def Tuple16Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16)] = ...
+```
+
+```scala
+implicit def Tuple17Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17)] = ...
+```
+
+```scala
+implicit def Tuple18Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18)] = ...
+```
+
+```scala
+implicit def Tuple19Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19)] = ...
+```
+
+```scala
+implicit def Tuple20Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20)] = ...
+```
+
+```scala
+implicit def Tuple21Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20], q21: Queryable.Row[Q21, R21]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21)] = ...
+```
+
+```scala
+implicit def Tuple22Queryable[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, Q22, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22](
+      implicit
+      q1: Queryable.Row[Q1, R1], q2: Queryable.Row[Q2, R2], q3: Queryable.Row[Q3, R3], q4: Queryable.Row[Q4, R4], q5: Queryable.Row[Q5, R5], q6: Queryable.Row[Q6, R6], q7: Queryable.Row[Q7, R7], q8: Queryable.Row[Q8, R8], q9: Queryable.Row[Q9, R9], q10: Queryable.Row[Q10, R10], q11: Queryable.Row[Q11, R11], q12: Queryable.Row[Q12, R12], q13: Queryable.Row[Q13, R13], q14: Queryable.Row[Q14, R14], q15: Queryable.Row[Q15, R15], q16: Queryable.Row[Q16, R16], q17: Queryable.Row[Q17, R17], q18: Queryable.Row[Q18, R18], q19: Queryable.Row[Q19, R19], q20: Queryable.Row[Q20, R20], q21: Queryable.Row[Q21, R21], q22: Queryable.Row[Q22, R22]
+  ): Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, Q22), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22)] = ...
+```
+
+```scala
+trait JoinAppend extends scalasql.query.JoinAppendLowPriority
+```
+
+```scala
+implicit def append2[Q1, Q2, QA, R1, R2, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, QA), (R1, R2, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2), QA, (Q1, Q2, QA), (R1, R2, RA)] = ...
+```
+
+```scala
+implicit def append3[Q1, Q2, Q3, QA, R1, R2, R3, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, QA), (R1, R2, R3, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3), QA, (Q1, Q2, Q3, QA), (R1, R2, R3, RA)] = ...
+```
+
+```scala
+implicit def append4[Q1, Q2, Q3, Q4, QA, R1, R2, R3, R4, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, QA), (R1, R2, R3, R4, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4), QA, (Q1, Q2, Q3, Q4, QA), (R1, R2, R3, R4, RA)] = ...
+```
+
+```scala
+implicit def append5[Q1, Q2, Q3, Q4, Q5, QA, R1, R2, R3, R4, R5, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, QA), (R1, R2, R3, R4, R5, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5), QA, (Q1, Q2, Q3, Q4, Q5, QA), (R1, R2, R3, R4, R5, RA)] = ...
+```
+
+```scala
+implicit def append6[Q1, Q2, Q3, Q4, Q5, Q6, QA, R1, R2, R3, R4, R5, R6, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, QA), (R1, R2, R3, R4, R5, R6, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6), QA, (Q1, Q2, Q3, Q4, Q5, Q6, QA), (R1, R2, R3, R4, R5, R6, RA)] = ...
+```
+
+```scala
+implicit def append7[Q1, Q2, Q3, Q4, Q5, Q6, Q7, QA, R1, R2, R3, R4, R5, R6, R7, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, QA), (R1, R2, R3, R4, R5, R6, R7, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, QA), (R1, R2, R3, R4, R5, R6, R7, RA)] = ...
+```
+
+```scala
+implicit def append8[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, QA, R1, R2, R3, R4, R5, R6, R7, R8, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, QA), (R1, R2, R3, R4, R5, R6, R7, R8, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, QA), (R1, R2, R3, R4, R5, R6, R7, R8, RA)] = ...
+```
+
+```scala
+implicit def append9[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, RA)] = ...
+```
+
+```scala
+implicit def append10[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, RA)] = ...
+```
+
+```scala
+implicit def append11[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, RA)] = ...
+```
+
+```scala
+implicit def append12[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, RA)] = ...
+```
+
+```scala
+implicit def append13[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, RA)] = ...
+```
+
+```scala
+implicit def append14[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, RA)] = ...
+```
+
+```scala
+implicit def append15[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, RA)] = ...
+```
+
+```scala
+implicit def append16[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, RA)] = ...
+```
+
+```scala
+implicit def append17[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, RA)] = ...
+```
+
+```scala
+implicit def append18[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, RA)] = ...
+```
+
+```scala
+implicit def append19[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, RA)] = ...
+```
+
+```scala
+implicit def append20[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, RA)] = ...
+```
+
+```scala
+implicit def append21[Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, QA, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, RA](
+        implicit qr0: Queryable.Row[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, RA)],
+        @annotation.nowarn("msg=never used") qr20: Queryable.Row[QA, RA]): scalasql.query.JoinAppend[(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21), QA, (Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15, Q16, Q17, Q18, Q19, Q20, Q21, QA), (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, RA)] = ...
+```
+
+#### `GetGeneratedKeys.scala`
+
+> Represents an [[Insert]] query that you want to call `JdbcStatement.getGeneratedKeys`
+> on to retrieve any auto-generated primary key values from the results
+
+```scala
+trait GetGeneratedKeys[Q, R] extends Query[Seq[R]]
+```
+
+```scala
+def single: Query.Single[R] = ...
+```
+
+```scala
+object GetGeneratedKeys
+```
+
+```scala
+class Impl[Q, R](base: Returning.InsertBase[Q])(implicit qr: Queryable.Row[?, R])
+```
+
+```scala
+def expr = ...
+```
+
+#### `Insert.scala`
+
+> A SQL `INSERT` query
+
+```scala
+trait Insert[V[_[_]], R] extends WithSqlExpr[V[Column]] with scalasql.generated.Insert[V, R]
+```
+
+```scala
+def table: TableRef
+```
+
+```scala
+def qr: Queryable[V[Column], R]
+```
+
+```scala
+def select[C, R2](columns: V[Expr] => C, select: Select[C, R2]): InsertSelect[V, C, R, R2]
+```
+
+```scala
+def columns(f: (V[Column] => Column.Assignment[?])*): InsertColumns[V, R]
+```
+
+```scala
+def values(f: R*): InsertValues[V, R]
+```
+
+```scala
+def batched[T1](f1: V[Column] => Column[T1])(items: Expr[T1]*): InsertColumns[V, R]
+```
+
+```scala
+object Insert
+```
+
+```scala
+class Impl[V[_[_]], R](val expr: V[Column], val table: TableRef)(
+      implicit val qr: Queryable.Row[V[Column], R],
+      dialect: DialectTypeMappers
+  ) extends Insert[V, R]
+      with scalasql.generated.InsertImpl[V, R]
+```
+
+```scala
+def newInsertSelect[C, R, R2](
+        insert: Insert[V, R],
+        columns: C,
+        select: Select[C, R2]
+    ): InsertSelect[V, C, R, R2] = ...
+```
+
+```scala
+def newInsertValues[R](
+        insert: Insert[V, R],
+        columns: Seq[Column[?]],
+        valuesLists: Seq[Seq[Expr[?]]]
+    )(implicit qr: Queryable[V[Column], R]): InsertColumns[V, R] = ...
+```
+
+```scala
+def select[C, R2](columns: V[Expr] => C, select: Select[C, R2]): InsertSelect[V, C, R, R2] = ...
+```
+
+```scala
+def columns(f: (V[Column] => Column.Assignment[?])*): InsertColumns[V, R] = ...
+```
+
+```scala
+def batched[T1](f1: V[Column] => Column[T1])(items: Expr[T1]*): InsertColumns[V, R] = ...
+```
+
+```scala
+override def values(values: R*): InsertValues[V, R] = ...
+```
+
+#### `InsertColumns.scala`
+
+> A SQL `INSERT VALUES` query
+
+```scala
+trait InsertColumns[V[_[_]], R]
+    extends Returning.InsertBase[V[Column]]
+    with Query.ExecuteUpdate[Int]
+```
+
+```scala
+def columns: Seq[Column[?]]
+```
+
+```scala
+def valuesLists: Seq[Seq[Expr[?]]]
+```
+
+```scala
+object InsertColumns
+```
+
+```scala
+class Impl[V[_[_]], R](
+      insert: Insert[V, R],
+      val columns: Seq[Column[?]],
+      val valuesLists: Seq[Seq[Expr[?]]]
+  )(implicit val qr: Queryable[V[Column], R], dialect: DialectTypeMappers)
+```
+
+```scala
+def table = ...
+```
+
+```scala
+class Renderer(
+      columns0: Seq[Column[?]],
+      prevContext: Context,
+      valuesLists: Seq[Seq[Expr[?]]],
+      tableName: String
+  )
+```
+
+```scala
+implicit lazy val ctx: Context = ...
+```
+
+```scala
+lazy val columns = ...
+```
+
+```scala
+lazy val values = ...
+```
+
+```scala
+def render() = ...
+```
+
+#### `InsertSelect.scala`
+
+> A SQL `INSERT SELECT` query
+
+```scala
+trait InsertSelect[V[_[_]], C, R, R2]
+    extends Returning.InsertBase[V[Column]]
+    with Query.ExecuteUpdate[Int]
+```
+
+```scala
+object InsertSelect
+```
+
+```scala
+class Impl[V[_[_]], C, R, R2](insert: Insert[V, R], columns: C, select: Select[C, R2])(
+      implicit dialect: DialectTypeMappers
+  ) extends InsertSelect[V, C, R, R2]
+```
+
+```scala
+def table = ...
+```
+
+```scala
+class Renderer(
+      select: Select[?, ?],
+      exprs: Seq[Expr[?]],
+      prevContext: Context,
+      tableName: String
+  )
+```
+
+```scala
+implicit lazy val ctx: Context = ...
+```
+
+```scala
+lazy val columns = ...
+```
+
+```scala
+lazy val selectSql = ...
+```
+
+```scala
+lazy val tableNameStr = ...
+```
+
+```scala
+def render() = ...
+```
+
+#### `InsertValues.scala`
+
+```scala
+trait InsertValues[V[_[_]], R]
+    extends Returning.InsertBase[V[Column]]
+    with Query.ExecuteUpdate[Int]
+```
+
+```scala
+def skipColumns(x: (V[Column] => Column[?])*): InsertValues[V, R]
+```
+
+```scala
+object InsertValues
+```
+
+```scala
+class Impl[V[_[_]], R](
+      insert: Insert[V, R],
+      values: Seq[R],
+      dialect: DialectTypeMappers,
+      qr: Queryable.Row[V[Column], R],
+      skippedColumns: Seq[Column[?]]
+  ) extends InsertValues[V, R]
+```
+
+```scala
+def table = ...
+```
+
+```scala
+override def skipColumns(x: (V[Column] => Column[?])*): InsertValues[V, R] = ...
+```
+
+```scala
+class Renderer[Q, R](
+      tableName: String,
+      columnsList0: Seq[String],
+      valuesList: Seq[R],
+      qr: Queryable.Row[Q, R],
+      skippedColumns: Seq[Column[?]]
+  )(implicit ctx: Context)
+```
+
+```scala
+lazy val skippedColumnsNames = ...
+```
+
+```scala
+lazy val (liveCols, liveIndices) = ...
+```
+
+```scala
+lazy val columns = ...
+```
+
+```scala
+lazy val liveIndicesSet = ...
+```
+
+```scala
+val valuesSqls = ...
+```
+
+```scala
+lazy val values = ...
+```
+
+```scala
+def render() = ...
+```
+
+#### `JoinAppend.scala`
+
+> Typeclass to allow `.join` to append tuples, such that `Query[(A, B)].join(Query[C])`
+> returns a flat `Query[(A, B, C)]` rather than a nested `Query[((A, B), B)]`. Can't
+> eliminate nesting in all cases, but eliminates nesting often enough to be useful
+
+```scala
+trait JoinAppend[Q, Q2, QF, RF]
+```
+
+```scala
+def appendTuple(t: Q, v: Q2): QF
+```
+
+```scala
+def qr: Queryable.Row[QF, RF]
+```
+
+```scala
+object JoinAppend extends scalasql.generated.JoinAppend
+```
+
+```scala
+trait JoinAppendLowPriority
+```
+
+```scala
+implicit def default[Q, R, Q2, R2](
+      implicit qr0: Queryable.Row[Q, R],
+      qr20: Queryable.Row[Q2, R2]
+  ): JoinAppend[Q, Q2, (Q, Q2), (R, R2)] = ...
+```
+
+#### `JoinOps.scala`
+
+```scala
+trait JoinOps[C[_, _], Q, R] extends WithSqlExpr[Q]
+```
+
+> Performs a `JOIN`/`INNER JOIN` on the given [[other]], typically a [[Table]] or [[Select]].
+
+```scala
+def join[Q2, R2, QF, RF](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): C[QF, RF] = ...
+```
+
+> Performs a `CROSS JOIN`, which is an `INNER JOIN` but without the `ON` clause
+
+```scala
+def crossJoin[Q2, R2, QF, RF](other: Joinable[Q2, R2])(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): C[QF, RF] = ...
+```
+
+```scala
+object JoinOps
+```
+
+```scala
+def join0[C[_, _], Q, R, Q2, R2, QF, RF](
+      v: JoinOps[C, Q, R],
+      prefix: String,
+      other: Joinable[Q2, R2],
+      on: Option[(Q, Q2) => Expr[Boolean]]
+  )(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ) = ...
+```
+
+#### `Joinable.scala`
+
+> Something that can be joined; typically a [[Select]] or a [[Table]]
+
+```scala
+trait Joinable[Q, R]
+```
+
+> Version of `crossJoin` meant for usage in `for`-comprehensions
+
+```scala
+def crossJoin[Q2, R2](): FlatJoin.Mapper[Q, Q2, R, R2] = ...
+```
+
+> Version of `join` meant for usage in `for`-comprehensions
+
+```scala
+def join[Q2, R2](on: Q => Expr[Boolean]): FlatJoin.Mapper[Q, Q2, R, R2] = ...
+```
+
+> Version of `leftJoin` meant for usage in `for`-comprehensions
+
+```scala
+def leftJoin[Q2, R2](on: Q => Expr[Boolean]): FlatJoin.NullableMapper[Q, Q2, R, R2] = ...
+```
+
+```scala
+object Joinable
+```
+
+```scala
+def toFromExpr[Q, R](x: Joinable[Q, R]) = ...
+```
+
+#### `JoinsToSql.scala`
+
+```scala
+object JoinsToSql
+```
+
+```scala
+def joinsToSqlStr(
+      joins: Seq[Join],
+      renderedFroms: Map[Context.From, SqlStr],
+      joinOns: Seq[Seq[Option[SqlStr.Flattened]]]
+  ) = ...
+```
+
+```scala
+def renderFroms(
+      selectables: Seq[Context.From],
+      prevContext: Context,
+      namedFromsMap: Map[Context.From, String],
+      liveExprs: LiveExprs
+  ) = ...
+```
+
+```scala
+def renderSingleFrom(
+      prevContext: Context,
+      liveExprs: LiveExprs,
+      f: Context.From,
+      namedFromsMap: Map[Context.From, String]
+  ): SqlStr = ...
+```
+
+```scala
+def renderLateralJoins(
+      prevContext: Context,
+      from: Seq[Context.From],
+      innerLiveExprs: LiveExprs,
+      joins0: Seq[Join],
+      renderedJoinOns: Seq[Seq[Option[SqlStr.Flattened]]]
+  ) = ...
+```
+
+#### `LateralJoinOps.scala`
+
+> Wrapper class with extension methods to add support for `JOIN LATERAL`, which
+> allow for `JOIN` clauses to access the results of earlier `JOIN` and `FROM` clauses.
+> Only supported by Postgres and MySql
+
+```scala
+class LateralJoinOps[C[_, _], Q, R](wrapped: JoinOps[C, Q, R] & Joinable[Q, R])(
+    implicit qr: Queryable.Row[Q, R]
+)
+```
+
+> Performs a `CROSS JOIN LATERAL`, similar to `CROSS JOIN` but allows the
+> `JOIN` clause to access the results of earlier `JOIN` and `FROM` clauses.
+> Only supported by Postgres and MySql
+
+```scala
+def crossJoinLateral[Q2, R2, QF, RF](other: Q => Joinable[Q2, R2])(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): C[QF, RF] = ...
+```
+
+> Performs a `JOIN LATERAL`, similar to `JOIN` but allows the
+> `JOIN` clause to access the results of earlier `JOIN` and `FROM` clauses.
+> Only supported by Postgres and MySql
+
+```scala
+def joinLateral[Q2, R2, QF, RF](other: Q => Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): C[QF, RF] = ...
+```
+
+```scala
+def leftJoinLateral[Q2, R2](other: Q => Joinable[Q2, R2])(
+      on: (Q, Q2) => Expr[Boolean]
+  )(implicit joinQr: Queryable.Row[Q2, R2]): Select[(Q, JoinNullable[Q2]), (R, Option[R2])] = ...
+```
+
+> Version of `crossJoinLateral` meant for use in `for`-comprehensions
+
+```scala
+def crossJoinLateral[Q2, R2](): FlatJoin.Mapper[Q, Q2, R, R2] = ...
+```
+
+> Version of `joinLateral` meant for use in `for`-comprehensions
+
+```scala
+def joinLateral[Q2, R2](on: Q => Expr[Boolean]): FlatJoin.Mapper[Q, Q2, R, R2] = ...
+```
+
+> Version of `leftJoinLateral` meant for use in `for`-comprehensions
+
+```scala
+def leftJoinLateral[Q2, R2](on: Q => Expr[Boolean]): FlatJoin.NullableMapper[Q, Q2, R, R2] = ...
+```
+
+#### `Model.scala`
+
+> Models a SQL `ORDER BY` clause
+
+```scala
+case class OrderBy(expr: Expr[?], ascDesc: Option[AscDesc], nulls: Option[Nulls])
+```
+
+```scala
+sealed trait AscDesc
+```
+
+```scala
+object AscDesc
+```
+
+> Models a SQL `ASC` clause
+
+```scala
+case object Asc extends AscDesc
+```
+
+> Models a SQL `DESC` clause
+
+```scala
+case object Desc extends AscDesc
+```
+
+```scala
+sealed trait Nulls
+```
+
+```scala
+object Nulls
+```
+
+> Models a SQL `NULLS FIRST` clause
+
+```scala
+case object First extends Nulls
+```
+
+> Models a SQL `NULSL LAST` clause
+
+```scala
+case object Last extends Nulls
+```
+
+> Models a SQL `GROUP BY` clause
+
+```scala
+case class GroupBy(keys: Seq[Expr[?]], select: () => Select[?, ?], having: Seq[Expr[?]])
+```
+
+> Models a SQL `JOIN` clause
+
+```scala
+case class Join(prefix: String, from: Seq[Join.From])
+```
+
+```scala
+object Join
+```
+
+```scala
+case class From(from: scalasql.core.Context.From, on: Option[Expr[?]])
+```
+
+#### `OnConflict.scala`
+
+> A query with a SQL `ON CONFLICT` clause, typically an `INSERT` or an `UPDATE`
+
+```scala
+class OnConflict[Q, R](query: Query[R] & Returning.InsertBase[Q], expr: Q, table: TableRef)
+```
+
+```scala
+def onConflictIgnore(c: (Q => Column[?])*) = ...
+```
+
+```scala
+def onConflictUpdate(c: (Q => Column[?])*)(c2: (Q => Column.Assignment[?])*) = ...
+```
+
+```scala
+object OnConflict
+```
+
+```scala
+class Ignore[Q, R](
+      protected val query: Query[R] & Returning.InsertBase[Q],
+      columns: Seq[Column[?]],
+      val table: TableRef
+  ) extends Query.DelegateQuery[R]
+      with Returning.InsertBase[Q]
+```
+
+```scala
+class Update[Q, R](
+      protected val query: Query[R] & Returning.InsertBase[Q],
+      columns: Seq[Column[?]],
+      updates: Seq[Column.Assignment[?]],
+      val table: TableRef
+  ) extends Query.DelegateQuery[R]
+      with Returning.InsertBase[Q]
+```
+
+#### `Query.scala`
+
+> A SQL Query, either a [[Query.Multiple]] that returns multiple rows, or
+> a [[Query.Single]] that returns a single row
+
+```scala
+trait Query[R] extends Renderable
+```
+
+```scala
+object Query
+```
+
+> Configuration for a typical update [[Query]]
+
+```scala
+trait ExecuteUpdate[R] extends scalasql.query.Query[R]
+```
+
+> Configuration for a [[Query]] that wraps another [[Query]], delegating
+> most of the abstract methods to it
+
+```scala
+trait DelegateQuery[R] extends scalasql.query.Query[R]
+```
+
+> Configuration for a [[Query]] that wraps an expr [[Q]] and [[Queryable]]
+
+```scala
+trait DelegateQueryable[Q, R] extends scalasql.query.Query[R] with WithSqlExpr[Q]
+```
+
+```scala
+implicit def QueryQueryable[R]: Queryable[Query[R], R] = ...
+```
+
+```scala
+def walkLabels[R](q: Query[R]) = ...
+```
+
+```scala
+def walkSqlExprs[R](q: Query[R]) = ...
+```
+
+```scala
+def isSingleRow[R](q: Query[R]) = ...
+```
+
+```scala
+def construct[R](q: Query[R], args: Queryable.ResultSetIterator) = ...
+```
+
+> The default [[Queryable]] instance for any [[Query]]. Delegates the implementation
+> of the [[Queryable]] methods to abstract methods on the [[Query]], to allow easy
+> overrides and subclassing of [[Query]] classes
+
+```scala
+class QueryQueryable[Q <: Query[R], R]() extends scalasql.core.Queryable[Q, R] {
+    override def isGetGeneratedKeys(q: Q) = ...
+```
+
+```scala
+override def isExecuteUpdate(q: Q) = ...
+```
+
+```scala
+override def walkLabels(q: Q) = ...
+```
+
+```scala
+override def walkExprs(q: Q) = ...
+```
+
+```scala
+override def isSingleRow(q: Q) = ...
+```
+
+```scala
+def renderSql(q: Q, ctx: Context): SqlStr = ...
+```
+
+```scala
+override def construct(q: Q, args: Queryable.ResultSetIterator): R = ...
+```
+
+> A [[Query]] that wraps another [[Query]] but sets [[queryIsSingleRow]] to `true`
+
+```scala
+class Single[R](protected val query: Query[Seq[R]]) extends Query.DelegateQuery[R]
+```
+
+#### `Returning.scala`
+
+> A query with a `RETURNING` clause
+
+```scala
+trait Returning[Q, R] extends Query[Seq[R]] with Query.DelegateQueryable[Q, Seq[R]]
+```
+
+```scala
+def single: Query.Single[R] = ...
+```
+
+```scala
+object Returning
+```
+
+> A query that could support a `RETURNING` clause, typically
+> an `INSERT` or `UPDATE`
+
+```scala
+trait Base[Q] extends Renderable with WithSqlExpr[Q]
+```
+
+```scala
+def table: TableRef
+```
+
+```scala
+trait InsertBase[Q] extends Base[Q]
+```
+
+> Makes this `INSERT` query call `JdbcStatement.getGeneratedKeys` when it is executed,
+> returning a `Seq[R]` where `R` is a Scala type compatible with the auto-generated
+> primary key type (typically something like `Int` or `Long`)
+
+```scala
+def getGeneratedKeys[R](implicit qr: Queryable.Row[?, R]): GetGeneratedKeys[Q, R] = ...
+```
+
+```scala
+class InsertImpl[Q, R](returnable: InsertBase[?], returning: Q)(
+      implicit qr: Queryable.Row[Q, R]
+  ) extends Returning.Impl0[Q, R](qr, returnable, returning)
+```
+
+```scala
+class Impl[Q, R](returnable: Base[?], returning: Q)(implicit qr: Queryable.Row[Q, R])
+```
+
+```scala
+class Impl0[Q, R](
+      protected val qr: Queryable.Row[Q, R],
+      returnable: Base[?],
+      protected val expr: Q
+  ) extends Returning[Q, R]
+```
+
+```scala
+override def queryIsSingleRow = ...
+```
+
+#### `Select.scala`
+
+> A SQL `SELECT` query, possible with `JOIN`, `WHERE`, `GROUP BY`,
+> `ORDER BY`, `LIMIT`, `OFFSET` clauses
+>
+> Models the various components of a SQL SELECT:
+>
+> {{{
+> SELECT DISTINCT column, AGG_FUNC(column_or_expression), …
+> FROM mytable
+> JOIN another_table ON mytable.column = another_table.column
+> WHERE constraint_expression
+> GROUP BY column HAVING constraint_expression
+> ORDER BY column ASC/DESC
+> LIMIT count OFFSET COUNT;
+> }}}
+>
+> Good syntax reference:
+>
+> https://www.cockroachlabs.com/docs/stable/selection-queries#set-operations
+> https://www.postgresql.org/docs/current/sql-select.html
+
+```scala
+trait Select[Q, R]
+    extends SqlStr.Renderable
+    with Aggregatable[Q]
+    with Joinable[Q, R]
+    with JoinOps[Select, Q, R]
+    with Query[Seq[R]]
+    with Query.DelegateQueryable[Q, Seq[R]]
+    with SubqueryRef.Wrapped
+```
+
+```scala
+def qr: Queryable.Row[Q, R]
+```
+
+> Causes this [[Select]] to ignore duplicate rows, translates into SQL `SELECT DISTINCT`
+
+```scala
+def distinct: Select[Q, R] = ...
+```
+
+> Transforms the return value of this [[Select]] with the given function
+
+```scala
+def map[Q2, R2](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R2]): Select[Q2, R2]
+```
+
+> Performs an implicit `JOIN` between this [[Select]] and the one returned by the
+> callback function [[f]]
+
+```scala
+def flatMap[Q2, R2](f: Q => FlatJoin.Rhs[Q2, R2])(
+      implicit qr: Queryable.Row[Q2, R2]
+  ): Select[Q2, R2]
+```
+
+> Filters this [[Select]] with the given predicate, translates into a SQL `WHERE` clause
+
+```scala
+def filter(f: Q => Expr[Boolean]): Select[Q, R]
+```
+
+> Alias for [[filter]]
+
+```scala
+def withFilter(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+> Filters this [[Select]] with the given predicate, if [[cond]] evaluates to true
+
+```scala
+def filterIf(cond: Boolean)(
+      f: Q => Expr[Boolean]
+  ): Select[Q, R]
+```
+
+> Filters this [[Select]] with the given predicate consuming provided option as a part of predicate's input,
+> if this option is Some[T]
+
+```scala
+def filterOpt[T](option: Option[T])(
+      f: (Q, T) => Expr[Boolean]
+  ): Select[Q, R]
+```
+
+> Performs one or more aggregates in a single [[Select]]
+
+```scala
+def aggregate[E, V](f: Aggregatable.Proxy[Q] => E)(
+      implicit qr: Queryable.Row[E, V]
+  ): Aggregate[E, V]
+```
+
+> Performs a `.map` which additionally provides a [[Aggregatable.Proxy]] that allows you to perform aggregate
+> functions.
+
+```scala
+def mapAggregate[Q2, R2](f: (Q, Aggregatable.Proxy[Q]) => Q2)(
+      implicit qr: Queryable.Row[Q2, R2]
+  ): Select[Q2, R2]
+```
+
+> Translates into a SQL `GROUP BY`, takes a function specifying the group-key and
+> a function specifying the group-aggregate.
+
+```scala
+def groupBy[K, V, R2, R3](groupKey: Q => K)(
+      groupAggregate: Aggregatable.Proxy[Q] => V
+  )(implicit qrk: Queryable.Row[K, R2], qrv: Queryable.Row[V, R3]): Select[(K, V), (R2, R3)]
+```
+
+> Sorts this [[Select]] via the given expression. Translates into a SQL `ORDER BY`
+> clause. Can be called more than once to sort on multiple columns, with the last
+> call to [[sortBy]] taking priority. Can be followed by [[asc]], [[desc]], [[nullsFirst]]
+> or [[nullsLast]] to configure the sort order
+
+```scala
+def sortBy(f: Q => Expr[?]): Select[Q, R]
+```
+
+> Combined with [[sortBy]] to make the sort order ascending, translates into SQL `ASC`
+
+```scala
+def asc: Select[Q, R]
+```
+
+> Combined with [[sortBy]] to make the sort order descending, translates into SQL `DESC`
+
+```scala
+def desc: Select[Q, R]
+```
+
+> Combined with [[sortBy]] to configure handling of nulls, translates into SQL `NULLS FIRST`
+
+```scala
+def nullsFirst: Select[Q, R]
+```
+
+> Combined with [[sortBy]] to configure handling of nulls, translates into SQL `NULLS LAST`
+
+```scala
+def nullsLast: Select[Q, R]
+```
+
+> Concatenates the result rows of this [[Select]] with another and removes duplicate
+> rows; translates into SQL `UNION`
+
+```scala
+def union(other: Select[Q, R]): Select[Q, R] = ...
+```
+
+> Concatenates the result rows of this [[Select]] with another; translates into SQL
+> `UNION ALL`
+
+```scala
+def unionAll(other: Select[Q, R]): Select[Q, R] = ...
+```
+
+> Intersects the result rows of this [[Select]] with another, preserving only rows
+> present in both this and the [[other]] and removing duplicates. Translates
+> into SQL `INTERSECT`
+
+```scala
+def intersect(other: Select[Q, R]): Select[Q, R] = ...
+```
+
+> Subtracts the [[other]] from this [[Select]], returning only rows present this
+> but absent in [[other]], and removing duplicates. Translates into SQL `EXCEPT`
+
+```scala
+def except(other: Select[Q, R]): Select[Q, R] = ...
+```
+
+> Drops the first [[n]] rows from this [[Select]]. Like when used in Scala collections,
+> if called multiple times the dropped rows add up
+
+```scala
+def drop(n: Int): Select[Q, R]
+```
+
+> Only returns the first [[n]] rows from this [[Select]]. Like when used in Scala collections,
+> if called multiple times only the smallest value of [[n]] takes effect
+
+```scala
+def take(n: Int): Select[Q, R]
+```
+
+> Asserts that this query returns exactly one row, and returns a single
+> value of type [[R]] rather than a `Seq[R]`. Throws an exception if
+> zero or multiple rows are returned.
+
+```scala
+def single: Query.Single[R] = ...
+```
+
+> Shorthand for `.take(1).single`:
+>
+> 1. If the query returns a single row, this returns it as a single value of type [[R]]
+> 2. If the query returns multiple rows, returns the first as a single value of type [[R]]
+> and discards the rest
+> 3. If the query returns zero rows, throws an exception.
+
+```scala
+def head: Query.Single[R] = ...
+```
+
+> Converts this [[Select]] into an [[Expr]], assuming it returns a single row and
+> a single column. Note that if this returns multiple rows, behavior is database-specific,
+> with some like Sqlite simply taking the first row while others like Postgres/MySql
+> throwing exceptions
+
+```scala
+def toExpr(implicit mt: TypeMapper[R]): Expr[R] = ...
+```
+
+> Forces this [[Select]] to be treated as a subquery that any further operations
+> will operate on, rather than having some operations flattened out into clauses
+> in this [[Select]]
+
+```scala
+def subquery: SimpleSelect[Q, R] = ...
+```
+
+> Performs a `LEFT JOIN` on the given [[other]], typically a [[Table]] or [[Select]].
+
+```scala
+def leftJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit joinQr: Queryable.Row[Q2, R2]
+  ): Select[(Q, JoinNullable[Q2]), (R, Option[R2])]
+```
+
+> Performs a `RIGHT JOIN` on the given [[other]], typically a [[Table]] or [[Select]].
+
+```scala
+def rightJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit joinQr: Queryable.Row[Q2, R2]
+  ): Select[(JoinNullable[Q], Q2), (Option[R], R2)]
+```
+
+> Performs a `OUTER JOIN` on the given [[other]], typically a [[Table]] or [[Select]].
+
+```scala
+def outerJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit joinQr: Queryable.Row[Q2, R2]
+  ): Select[(JoinNullable[Q], JoinNullable[Q2]), (Option[R], Option[R2])]
+```
+
+> Returns whether or not the [[Select]] on the left contains the [[other]] value on the right
+
+```scala
+def contains(other: Q): Expr[Boolean] = ...
+```
+
+> Returns whether or not the [[Select]] on the left is empty with zero elements
+
+```scala
+def isEmpty: Expr[Boolean] = ...
+```
+
+> Returns whether or not the [[Select]] on the left is nonempty with one or more elements
+
+```scala
+def nonEmpty: Expr[Boolean] = ...
+```
+
+```scala
+object Select
+```
+
+```scala
+def newSimpleSelect[Q, R](
+      lhs: Select[Q, R],
+      expr: Q,
+      exprPrefix: Option[Context => SqlStr],
+      exprSuffix: Option[Context => SqlStr],
+      preserveAll: Boolean,
+      from: Seq[Context.From],
+      joins: Seq[Join],
+      where: Seq[Expr[?]],
+      groupBy0: Option[GroupBy]
+  )(implicit qr: Queryable.Row[Q, R], dialect: DialectTypeMappers): SimpleSelect[Q, R] = ...
+```
+
+```scala
+def toSimpleFrom[Q, R](s: Select[Q, R]) = ...
+```
+
+```scala
+def withExprPrefix[Q, R](s: Select[Q, R], preserveAll: Boolean, str: Context => SqlStr) = ...
+```
+
+```scala
+def withExprSuffix[Q, R](s: Select[Q, R], preserveAll: Boolean, str: Context => SqlStr) = ...
+```
+
+```scala
+implicit class ExprSelectOps[T](s: Select[Expr[T], T])
+```
+
+```scala
+def sorted(implicit tm: TypeMapper[T]): Select[Expr[T], T] = ...
+```
+
+```scala
+trait Proxy[Q, R] extends Select[Q, R]
+```
+
+```scala
+override def qr: Queryable.Row[Q, R]
+```
+
+```scala
+override def map[Q2, R2](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+```scala
+override def flatMap[Q2, R2](f: Q => FlatJoin.Rhs[Q2, R2])(
+        implicit qr: Queryable.Row[Q2, R2]
+    ): Select[Q2, R2] = ...
+```
+
+```scala
+override def filter(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+override def filterIf(cond: Boolean)(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+override def filterOpt[T](option: Option[T])(f: (Q, T) => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+override def aggregate[E, V](f: Aggregatable.Proxy[Q] => E)(
+        implicit qr: Queryable.Row[E, V]
+    ): Aggregate[E, V] = ...
+```
+
+```scala
+override def mapAggregate[Q2, R2](f: (Q, Aggregatable.Proxy[Q]) => Q2)(
+        implicit qr: Queryable.Row[Q2, R2]
+    ): Select[Q2, R2] = ...
+```
+
+```scala
+override def groupBy[K, V, R2, R3](groupKey: Q => K)(
+        groupAggregate: Aggregatable.Proxy[Q] => V
+    )(implicit qrk: Queryable.Row[K, R2], qrv: Queryable.Row[V, R3]): Select[(K, V), (R2, R3)] = ...
+```
+
+```scala
+override def sortBy(f: Q => Expr[?]): Select[Q, R] = ...
+```
+
+```scala
+override def asc: Select[Q, R] = ...
+```
+
+```scala
+override def desc: Select[Q, R] = ...
+```
+
+```scala
+override def nullsFirst: Select[Q, R] = ...
+```
+
+```scala
+override def nullsLast: Select[Q, R] = ...
+```
+
+```scala
+override def drop(n: Int): Select[Q, R] = ...
+```
+
+```scala
+override def take(n: Int): Select[Q, R] = ...
+```
+
+```scala
+override def leftJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+        implicit joinQr: Queryable.Row[Q2, R2]
+    ): Select[(Q, JoinNullable[Q2]), (R, Option[R2])] = ...
+```
+
+```scala
+override def rightJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+        implicit joinQr: Queryable.Row[Q2, R2]
+    ): Select[(JoinNullable[Q], Q2), (Option[R], R2)] = ...
+```
+
+```scala
+override def outerJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+        implicit joinQr: Queryable.Row[Q2, R2]
+    ): Select[(JoinNullable[Q], JoinNullable[Q2]), (Option[R], Option[R2])] = ...
+```
+
+```scala
+override def aggregateExpr[V: TypeMapper](f: Q => Context => SqlStr)(
+        implicit qr: Queryable.Row[Expr[V], V]
+    ): Expr[V] = ...
+```
+
+#### `SimpleSelect.scala`
+
+> A `SELECT` query, with `FROM`/`JOIN`/`WHERE`/`GROUP BY`
+> clauses, but without `ORDER BY`/`LIMIT`/`TAKE`/`UNION` clauses
+
+```scala
+class SimpleSelect[Q, R](
+    val expr: Q,
+    val exprPrefix: Option[Context => SqlStr],
+    val exprSuffix: Option[Context => SqlStr],
+    val preserveAll: Boolean,
+    val from: Seq[Context.From],
+    val joins: Seq[Join],
+    val where: Seq[Expr[?]],
+    val groupBy0: Option[GroupBy]
+)(implicit val qr: Queryable.Row[Q, R], protected val dialect: DialectTypeMappers)
+```
+
+```scala
+def selectWithExprPrefix(preserveAll: Boolean, s: Context => SqlStr): Select[Q, R] = ...
+```
+
+```scala
+def selectWithExprSuffix(preserveAll: Boolean, s: Context => SqlStr): Select[Q, R] = ...
+```
+
+```scala
+def aggregateExpr[V: TypeMapper](
+      f: Q => Context => SqlStr
+  )(implicit qr2: Queryable.Row[Expr[V], V]): Expr[V] = ...
+```
+
+```scala
+def map[Q2, R2](f: Q => Q2)(implicit qr: Queryable.Row[Q2, R2]): SimpleSelect[Q2, R2] = ...
+```
+
+```scala
+def flatMap[Q2, R2](
+      f: Q => FlatJoin.Rhs[Q2, R2]
+  )(implicit qr2: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+```scala
+def filter(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+def filterIf(cond: Boolean)(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+def filterOpt[T](option: Option[T])(f: (Q, T) => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+def join0[Q2, R2, QF, RF](
+      prefix: String,
+      other: Joinable[Q2, R2],
+      on: Option[(Q, Q2) => Expr[Boolean]]
+  )(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): Select[QF, RF] = ...
+```
+
+```scala
+def leftJoin[Q2, R2](other: Joinable[Q2, R2])(
+      on: (Q, Q2) => Expr[Boolean]
+  )(implicit joinQr: Queryable.Row[Q2, R2]): Select[(Q, JoinNullable[Q2]), (R, Option[R2])] = ...
+```
+
+```scala
+def rightJoin[Q2, R2](other: Joinable[Q2, R2])(
+      on: (Q, Q2) => Expr[Boolean]
+  )(implicit joinQr: Queryable.Row[Q2, R2]): Select[(JoinNullable[Q], Q2), (Option[R], R2)] = ...
+```
+
+```scala
+def outerJoin[Q2, R2](other: Joinable[Q2, R2])(on: (Q, Q2) => Expr[Boolean])(
+      implicit joinQr: Queryable.Row[Q2, R2]
+  ): Select[(JoinNullable[Q], JoinNullable[Q2]), (Option[R], Option[R2])] = ...
+```
+
+```scala
+def aggregate[E, V](
+      f: Aggregatable.Proxy[Q] => E
+  )(implicit qr: Queryable.Row[E, V]): Aggregate[E, V] = ...
+```
+
+```scala
+def mapAggregate[Q2, R2](
+      f: (Q, Aggregatable.Proxy[Q]) => Q2
+  )(implicit qr: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+```scala
+def groupBy[K, V, R1, R2](groupKey: Q => K)(
+      groupAggregate: Aggregatable.Proxy[Q] => V
+  )(implicit qrk: Queryable.Row[K, R1], qrv: Queryable.Row[V, R2]): Select[(K, V), (R1, R2)] = ...
+```
+
+```scala
+def sortBy(f: Q => Expr[?]): Select[Q, R] = ...
+```
+
+```scala
+def asc: Select[Q, R] = ...
+```
+
+```scala
+def desc: Select[Q, R] = ...
+```
+
+```scala
+def nullsFirst: Select[Q, R] = ...
+```
+
+```scala
+def nullsLast: Select[Q, R] = ...
+```
+
+```scala
+def compound0(op: String, other: Select[Q, R]) = ...
+```
+
+```scala
+def drop(n: Int): Select[Q, R] = ...
+```
+
+```scala
+def take(n: Int): Select[Q, R] = ...
+```
+
+```scala
+object SimpleSelect
+```
+
+```scala
+def joinCopy[Q, R, Q2, R2, Q3, R3](
+      self: SimpleSelect[Q, R],
+      other: Joinable[Q2, R2],
+      on: Option[(Q, Q2) => Expr[Boolean]],
+      joinPrefix: String
+  )(f: (Q, Q2) => Q3)(implicit jqr: Queryable.Row[Q3, R3]) = ...
+```
+
+```scala
+def getRenderer(s: SimpleSelect[?, ?], prevContext: Context): SimpleSelect.Renderer[?, ?] = ...
+```
+
+```scala
+class Renderer[Q, R](query: SimpleSelect[Q, R], prevContext: Context)
+```
+
+```scala
+lazy val flattenedExpr = ...
+```
+
+```scala
+lazy val froms = ...
+```
+
+```scala
+implicit lazy val context: Context = ...
+```
+
+```scala
+lazy val joinOns = ...
+```
+
+```scala
+lazy val exprsStrs = ...
+```
+
+```scala
+lazy val filtersOpt = ...
+```
+
+```scala
+lazy val groupByOpt = ...
+```
+
+```scala
+def render(liveExprs0: LiveExprs) = ...
+```
+
+#### `SqlWindow.scala`
+
+```scala
+case class SqlWindow[T](
+    e: Expr[T],
+    partitionBy0: Option[Expr[?]],
+    filter0: Option[Expr[Boolean]],
+    orderBy: Seq[scalasql.query.OrderBy],
+    frameStart0: Option[SqlStr],
+    frameEnd0: Option[SqlStr],
+    exclusions: Option[SqlStr]
+)(implicit dialect: DialectTypeMappers)
+```
+
+```scala
+def partitionBy(e: Expr[?]) = ...
+```
+
+```scala
+def filter(expr: Expr[Boolean]) = ...
+```
+
+```scala
+def sortBy(expr: Expr[?]) = ...
+```
+
+```scala
+def asc = ...
+```
+
+```scala
+def desc = ...
+```
+
+```scala
+def nullsFirst = ...
+```
+
+```scala
+def nullsLast = ...
+```
+
+```scala
+class FrameConfig(f: Some[SqlStr] => SqlWindow[T])
+```
+
+```scala
+def preceding(offset: Int = -1) = ...
+```
+
+```scala
+def currentRow = ...
+```
+
+```scala
+def following(offset: Int = -1) = ...
+```
+
+```scala
+def frameStart = ...
+```
+
+```scala
+def frameEnd = ...
+```
+
+```scala
+object exclude
+```
+
+```scala
+def currentRow = ...
+```
+
+```scala
+def group = ...
+```
+
+```scala
+def ties = ...
+```
+
+```scala
+def noOthers = ...
+```
+
+#### `Table.scala`
+
+> In-code representation of a SQL table, associated with a given `case class` [[V]].
+
+```scala
+abstract class Table[V[_[_]]]()(implicit name: sourcecode.Name, metadata0: Table.Metadata[V])
+```
+
+```scala
+implicit def containerQr(implicit dialect: DialectTypeMappers): Queryable.Row[V[Expr], V[Sc]] = ...
+```
+
+```scala
+implicit def tableImplicitMetadata: Table.ImplicitMetadata[V] = ...
+```
+
+```scala
+object Table
+```
+
+```scala
+trait LowPri[V[_[_]]]
+```
+
+```scala
+implicit def containerQr2(
+        implicit dialect: DialectTypeMappers
+    ): Queryable.Row[V[Column], V[Sc]] = ...
+```
+
+```scala
+case class ImplicitMetadata[V[_[_]]](value: Metadata[V])
+```
+
+```scala
+def metadata[V[_[_]]](t: Table[V]) = ...
+```
+
+```scala
+def ref[V[_[_]]](t: Table[V]) = ...
+```
+
+```scala
+def name(t: Table.Base) = ...
+```
+
+```scala
+def labels(t: Table.Base) = ...
+```
+
+```scala
+def columnNameOverride[V[_[_]]](t: Table.Base)(s: String) = ...
+```
+
+```scala
+def identifier(t: Table.Base)(implicit context: Context): String = ...
+```
+
+```scala
+def fullIdentifier(
+      t: Table.Base
+  )(implicit context: Context): String = ...
+```
+
+```scala
+trait Base
+```
+
+```scala
+class Metadata[V[_[_]]](
+      val queryables: (DialectTypeMappers, Int) => Queryable.Row[?, ?],
+      val walkLabels0: () => Seq[String],
+      val queryable: (
+          () => Seq[String],
+          DialectTypeMappers,
+          Metadata.QueryableProxy
+      ) => Queryable[V[Expr], V[Sc]],
+      val vExpr0: (TableRef, DialectTypeMappers, Metadata.QueryableProxy) => V[Column]
+  )
+```
+
+```scala
+def vExpr(t: TableRef, d: DialectTypeMappers) = ...
+```
+
+```scala
+object Metadata extends scalasql.query.TableMacros
+```
+
+```scala
+class QueryableProxy(queryables: Int => Queryable.Row[?, ?])
+```
+
+```scala
+def apply[T, V](n: Int): Queryable.Row[T, V] = ...
+```
+
+```scala
+object Internal
+```
+
+```scala
+class TableQueryable[Q, R <: scala.Product](
+        walkLabels0: () => Seq[String],
+        walkExprs0: Q => Seq[Expr[?]],
+        construct0: Queryable.ResultSetIterator => R,
+        deconstruct0: R => Q = ???
+    ) extends Queryable.Row[Q, R]
+```
+
+```scala
+def walkLabels(): Seq[List[String]] = ...
+```
+
+```scala
+def walkExprs(q: Q): Seq[Expr[?]] = ...
+```
+
+```scala
+def construct(args: Queryable.ResultSetIterator) = ...
+```
+
+```scala
+def deconstruct(r: R): Q = ...
+```
+
+#### `TableMacros.scala`
+
+```scala
+object TableMacros
+```
+
+```scala
+def applyImpl[V[_[_]] <: Product](using Quotes, Type[V]): Expr[Table.Metadata[V]] = {
+    import quotes.reflect.*
+```
+
+```scala
+trait TableMacros
+```
+
+```scala
+inline given initTableMetadata[V[_[_]] <: Product]: Table.Metadata[V] = ${
+    TableMacros.applyImpl[V]
+```
+
+#### `Update.scala`
+
+> A SQL `UPDATE` query
+
+```scala
+trait Update[Q, R]
+    extends JoinOps[Update, Q, R]
+    with Returning.Base[Q]
+    with Query.ExecuteUpdate[Int]
+```
+
+```scala
+def filter(f: Q => Expr[Boolean]): Update[Q, R]
+```
+
+```scala
+def withFilter(f: Q => Expr[Boolean]): Update[Q, R] = ...
+```
+
+```scala
+def set(f: (Q => Column.Assignment[?])*): Update[Q, R]
+```
+
+```scala
+def join0[Q2, R2, QF, RF](
+      prefix: String,
+      other: Joinable[Q2, R2],
+      on: Option[(Q, Q2) => Expr[Boolean]]
+  )(
+      implicit ja: JoinAppend[Q, Q2, QF, RF]
+  ): Update[QF, RF]
+```
+
+```scala
+def qr: Queryable.Row[Q, R]
+```
+
+```scala
+object Update
+```
+
+> Syntax reference
+>
+> https://www.postgresql.org/docs/current/sql-update.html
+
+```scala
+class Impl[Q, R](
+      val expr: Q,
+      val table: TableRef,
+      val set0: Seq[Column.Assignment[?]],
+      val joins: Seq[Join],
+      val where: Seq[Expr[?]]
+  )(implicit val qr: Queryable.Row[Q, R], dialect: DialectTypeMappers)
+```
+
+```scala
+def filter(f: Q => Expr[Boolean]) = ...
+```
+
+```scala
+def set(f: (Q => Column.Assignment[?])*) = ...
+```
+
+```scala
+def join0[Q2, R2, QF, RF](
+        prefix: String,
+        other: Joinable[Q2, R2],
+        on: Option[(Q, Q2) => Expr[Boolean]]
+    )(
+        implicit ja: JoinAppend[Q, Q2, QF, RF]
+    ) = ...
+```
+
+```scala
+class Renderer(
+      joins0: Seq[Join],
+      table: TableRef,
+      set0: Seq[Column.Assignment[?]],
+      where0: Seq[Expr[?]],
+      prevContext: Context
+  )
+```
+
+```scala
+lazy val froms = ...
+```
+
+```scala
+lazy val contextStage1: Context = ...
+```
+
+```scala
+implicit lazy val context: Context = ...
+```
+
+```scala
+lazy val updateList = ...
+```
+
+```scala
+lazy val sets = ...
+```
+
+```scala
+lazy val where = ...
+```
+
+```scala
+lazy val liveExprs = ...
+```
+
+```scala
+lazy val renderedFroms = ...
+```
+
+```scala
+lazy val from = ...
+```
+
+```scala
+lazy val fromOns = ...
+```
+
+```scala
+lazy val joinOns = ...
+```
+
+```scala
+lazy val joins = ...
+```
+
+```scala
+lazy val tableName = ...
+```
+
+```scala
+def render() = ...
+```
+
+#### `Values.scala`
+
+> A SQL `VALUES` clause, used to treat a sequence of primitive [[T]]s as
+> a [[Select]] query.
+
+```scala
+class Values[Q, R](val ts: Seq[R])(
+    implicit val qr: Queryable.Row[Q, R],
+    protected val dialect: DialectTypeMappers
+) extends Select.Proxy[Q, R]
+    with Query.DelegateQueryable[Q, Seq[R]]
+```
+
+```scala
+val tableRef = ...
+```
+
+```scala
+object Values
+```
+
+```scala
+class Renderer[Q, R](v: Values[Q, R])(implicit qr: Queryable.Row[Q, R], ctx: Context)
+```
+
+```scala
+def wrapRow(t: R): SqlStr = ...
+```
+
+```scala
+def render(liveExprs: LiveExprs): SqlStr = ...
+```
+
+```scala
+def context = ...
+```
+
+#### `WithCte.scala`
+
+> A SQL `WITH` clause
+
+```scala
+class WithCte[Q, R](
+    walked: Queryable.Walked,
+    val lhs: Select[?, ?],
+    val cteRef: WithCteRef,
+    val rhs: Select[Q, R],
+    val withPrefix: SqlStr = sql"WITH "
+)(implicit val qr: Queryable.Row[Q, R], protected val dialect: DialectTypeMappers)
+```
+
+```scala
+override def map[Q2, R2](f: Q => Q2)(implicit qr2: Queryable.Row[Q2, R2]): Select[Q2, R2] = ...
+```
+
+```scala
+override def filter(f: Q => Expr[Boolean]): Select[Q, R] = ...
+```
+
+```scala
+override def sortBy(f: Q => Expr[?]): Select[Q, R] = ...
+```
+
+```scala
+override def drop(n: Int): Select[Q, R] = ...
+```
+
+```scala
+override def take(n: Int): Select[Q, R] = ...
+```
+
+```scala
+object WithCte
+```
+
+```scala
+class Proxy[Q, R](
+      lhs: Select[Q, R],
+      lhsSubQueryRef: WithCteRef,
+      val qr: Queryable.Row[Q, R],
+      protected val dialect: DialectTypeMappers
+  ) extends Select.Proxy[Q, R]
+```
+
+```scala
+override def joinableToFromExpr: (Context.From, Q) = ...
+```
+
+```scala
+override def selectRenderer(prevContext: Context): SubqueryRef.Wrapped.Renderer = ...
+```
+
+```scala
+class Renderer[Q, R](
+      walked: Queryable.Walked,
+      withPrefix: SqlStr,
+      query: WithCte[Q, R],
+      prevContext: Context
+  ) extends SubqueryRef.Wrapped.Renderer
+```
+
+```scala
+def render(liveExprs: LiveExprs) = ...
+```
+
+### `com.lihaoyi:scalasql-operations_3:0.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/scalasql-operations_3/0.3.1/scalasql-operations_3-0.3.1-sources.jar
+
+#### `AggAnyOps.scala`
+
+> Aggregations that apply to any element type `T`, e.g. COUNT and COUNT(DISTINCT)
+> over an aggregated `Expr[T]` sequence.
+
+```scala
+class AggAnyOps[T](v: Aggregatable[Expr[T]])(
+    implicit tmInt: TypeMapper[Int],
+    qrInt: Queryable.Row[Expr[Int], Int]
+)
+```
+
+> Counts non-null values
+
+```scala
+def count: Expr[Int] = ...
+```
+
+> Counts distinct non-null values
+
+```scala
+def countDistinct: Expr[Int] = ...
+```
+
+#### `AggNumericOps.scala`
+
+```scala
+class AggNumericOps[V: Numeric: TypeMapper](v: Aggregatable[Expr[V]])(
+    implicit qr: Queryable.Row[Expr[V], V]
+)
+```
+
+> Computes the sum of column values
+
+```scala
+def sum: Expr[V] = ...
+```
+
+> Finds the minimum value in a column
+
+```scala
+def min: Expr[V] = ...
+```
+
+> Finds the maximum value in a column
+
+```scala
+def max: Expr[V] = ...
+```
+
+> Computes the average value of a column
+
+```scala
+def avg: Expr[V] = ...
+```
+
+#### `AggOps.scala`
+
+```scala
+class AggOps[T](v: Aggregatable[T])(implicit qr: Queryable.Row[T, ?], dialect: DialectTypeMappers)
+```
+
+> Counts the rows
+
+```scala
+def size: Expr[Int] = ...
+```
+
+> Counts non-null values in the selected column
+
+```scala
+def countBy[V](f: T => Expr[V])(implicit qrInt: Queryable.Row[Expr[Int], Int]): Expr[Int] = ...
+```
+
+> Counts distinct non-null values in the selected column
+
+```scala
+def countDistinctBy[V](
+      f: T => Expr[V]
+  )(implicit qrInt: Queryable.Row[Expr[Int], Int]): Expr[Int] = ...
+```
+
+> Computes the sum of column values
+
+```scala
+def sumBy[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[V] = ...
+```
+
+> Finds the minimum value in a column
+
+```scala
+def minBy[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[V] = ...
+```
+
+> Finds the maximum value in a column
+
+```scala
+def maxBy[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[V] = ...
+```
+
+> Computes the average value of a column
+
+```scala
+def avgBy[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[V] = ...
+```
+
+> Computes the sum of column values
+
+```scala
+def sumByOpt[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[Option[V]] = ...
+```
+
+> Finds the minimum value in a column
+
+```scala
+def minByOpt[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[Option[V]] = ...
+```
+
+> Finds the maximum value in a column
+
+```scala
+def maxByOpt[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[Option[V]] = ...
+```
+
+> Computes the average value of a column
+
+```scala
+def avgByOpt[V: TypeMapper](f: T => Expr[V])(
+      implicit qr: Queryable.Row[Expr[V], V]
+  ): Expr[Option[V]] = ...
+```
+
+> TRUE if any value in a set is TRUE
+
+```scala
+def any(f: T => Expr[Boolean]): Expr[Boolean] = ...
+```
+
+> TRUE if all values in a set are TRUE
+
+```scala
+def all(f: T => Expr[Boolean]): Expr[Boolean] = ...
+```
+
+#### `BitwiseFunctionOps.scala`
+
+```scala
+trait BitwiseFunctionOps[T] extends scalasql.operations.ExprNumericOps[T]
+```
+
+```scala
+override def &[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+```scala
+override def |[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+```scala
+override def unary_~ : Expr[T] = ...
+```
+
+#### `CaseWhen.scala`
+
+```scala
+class CaseWhen[T: TypeMapper](values: Seq[(Expr[Boolean], Expr[T])]) extends Expr[T]
+```
+
+```scala
+def renderToSql0(implicit ctx: Context): SqlStr = ...
+```
+
+```scala
+def `else`(other: Expr[T]) = ...
+```
+
+```scala
+object CaseWhen
+```
+
+```scala
+class Else[T: TypeMapper](values: Seq[(Expr[Boolean], Expr[T])], `else`: Expr[T])
+```
+
+```scala
+def renderToSql0(implicit ctx: Context): SqlStr = ...
+```
+
+#### `ConcatOps.scala`
+
+```scala
+trait ConcatOps
+```
+
+> Concatenate all arguments. NULL arguments are ignored.
+
+```scala
+def concat(values: Expr[?]*): Expr[String] = ...
+```
+
+> Concatenate all but first arguments with separators. The first parameter is used
+> as a separator. NULL arguments are ignored.
+
+```scala
+def concatWs(sep: Expr[String], values: Expr[?]*): Expr[String] = ...
+```
+
+#### `DbApiOps.scala`
+
+```scala
+class DbApiOps(dialect: DialectTypeMappers)
+```
+
+> Creates a SQL `CASE`/`WHEN`/`ELSE` clause
+
+```scala
+def caseWhen[T: TypeMapper](values: (Expr[Boolean], Expr[T])*) = ...
+```
+
+> The row_number() of the first peer in each group - the rank of the current row
+> with gaps. If there is no ORDER BY clause, then all rows are considered peers and
+> this function always returns 1.
+
+```scala
+def rank(): Expr[Int] = ...
+```
+
+> The number of the row within the current partition. Rows are numbered starting
+> from 1 in the order defined by the ORDER BY clause in the window definition, or
+> in arbitrary order otherwise.
+
+```scala
+def rowNumber(): Expr[Int] = ...
+```
+
+> The number of the current row's peer group within its partition - the rank of the
+> current row without gaps. Rows are numbered starting from 1 in the order defined
+> by the ORDER BY clause in the window definition. If there is no ORDER BY clause,
+> then all rows are considered peers and this function always returns 1.
+
+```scala
+def denseRank(): Expr[Int] = ...
+```
+
+> Despite the name, this function always returns a value between 0.0 and 1.0 equal to
+> (rank - 1)/(partition-rows - 1), where rank is the value returned by built-in window
+> function rank() and partition-rows is the total number of rows in the partition. If
+> the partition contains only one row, this function returns 0.0.
+
+```scala
+def percentRank(): Expr[Double] = ...
+```
+
+> The cumulative distribution. Calculated as row-number/partition-rows, where row-number
+> is the value returned by row_number() for the last peer in the group and partition-rows
+> the number of rows in the partition.
+
+```scala
+def cumeDist(): Expr[Double] = ...
+```
+
+> Argument N is handled as an integer. This function divides the partition into N groups
+> as evenly as possible and assigns an integer between 1 and N to each group, in the order
+> defined by the ORDER BY clause, or in arbitrary order otherwise. If necessary, larger
+> groups occur first. This function returns the integer value assigned to the group that
+> the current row is a part of.
+
+```scala
+def ntile(n: Int): Expr[Int] = ...
+```
+
+> The lag() function returns the result of evaluating expression expr against the
+> previous row in the partition. Or, if there is no previous row (because the current
+> row is the first), NULL.
+>
+> If the offset argument is provided, then it must be a non-negative integer. In this
+> case the value returned is the result of evaluating expr against the row offset rows
+> before the current row within the partition. If offset is 0, then expr is evaluated
+> against the current row. If there is no row offset rows before the current row, NULL
+> is returned.
+>
+> If default is also provided, then it is returned instead of NULL if the row identified
+> by offset does not exist.
+
+```scala
+def lag[T](e: Expr[T], offset: Int = -1, default: Expr[T] = null): Expr[T] = ...
+```
+
+> The lead() function returns the result of evaluating expression expr against the next
+> row in the partition. Or, if there is no next row (because the current row is the last),
+> NULL.
+>
+> If the offset argument is provided, then it must be a non-negative integer. In this
+> case the value returned is the result of evaluating expr against the row offset rows
+> after the current row within the partition. If offset is 0, then expr is evaluated
+> against the current row. If there is no row offset rows after the current row, NULL
+> is returned.
+>
+> If default is also provided, then it is returned instead of NULL if the row identified
+> by offset does not exist.
+
+```scala
+def lead[T](e: Expr[T], offset: Int = -1, default: Expr[T] = null): Expr[T] = ...
+```
+
+> Calculates the window frame for each row in the same way as an aggregate window
+> function. It returns the value of expr evaluated against the first row in the window
+> frame for each row.
+
+```scala
+def firstValue[T](e: Expr[T]): Expr[T] = ...
+```
+
+> Calculates the window frame for each row in the same way as an aggregate window
+> function. It returns the value of expr evaluated against the last row in the window
+> frame for each row.
+
+```scala
+def lastValue[T](e: Expr[T]): Expr[T] = ...
+```
+
+> Calculates the window frame for each row in the same way as an aggregate window
+> function. It returns the value of expr evaluated against the row N of the window
+> frame. Rows are numbered within the window frame starting from 1 in the order
+> defined by the ORDER BY clause if one is present, or in arbitrary order otherwise.
+> If there is no Nth row in the partition, then NULL is returned.
+
+```scala
+def nthValue[T](e: Expr[T], n: Int): Expr[T] = ...
+```
+
+#### `ExprAggOps.scala`
+
+```scala
+abstract class ExprAggOps[T](v: Aggregatable[Expr[T]])
+```
+
+> Concatenates the given values into one string using the given separator
+
+```scala
+def mkString(sep: Expr[String] = null)(implicit tm: TypeMapper[T]): Expr[String]
+```
+
+#### `ExprBooleanOps.scala`
+
+```scala
+class ExprBooleanOps(v: Expr[Boolean])
+```
+
+> TRUE if both Boolean expressions are TRUE
+
+```scala
+def &&(x: Expr[Boolean]): Expr[Boolean] = ...
+```
+
+> TRUE if either Boolean expression is TRUE
+
+```scala
+def ||(x: Expr[Boolean]): Expr[Boolean] = ...
+```
+
+> Reverses the value of any other Boolean operator
+
+```scala
+def unary_! : Expr[Boolean] = ...
+```
+
+#### `ExprNumericOps.scala`
+
+```scala
+class ExprNumericOps[T: Numeric](v: Expr[T])(implicit val m: TypeMapper[T])
+```
+
+> Addition
+
+```scala
+def +[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Subtraction
+
+```scala
+def -[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Multiplication
+
+```scala
+def *[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Division
+
+```scala
+def /[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Remainder
+
+```scala
+def %[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Bitwise AND
+
+```scala
+def &[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Bitwise OR
+
+```scala
+def |[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Bitwise XOR
+
+```scala
+def ^[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> TRUE if the operand is within a range
+
+```scala
+def between(x: Expr[Int], y: Expr[Int]): Expr[Boolean] = ...
+```
+
+> Unary Positive Operator
+
+```scala
+def unary_+ : Expr[T] = ...
+```
+
+> Unary Negation Operator
+
+```scala
+def unary_- : Expr[T] = ...
+```
+
+> Unary Bitwise NOT Operator
+
+```scala
+def unary_~ : Expr[T] = ...
+```
+
+> Returns the absolute value of a number.
+
+```scala
+def abs: Expr[T] = ...
+```
+
+> Returns the remainder of one number divided into another.
+
+```scala
+def mod[V: Numeric](x: Expr[V]): Expr[T] = ...
+```
+
+> Rounds a noninteger value upwards to the next greatest integer. Returns an integer value unchanged.
+
+```scala
+def ceil: Expr[T] = ...
+```
+
+> Rounds a noninteger value downwards to the next least integer. Returns an integer value unchanged.
+
+```scala
+def floor: Expr[T] = ...
+```
+
+> The sign(X) function returns -1, 0, or +1 if the argument X is a numeric
+> value that is negative, zero, or positive, respectively. If the argument to sign(X)
+> is NULL or is a string or blob that cannot be losslessly converted into a number,
+> then sign(X) returns NULL.
+
+```scala
+def sign: Expr[T] = ...
+```
+
+#### `ExprOps.scala`
+
+```scala
+class ExprOps[A](v: Expr[A])
+```
+
+> SQL-style Equals to, translates to SQL `=`. Returns `false` if both values are `NULL`
+
+```scala
+def ` = ...
+```
+
+> SQL-style Not equals to, translates to SQL `<>`. Returns `false` if both values are `NULL`
+
+```scala
+def <>[V](x: Expr[V])(using TypeEq[A, V]): Expr[Boolean] = ...
+```
+
+> Greater than
+
+```scala
+def >[V](x: Expr[V])(using TypeEq[A, V]): Expr[Boolean] = ...
+```
+
+> Less than
+
+```scala
+def <[V](x: Expr[V])(using TypeEq[A, V]): Expr[Boolean] = Expr { implicit ctx =>
+    sql"($v < $x)"
+```
+
+> Greater than or equal to
+
+```scala
+def > = ...
+```
+
+> Less than or equal to
+
+```scala
+def <=[V](x: Expr[V])(using TypeEq[A, V]): Expr[Boolean] = Expr { implicit ctx =>
+    sql"($v <= $x)"
+```
+
+> Translates to a SQL `CAST` from one type to another
+
+```scala
+def cast[V: TypeMapper]: Expr[V] = ...
+```
+
+> Similar to [[cast]], but allows you to pass in an explicit [[SqlStr]] to
+> further specify the SQL type you want to cast to
+
+```scala
+def castNamed[V: TypeMapper](typeName: SqlStr): Expr[V] = ...
+```
+
+#### `ExprOptionOps.scala`
+
+```scala
+class ExprOptionOps[T: TypeMapper](v: Expr[Option[T]])(implicit dialect: DialectTypeMappers)
+```
+
+```scala
+def isDefined: Expr[Boolean] = ...
+```
+
+```scala
+def isEmpty: Expr[Boolean] = ...
+```
+
+```scala
+def map[V: TypeMapper](f: Expr[T] => Expr[V]): Expr[Option[V]] = ...
+```
+
+```scala
+def flatMap[V: TypeMapper](f: Expr[T] => Expr[Option[V]]): Expr[Option[V]] = ...
+```
+
+```scala
+def get: Expr[T] = ...
+```
+
+```scala
+def getOrElse(other: Expr[T]): Expr[T] = ...
+```
+
+```scala
+def orElse(other: Expr[Option[T]]): Expr[Option[T]] = ...
+```
+
+```scala
+def filter(other: Expr[T] => Expr[Boolean]): Expr[Option[T]] = ...
+```
+
+#### `ExprStringLikeOps.scala`
+
+```scala
+abstract class ExprStringLikeOps[T](v: Expr[T])
+```
+
+> Concatenates two strings
+
+```scala
+def +(x: Expr[T]): Expr[T] = ...
+```
+
+> TRUE if the operand matches a pattern
+
+```scala
+def like(x: Expr[T]): Expr[Boolean] = ...
+```
+
+> Returns an integer value representing the starting position of a string within the search string.
+
+```scala
+def indexOf(x: Expr[T]): Expr[Int]
+```
+
+> Converts a string to all lowercase characters.
+
+```scala
+def toLowerCase: Expr[T] = ...
+```
+
+> Converts a string to all uppercase characters.
+
+```scala
+def toUpperCase: Expr[T] = ...
+```
+
+> Returns the number of characters in this string
+
+```scala
+def length: Expr[Int] = ...
+```
+
+> Returns the number of bytes in this string
+
+```scala
+def octetLength: Expr[Int] = ...
+```
+
+> Returns a portion of a string.
+
+```scala
+def substring(start: Expr[Int], length: Expr[Int]): Expr[T] = ...
+```
+
+> Returns whether or not this strings starts with the other.
+
+```scala
+def startsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+> Returns whether or not this strings ends with the other.
+
+```scala
+def endsWith(other: Expr[T]): Expr[Boolean] = ...
+```
+
+> Returns whether or not this strings contains the other.
+
+```scala
+def contains(other: Expr[T]): Expr[Boolean] = ...
+```
+
+#### `ExprStringOps.scala`
+
+```scala
+trait ExprStringOps[T]
+```
+
+> Removes leading and trailing whitespace characters from a character string.
+
+```scala
+def trim: Expr[T] = ...
+```
+
+> Removes leading whitespace characters from a character string.
+
+```scala
+def ltrim: Expr[T] = ...
+```
+
+> Removes trailing whitespace characters from a character string.
+
+```scala
+def rtrim: Expr[T] = ...
+```
+
+> The replace(X,Y,Z) function returns a string formed by substituting string Z
+> for every occurrence of string Y in string X
+
+```scala
+def replace(y: Expr[T], z: Expr[T]): Expr[T] = ...
+```
+
+#### `ExprTypedOps.scala`
+
+```scala
+class ExprTypedOps[T: ClassTag](v: Expr[T])
+```
+
+> Scala-style Equals to, returns `true` if both values are `NULL`.
+> Translates to `IS NOT DISTINCT FROM` if both values are nullable,
+> otherwise translates to `=`
+
+```scala
+def = ...
+```
+
+> Scala-style Not equals to, returns `false` if both values are `NULL`
+> Translates to `IS DISTINCT FROM` if both values are nullable,
+> otherwise translates to `<>`
+
+```scala
+def ! = ...
+```
+
+#### `HyperbolicMathOps.scala`
+
+```scala
+trait HyperbolicMathOps
+```
+
+> Calculate the hyperbolic sine
+
+```scala
+def sinh[T: Numeric](v: Expr[T]): Expr[T] = ...
+```
+
+> Calculate the hyperbolic cosine
+
+```scala
+def cosh[T: Numeric](v: Expr[T]): Expr[T] = ...
+```
+
+> Calculate the hyperbolic tangent
+
+```scala
+def tanh[T: Numeric](v: Expr[T]): Expr[T] = ...
+```
+
+#### `MathOps.scala`
+
+```scala
+trait MathOps
+```
+
+> Converts radians to degrees
+
+```scala
+def degrees[T: Numeric](x: Expr[T]): Expr[Double] = ...
+```
+
+> Converts degrees to radians
+
+```scala
+def radians[T: Numeric](x: Expr[T]): Expr[Double] = ...
+```
+
+> `x` raised to the power of `y`
+
+```scala
+def power[T: Numeric](x: Expr[T], y: Expr[T]): Expr[Double] = ...
+```
+
+> Raises a value to the power of the mathematical constant known as e.
+
+```scala
+def exp[T: Numeric](x: Expr[T]): Expr[Double] = ...
+```
+
+> Returns the natural logarithm of a number.
+
+```scala
+def ln[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Logarithm of x to base b
+
+```scala
+def log[T: Numeric](b: Expr[Int], x: Expr[T]): Expr[Double] = ...
+```
+
+> Base 10 logarithm
+
+```scala
+def log10[T: Numeric](x: Expr[T]): Expr[Double] = ...
+```
+
+> Computes the square root of a number.
+
+```scala
+def sqrt[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the trigonometric sine
+
+```scala
+def sin[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the trigonometric cosine
+
+```scala
+def cos[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the trigonometric tangent
+
+```scala
+def tan[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the arc sine
+
+```scala
+def asin[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the arc cosine
+
+```scala
+def acos[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the arc tangent
+
+```scala
+def atan[T: Numeric](v: Expr[T]): Expr[Double] = ...
+```
+
+> Calculate the arc tangent
+
+```scala
+def atan2[T: Numeric](v: Expr[T], y: Expr[T]): Expr[Double] = ...
+```
+
+> Returns the value of Pi
+
+```scala
+def pi: Expr[Double] = ...
+```
+
+#### `PadOps.scala`
+
+```scala
+trait PadOps
+```
+
+```scala
+def rpad(length: Expr[Int], fill: Expr[String]): Expr[String] = ...
+```
+
+```scala
+def lpad(length: Expr[Int], fill: Expr[String]): Expr[String] = ...
+```
+
+#### `TrimOps.scala`
+
+```scala
+trait TrimOps
+```
+
+> Trim [[x]]s from the left hand side of the string [[v]]
+
+```scala
+def ltrim(x: Expr[String]): Expr[String] = ...
+```
+
+> Trim [[x]]s from the right hand side of the string [[v]]
+
+```scala
+def rtrim(x: Expr[String]): Expr[String] = ...
+```
+
+#### `TypeEq.scala`
+
+> TypeEq indicates that values of two given types can be compared with each other.
+
+```scala
+trait TypeEq[A, B]
+```
+
+```scala
+object TypeEq extends LowLevelDeprecated
+```
+
+```scala
+given [A, B](using A =:= B): TypeEq[A, B] = ...
+```
+
+```scala
+trait LowLevelDeprecated
+```
+
+```scala
+given [A, B](using A =:= B): TypeEq[Option[A], B] = ...
+```
+
+```scala
+given [A, B](using A =:= B): TypeEq[A, Option[B]] = ...
+```
+
+```scala
+given [A, B]: TypeEq[A, B] = ...
+```
+
+```scala
+trait unsafeEq
+```
+
+```scala
+given [A, B]: TypeEq[A, B] = ...
+```
+
+```scala
+given [A, B](using A =:= B): TypeEq[A, Option[B]] = ...
+```
+
+```scala
+given [A, B](using A =:= B): TypeEq[Option[A], B] = ...
+```
+
+```scala
+object unsafeEq extends unsafeEq
+```
+

--- a/docs/slf4j-nop-2.0.13.md
+++ b/docs/slf4j-nop-2.0.13.md
@@ -1,0 +1,70 @@
+# SLF4J NOP 2.0.13 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `7` non-private declaration signatures from `1` source files.
+
+## Coordinates
+- Direct dependency: `org.slf4j:slf4j-nop:2.0.13`
+- Upstream docs: https://www.slf4j.org/
+- Source artifacts included:
+  - `org.slf4j:slf4j-nop:2.0.13`
+
+## Common imports
+
+```scala
+// Usually no imports: this dependency is activated by the SLF4J service provider on the classpath.
+```
+
+## Usage notes
+
+No-operation SLF4J service provider/binding. It normally is not called directly; putting it on the classpath silences SLF4J logging from libraries.
+
+```scala
+// build.mill dependency only:
+val slf4jNop = mvn"org.slf4j:slf4j-nop:2.0.13"
+
+// Optional direct sanity check, though normal application code should not need it:
+val logger = org.slf4j.LoggerFactory.getLogger("mif")
+logger.info("discarded by slf4j-nop")
+```
+
+## API signatures from upstream source
+
+### `org.slf4j:slf4j-nop:2.0.13`
+
+Source: https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/2.0.13/slf4j-nop-2.0.13-sources.jar
+
+#### `org/slf4j/nop/NOPServiceProvider.java`
+
+```java
+public class NOPServiceProvider implements SLF4JServiceProvider
+```
+
+> Declare the version of the SLF4J API this implementation is compiled against.
+> The value of this field is modified with each major release.
+
+```java
+public static String REQUESTED_API_VERSION = ...
+```
+
+```java
+public ILoggerFactory getLoggerFactory()
+```
+
+```java
+public IMarkerFactory getMarkerFactory()
+```
+
+```java
+public MDCAdapter getMDCAdapter()
+```
+
+```java
+    @Override
+public String getRequestedApiVersion()
+```
+
+```java
+public void initialize()
+```
+

--- a/docs/sqlite-jdbc-3.46.1.0.md
+++ b/docs/sqlite-jdbc-3.46.1.0.md
@@ -1,0 +1,9402 @@
+# SQLite JDBC 3.46.1.0 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `1441` non-private declaration signatures from `56` source files.
+
+## Coordinates
+- Direct dependency: `org.xerial:sqlite-jdbc:3.46.1.0`
+- Upstream docs: https://github.com/xerial/sqlite-jdbc
+- Source artifacts included:
+  - `org.xerial:sqlite-jdbc:3.46.1.0`
+
+## Common imports
+
+```scala
+import org.sqlite.SQLiteDataSource
+```
+
+## Usage notes
+
+Xerial SQLite JDBC driver and data source classes. This project primarily uses `org.sqlite.SQLiteDataSource` to create a JDBC data source for ScalaSql.
+
+```scala
+val dataSource = new org.sqlite.SQLiteDataSource()
+dataSource.setUrl("jdbc:sqlite:/tmp/repository.sqlite")
+dataSource.setBusyTimeout(5000)
+
+val connection = dataSource.getConnection()
+try
+  val statement = connection.createStatement()
+  try statement.executeUpdate("PRAGMA foreign_keys = ON")
+  finally statement.close()
+finally connection.close()
+```
+
+## API signatures from upstream source
+
+### `org.xerial:sqlite-jdbc:3.46.1.0`
+
+Source: https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.46.1.0/sqlite-jdbc-3.46.1.0-sources.jar
+
+#### `org/sqlite/BusyHandler.java`
+
+> https://www.sqlite.org/c3ref/busy_handler.html
+
+```java
+public abstract class BusyHandler
+```
+
+> Sets a busy handler for the connection.
+>
+> @param conn the SQLite connection
+> @param busyHandler the busyHandler
+> @throws SQLException
+
+```java
+public static final void setHandler(Connection conn, BusyHandler busyHandler)
+```
+
+> Clears any busy handler registered with the connection.
+>
+> @param conn the SQLite connection
+> @throws SQLException
+
+```java
+public static final void clearHandler(Connection conn) throws SQLException
+```
+
+#### `org/sqlite/Collation.java`
+
+> Provides an interface for creating SQLite user-defined collations.
+>
+> <p>A subclass of <tt>org.sqlite.Collation</tt> can be registered with <tt>Collation.create()</tt>
+> and called by the name it was given. All collations must implement <tt>xCompare(String,
+> String)</tt>, which is called when SQLite compares two strings using the custom collation. Eg.
+>
+> <pre>
+> Class.forName("org.sqlite.JDBC");
+> Connection conn = DriverManager.getConnection("jdbc:sqlite:");
+>
+> Collation.create(conn, "REVERSE", new Collation() {
+> protected int xCompare(String str1, String str2) {
+> return str1.compareTo(str2) * -1;
+> }
+> });
+>
+> conn.createStatement().execute("select c1 from t order by c1 collate REVERSE;");
+> </pre>
+
+```java
+public abstract class Collation
+```
+
+> Registers a given collation with the connection.
+>
+> @param conn The connection.
+> @param name The name of the collation.
+> @param f The collation to register.
+
+```java
+public static final void create(Connection conn, String name, Collation f) throws SQLException
+```
+
+> Removes a named collation from the given connection.
+>
+> @param conn The connection to remove the collation from.
+> @param name The name of the collation.
+> @throws SQLException
+
+```java
+public static final void destroy(Connection conn, String name) throws SQLException
+```
+
+#### `org/sqlite/ExtendedCommand.java`
+
+> parsing SQLite specific extension of SQL command
+>
+> @author leo
+
+```java
+public class ExtendedCommand
+```
+
+```java
+public static interface SQLExtension
+```
+
+```java
+public void execute(DB db) throws SQLException ;
+```
+
+> Parses extended commands of "backup" or "restore" for SQLite database.
+>
+> @param sql One of the extended commands:<br>
+> backup sourceDatabaseName to destinationFileName OR restore targetDatabaseName from
+> sourceFileName
+> @return BackupCommand object if the argument is a backup command; RestoreCommand object if
+> the argument is a restore command;
+> @throws SQLException
+
+```java
+public static SQLExtension parse(String sql) throws SQLException
+```
+
+> Remove the quotation mark from string.
+>
+> @param s String with quotation mark.
+> @return String with quotation mark removed.
+
+```java
+public static String removeQuotation(String s)
+```
+
+```java
+public static class BackupCommand implements SQLExtension
+```
+
+```java
+public final String srcDB ;
+```
+
+```java
+public final String destFile ;
+```
+
+> Parses SQLite database backup command and creates a BackupCommand object.
+>
+> @param sql SQLite database backup command.
+> @return BackupCommand object.
+> @throws SQLException
+
+```java
+public static BackupCommand parse(String sql) throws SQLException
+```
+
+```java
+public void execute(DB db) throws SQLException
+```
+
+```java
+public static class RestoreCommand implements SQLExtension
+```
+
+```java
+public final String targetDB ;
+```
+
+```java
+public final String srcFile ;
+```
+
+> Parses SQLite database restore command and creates a RestoreCommand object.
+>
+> @param sql SQLite restore backup command
+> @return RestoreCommand object.
+> @throws SQLException
+
+```java
+public static RestoreCommand parse(String sql) throws SQLException
+```
+
+> @see org.sqlite.ExtendedCommand.SQLExtension#execute(org.sqlite.core.DB)
+
+```java
+public void execute(DB db) throws SQLException
+```
+
+#### `org/sqlite/FileException.java`
+
+```java
+public class FileException extends Exception
+```
+
+#### `org/sqlite/Function.java`
+
+> Provides an interface for creating SQLite user-defined functions.
+>
+> <p>A subclass of <tt>org.sqlite.Function</tt> can be registered with <tt>Function.create()</tt>
+> and called by the name it was given. All functions must implement <tt>xFunc()</tt>, which is
+> called when SQLite runs the custom function. E.g.
+>
+> <pre>
+> Class.forName("org.sqlite.JDBC");
+> Connection conn = DriverManager.getConnection("jdbc:sqlite:");
+>
+> Function.create(conn, "myFunc", new Function() {
+> protected void xFunc() {
+> System.out.println("myFunc called!");
+> }
+> });
+>
+> conn.createStatement().execute("select myFunc();");
+> </pre>
+>
+> <p>Arguments passed to a custom function can be accessed using the <tt>protected</tt> functions
+> provided. <tt>args()</tt> returns the number of arguments passed, while
+> <tt>value_<type>(int)</tt> returns the value of the specific argument. Similarly, a
+> function can return a value using the <tt>result(<type>)</tt> function.
+
+```java
+public abstract class Function
+```
+
+> Flag to provide to {@link #create(Connection, String, Function, int)} that marks this
+> Function as deterministic, making is usable in Indexes on Expressions.
+
+```java
+public static final int FLAG_DETERMINISTIC = ...
+```
+
+> Registers a given function with the connection.
+>
+> @param conn The connection.
+> @param name The name of the function.
+> @param f The function to register.
+
+```java
+public static void create(Connection conn, String name, Function f) throws SQLException
+```
+
+> Registers a given function with the connection.
+>
+> @param conn The connection.
+> @param name The name of the function.
+> @param f The function to register.
+> @param flags Extra flags to pass, such as {@link #FLAG_DETERMINISTIC}
+
+```java
+public static void create(Connection conn, String name, Function f, int flags)
+```
+
+> Registers a given function with the connection.
+>
+> @param conn The connection.
+> @param name The name of the function.
+> @param f The function to register.
+> @param nArgs The number of arguments that the function takes.
+> @param flags Extra flags to pass, such as {@link #FLAG_DETERMINISTIC}
+
+```java
+public static void create(Connection conn, String name, Function f, int nArgs, int flags)
+```
+
+> Removes a named function from the given connection.
+>
+> @param conn The connection to remove the function from.
+> @param name The name of the function.
+> @param nArgs Ignored.
+> @throws SQLException
+
+```java
+public static void destroy(Connection conn, String name, int nArgs) throws SQLException
+```
+
+> Removes a named function from the given connection.
+>
+> @param conn The connection to remove the function from.
+> @param name The name of the function.
+> @throws SQLException
+
+```java
+public static void destroy(Connection conn, String name) throws SQLException
+```
+
+> Provides an interface for creating SQLite user-defined aggregate functions.
+>
+> @see Function
+
+```java
+public abstract static class Aggregate extends Function implements Cloneable
+```
+
+> @see java.lang.Object#clone()
+
+```java
+public Object clone() throws CloneNotSupportedException
+```
+
+> Provides an interface for creating SQLite user-defined window functions.
+>
+> @see Aggregate
+
+```java
+public abstract static class Window extends Aggregate
+```
+
+#### `org/sqlite/JDBC.java`
+
+```java
+public class JDBC implements Driver
+```
+
+```java
+public static final String PREFIX = ...
+```
+
+> @see java.sql.Driver#getMajorVersion()
+
+```java
+public int getMajorVersion()
+```
+
+> @see java.sql.Driver#getMinorVersion()
+
+```java
+public int getMinorVersion()
+```
+
+> @see java.sql.Driver#jdbcCompliant()
+
+```java
+public boolean jdbcCompliant()
+```
+
+```java
+public Logger getParentLogger() throws SQLFeatureNotSupportedException
+```
+
+> @see java.sql.Driver#acceptsURL(java.lang.String)
+
+```java
+public boolean acceptsURL(String url)
+```
+
+> Validates a URL
+>
+> @param url
+> @return true if the URL is valid, false otherwise
+
+```java
+public static boolean isValidURL(String url)
+```
+
+> @see java.sql.Driver#getPropertyInfo(java.lang.String, java.util.Properties)
+
+```java
+public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException
+```
+
+> @see java.sql.Driver#connect(java.lang.String, java.util.Properties)
+
+```java
+public Connection connect(String url, Properties info) throws SQLException
+```
+
+> Gets the location to the database from a given URL.
+>
+> @param url The URL to extract the location from.
+> @return The location to the database.
+
+```java
+static String extractAddress(String url)
+```
+
+> Creates a new database connection to a given URL.
+>
+> @param url the URL
+> @param prop the properties
+> @return a Connection object that represents a connection to the URL
+> @throws SQLException
+> @see java.sql.Driver#connect(java.lang.String, java.util.Properties)
+
+```java
+public static SQLiteConnection createConnection(String url, Properties prop)
+```
+
+#### `org/sqlite/NativeLibraryNotFoundException.java`
+
+```java
+public class NativeLibraryNotFoundException extends Exception
+```
+
+#### `org/sqlite/ProgressHandler.java`
+
+> https://www.sqlite.org/c3ref/progress_handler.html
+
+```java
+public abstract class ProgressHandler
+```
+
+> Sets a progress handler for the connection.
+>
+> @param conn the SQLite connection
+> @param vmCalls the approximate number of virtual machine instructions that are evaluated
+> between successive invocations of the progressHandler
+> @param progressHandler the progressHandler
+> @throws SQLException
+
+```java
+public static final void setHandler(
+            Connection conn, int vmCalls, ProgressHandler progressHandler) throws SQLException
+```
+
+> Clears any progress handler registered with the connection.
+>
+> @param conn the SQLite connection
+> @throws SQLException
+
+```java
+public static final void clearHandler(Connection conn) throws SQLException
+```
+
+#### `org/sqlite/SQLiteCommitListener.java`
+
+> https://www.sqlite.org/c3ref/commit_hook.html
+
+```java
+public interface SQLiteCommitListener
+```
+
+#### `org/sqlite/SQLiteConfig.java`
+
+> SQLite Configuration
+>
+> <p>See also https://www.sqlite.org/pragma.html
+>
+> @author leo
+
+```java
+public class SQLiteConfig
+```
+
+```java
+public static final String DEFAULT_DATE_STRING_FORMAT = ...
+```
+
+```java
+public SQLiteConnectionConfig newConnectionConfig()
+```
+
+> Create a new JDBC connection using the current configuration
+>
+> @return The connection.
+> @throws SQLException
+
+```java
+public Connection createConnection(String url) throws SQLException
+```
+
+> Configures a connection.
+>
+> @param conn The connection to configure.
+> @throws SQLException
+
+```java
+public void apply(Connection conn) throws SQLException
+```
+
+> Checks if the shared cache option is turned on.
+>
+> @return True if turned on; false otherwise.
+
+```java
+public boolean isEnabledSharedCache()
+```
+
+> Checks if the load extension option is turned on.
+>
+> @return True if turned on; false otherwise.
+
+```java
+public boolean isEnabledLoadExtension()
+```
+
+> @return The open mode flags.
+
+```java
+public int getOpenModeFlags()
+```
+
+> Sets a pragma's value.
+>
+> @param pragma The pragma to change.
+> @param value The value to set it to.
+
+```java
+public void setPragma(Pragma pragma, String value)
+```
+
+> Convert this configuration into a Properties object, which can be passed to the {@link
+> DriverManager#getConnection(String, Properties)}.
+>
+> @return The property object.
+
+```java
+public Properties toProperties()
+```
+
+> @return Array of DriverPropertyInfo objects.
+
+```java
+static DriverPropertyInfo[] getDriverPropertyInfo()
+```
+
+```java
+static class OnOff
+```
+
+```java
+static final Set<String> pragmaSet = ...
+```
+
+> @return true if explicit read only transactions are enabled
+
+```java
+public boolean isExplicitReadOnly()
+```
+
+> Enable read only transactions after connection creation if explicit read only is true.
+>
+> @param readOnly whether to enable explicit read only
+
+```java
+public void setExplicitReadOnly(boolean readOnly)
+```
+
+```java
+public enum Pragma
+```
+
+```java
+public final String pragmaName ;
+```
+
+```java
+public final String[] choices ;
+```
+
+```java
+public final String description ;
+```
+
+```java
+public final String getPragmaName()
+```
+
+> Sets the open mode flags.
+>
+> @param mode The open mode.
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+
+```java
+public void setOpenMode(SQLiteOpenMode mode)
+```
+
+> Re-sets the open mode flags.
+>
+> @param mode The open mode.
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+
+```java
+public void resetOpenMode(SQLiteOpenMode mode)
+```
+
+> Enables or disables the sharing of the database cache and schema data structures between
+> connections to the same database.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/c3ref/enable_shared_cache.html">www.sqlite.org/c3ref/enable_shared_cache.html</a>
+
+```java
+public void setSharedCache(boolean enable)
+```
+
+> Enables or disables extension loading.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/c3ref/load_extension.html">www.sqlite.org/c3ref/load_extension.html</a>
+
+```java
+public void enableLoadExtension(boolean enable)
+```
+
+> Sets the read-write mode for the database.
+>
+> @param readOnly True for read-only; otherwise read-write.
+
+```java
+public void setReadOnly(boolean readOnly)
+```
+
+> Changes the maximum number of database disk pages that SQLite will hold in memory at once per
+> open database file.
+>
+> @param numberOfPages Cache size in number of pages.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
+
+```java
+public void setCacheSize(int numberOfPages)
+```
+
+> Enables or disables case sensitive for the LIKE operator.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_case_sensitive_like">www.sqlite.org/pragma.html#pragma_case_sensitive_like</a>
+
+```java
+public void enableCaseSensitiveLike(boolean enable)
+```
+
+> @deprecated Enables or disables the count-changes flag. When enabled, INSERT, UPDATE and
+> DELETE statements return the number of rows they modified.
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_count_changes">www.sqlite.org/pragma.html#pragma_count_changes</a>
+
+```java
+    @Deprecated
+public void enableCountChanges(boolean enable)
+```
+
+> Sets the suggested maximum number of database disk pages that SQLite will hold in memory at
+> once per open database file. The cache size set here persists across database connections.
+>
+> @param numberOfPages Cache size in number of pages.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
+
+```java
+public void setDefaultCacheSize(int numberOfPages)
+```
+
+> Defers enforcement of foreign key constraints until the outermost transaction is committed.
+>
+> @param enable True to enable; false to disable;
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_defer_foreign_keys">https://www.sqlite.org/pragma.html#pragma_defer_foreign_keys</a>
+
+```java
+public void deferForeignKeys(boolean enable)
+```
+
+> @deprecated Enables or disables the empty_result_callbacks flag.
+> @param enable True to enable; false to disable. false.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_empty_result_callbacks">https://www.sqlite.org/pragma.html#pragma_empty_result_callbacks</a>
+
+```java
+    @Deprecated
+public void enableEmptyResultCallBacks(boolean enable)
+```
+
+```java
+public String getValue() ;
+```
+
+```java
+public enum Encoding implements PragmaValue
+```
+
+```java
+public final String typeName ;
+```
+
+```java
+public String getValue()
+```
+
+```java
+public static Encoding getEncoding(String value)
+```
+
+```java
+public enum JournalMode implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+> Sets the text encoding used by the main database.
+>
+> @param encoding One of {@link Encoding}
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_encoding">www.sqlite.org/pragma.html#pragma_encoding</a>
+
+```java
+public void setEncoding(Encoding encoding)
+```
+
+> Whether to enforce foreign key constraints. This setting affects the execution of all
+> statements prepared using the database connection, including those prepared before the
+> setting was changed.
+>
+> @param enforce True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_foreign_keys">www.sqlite.org/pragma.html#pragma_foreign_keys</a>
+
+```java
+public void enforceForeignKeys(boolean enforce)
+```
+
+> @deprecated Enables or disables the full_column_name flag. This flag together with the
+> short_column_names flag determine the way SQLite assigns names to result columns of
+> SELECT statements.
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_full_column_names">www.sqlite.org/pragma.html#pragma_full_column_names</a>
+
+```java
+    @Deprecated
+public void enableFullColumnNames(boolean enable)
+```
+
+> Enables or disables the fullfsync flag. This flag determines whether or not the F_FULLFSYNC
+> syncing method is used on systems that support it. The default value of the fullfsync flag is
+> off. Only Mac OS X supports F_FULLFSYNC.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_fullfsync">www.sqlite.org/pragma.html#pragma_fullfsync</a>
+
+```java
+public void enableFullSync(boolean enable)
+```
+
+> Sets the incremental_vacuum value; the number of pages to be removed from the <a
+> href="https://www.sqlite.org/fileformat2.html#freelist">freelist</a>. The database file is
+> truncated by the same amount.
+>
+> @param numberOfPagesToBeRemoved The number of pages to be removed.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_incremental_vacuum">www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
+
+```java
+public void incrementalVacuum(int numberOfPagesToBeRemoved)
+```
+
+> Sets the journal mode for databases associated with the current database connection.
+>
+> @param mode One of {@link JournalMode}
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_journal_mode">www.sqlite.org/pragma.html#pragma_journal_mode</a>
+
+```java
+public void setJournalMode(JournalMode mode)
+```
+
+> Sets the journal_size_limit. This setting limits the size of the rollback-journal and WAL
+> files left in the file-system after transactions or checkpoints.
+>
+> @param limit Limit value in bytes. A negative number implies no limit.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit">www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
+
+```java
+public void setJournalSizeLimit(int limit)
+```
+
+> Sets the value of the legacy_file_format flag. When this flag is enabled, new SQLite
+> databases are created in a file format that is readable and writable by all versions of
+> SQLite going back to 3.0.0. When the flag is off, new databases are created using the latest
+> file format which might not be readable or writable by versions of SQLite prior to 3.3.0.
+>
+> @param use True to turn on legacy file format; false to turn off.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_legacy_file_format">www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
+
+```java
+public void useLegacyFileFormat(boolean use)
+```
+
+> Sets the value of the legacy_alter_table flag. When this flag is on, the ALTER TABLE RENAME
+> command (for changing the name of a table) works as it did in SQLite 3.24.0 (2018-06-04) and
+> earlier.When the flag is off, using the ALTER TABLE RENAME command will mean that all
+> references to the table anywhere in the schema will be converted to the new name.
+>
+> @param flag True to turn on legacy alter table behaviour; false to turn off.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_legacy_alter_table</a>
+
+```java
+public void setLegacyAlterTable(boolean flag)
+```
+
+```java
+public enum LockingMode implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+> Sets the database connection locking-mode.
+>
+> @param mode One of {@link LockingMode}
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_locking_mode">www.sqlite.org/pragma.html#pragma_locking_mode</a>
+
+```java
+public void setLockingMode(LockingMode mode)
+```
+
+> Sets the page size of the database. The page size must be a power of two between 512 and
+> 65536 inclusive.
+>
+> @param numBytes A power of two between 512 and 65536 inclusive.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_page_size">www.sqlite.org/pragma.html#pragma_page_size</a>
+
+```java
+public void setPageSize(int numBytes)
+```
+
+> Sets the maximum number of pages in the database file.
+>
+> @param numPages Number of pages.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_max_page_count">www.sqlite.org/pragma.html#pragma_max_page_count</a>
+
+```java
+public void setMaxPageCount(int numPages)
+```
+
+> Enables or disables useReadUncommittedIsolationMode.
+>
+> @param useReadUncommittedIsolationMode True to turn on; false to disable. disabled otherwise.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_read_uncommitted">www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
+
+```java
+public void setReadUncommitted(boolean useReadUncommittedIsolationMode)
+```
+
+> Enables or disables the recursive trigger capability.
+>
+> @param enable True to enable the recursive trigger capability.
+> @see <a
+> href="www.sqlite.org/pragma.html#pragma_recursive_triggers">www.sqlite.org/pragma.html#pragma_recursive_triggers</a>
+
+```java
+public void enableRecursiveTriggers(boolean enable)
+```
+
+> Enables or disables the reverse_unordered_selects flag. This setting causes SELECT statements
+> without an ORDER BY clause to emit their results in the reverse order of what they normally
+> would. This can help debug applications that are making invalid assumptions about the result
+> order.
+>
+> @param enable True to enable reverse_unordered_selects.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
+
+```java
+public void enableReverseUnorderedSelects(boolean enable)
+```
+
+> Enables or disables the short_column_names flag. This flag affects the way SQLite names
+> columns of data returned by SELECT statements.
+>
+> @param enable True to enable short_column_names.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_short_column_names">www.sqlite.org/pragma.html#pragma_short_column_names</a>
+
+```java
+public void enableShortColumnNames(boolean enable)
+```
+
+```java
+public enum SynchronousMode implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+> Changes the setting of the "synchronous" flag.
+>
+> @param mode One of {@link SynchronousMode}:
+> <ul>
+> <li>OFF - SQLite continues without syncing as soon as it has handed data off to the
+> operating system
+> <li>NORMAL - the SQLite database engine will still sync at the most critical moments,
+> but less often than in FULL mode
+> <li>FULL - the SQLite database engine will use the xSync method of the VFS to ensure
+> that all content is safely written to the disk surface prior to continuing. This
+> ensures that an operating system crash or power failure will not corrupt the
+> database.
+> </ul>
+>
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_synchronous">www.sqlite.org/pragma.html#pragma_synchronous</a>
+
+```java
+public void setSynchronous(SynchronousMode mode)
+```
+
+```java
+public enum TempStore implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+> Changes the setting of the "hexkey" flag.
+>
+> @param mode One of {@link HexKeyMode}:
+> <ul>
+> <li>NONE - SQLite uses a string based password
+> <li>SSE - the SQLite database engine will use pragma hexkey = '' to set the password
+> <li>SQLCIPHER - the SQLite database engine calls pragma key = "x''" to set the password
+> </ul>
+
+```java
+public void setHexKeyMode(HexKeyMode mode)
+```
+
+```java
+public enum HexKeyMode implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+> Changes the setting of the "temp_store" parameter.
+>
+> @param storeType One of {@link TempStore}:
+> <ul>
+> <li>DEFAULT - the compile-time C preprocessor macro SQLITE_TEMP_STORE is used to
+> determine where temporary tables and indices are stored
+> <li>FILE - temporary tables and indices are stored in a file.
+> </ul>
+> <li>MEMORY - temporary tables and indices are kept in as if they were pure in-memory
+> databases memory
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_temp_store">www.sqlite.org/pragma.html#pragma_temp_store</a>
+
+```java
+public void setTempStore(TempStore storeType)
+```
+
+> Changes the value of the sqlite3_temp_directory global variable, which many operating-system
+> interface backends use to determine where to store temporary tables and indices.
+>
+> @param directoryName Directory name for storing temporary tables and indices.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_temp_store_directory">www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
+
+```java
+public void setTempStoreDirectory(String directoryName)
+```
+
+> Set the value of the user-version. The user-version is not used internally by SQLite. It may
+> be used by applications for any purpose. The value is stored in the database header at offset
+> 60.
+>
+> @param version A big-endian 32-bit signed integer.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_user_version">www.sqlite.org/pragma.html#pragma_user_version</a>
+
+```java
+public void setUserVersion(int version)
+```
+
+> Set the value of the application-id. The application-id is not used internally by SQLite.
+> Applications that use SQLite as their application file-format should set the Application ID
+> integer to a unique integer so that utilities such as file(1) can determine the specific file
+> type. The value is stored in the database header at offset 68.
+>
+> @param id A big-endian 32-bit unsigned integer.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_application_id">www.sqlite.org/pragma.html#pragma_application_id</a>
+
+```java
+public void setApplicationId(int id)
+```
+
+```java
+public enum TransactionMode implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+```java
+public static TransactionMode getMode(String mode)
+```
+
+> Sets the mode that will be used to start transactions.
+>
+> @param transactionMode One of {@link TransactionMode}.
+> @see <a
+> href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
+
+```java
+public void setTransactionMode(TransactionMode transactionMode)
+```
+
+> Sets the mode that will be used to start transactions.
+>
+> @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
+> @see <a
+> href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
+
+```java
+public void setTransactionMode(String transactionMode)
+```
+
+> @return The transaction mode.
+
+```java
+public TransactionMode getTransactionMode()
+```
+
+```java
+public enum DatePrecision implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+```java
+public static DatePrecision getPrecision(String precision)
+```
+
+> @param datePrecision One of SECONDS or MILLISECONDS
+
+```java
+public void setDatePrecision(String datePrecision)
+```
+
+```java
+public enum DateClass implements PragmaValue
+```
+
+```java
+public String getValue()
+```
+
+```java
+public static DateClass getDateClass(String dateClass)
+```
+
+> @param dateClass One of INTEGER, TEXT or REAL
+
+```java
+public void setDateClass(String dateClass)
+```
+
+> @param dateStringFormat Format of date string
+
+```java
+public void setDateStringFormat(String dateStringFormat)
+```
+
+> @param milliseconds Connect to DB timeout in milliseconds
+
+```java
+public void setBusyTimeout(int milliseconds)
+```
+
+```java
+public int getBusyTimeout()
+```
+
+#### `org/sqlite/SQLiteConnection.java`
+
+```java
+public abstract class SQLiteConnection implements Connection
+```
+
+```java
+public TransactionMode getCurrentTransactionMode()
+```
+
+```java
+public void setCurrentTransactionMode(final TransactionMode currentTransactionMode)
+```
+
+```java
+public void setFirstStatementExecuted(final boolean firstStatementExecuted)
+```
+
+```java
+public boolean isFirstStatementExecuted()
+```
+
+```java
+public SQLiteConnectionConfig getConnectionConfig()
+```
+
+```java
+public CoreDatabaseMetaData getSQLiteDatabaseMetaData() throws SQLException
+```
+
+```java
+    @Override
+public DatabaseMetaData getMetaData() throws SQLException
+```
+
+```java
+public String getUrl()
+```
+
+```java
+public void setSchema(String schema) throws SQLException
+```
+
+```java
+public String getSchema() throws SQLException
+```
+
+```java
+public void abort(Executor executor) throws SQLException
+```
+
+```java
+public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
+```
+
+```java
+public int getNetworkTimeout() throws SQLException
+```
+
+> @see java.sql.Connection#getTransactionIsolation()
+
+```java
+    @Override
+public int getTransactionIsolation()
+```
+
+> @see java.sql.Connection#setTransactionIsolation(int)
+
+```java
+public void setTransactionIsolation(int level) throws SQLException
+```
+
+```java
+public DB getDatabase()
+```
+
+> @see java.sql.Connection#getAutoCommit()
+
+```java
+    @Override
+public boolean getAutoCommit() throws SQLException
+```
+
+> @see java.sql.Connection#setAutoCommit(boolean)
+
+```java
+    @Override
+public void setAutoCommit(boolean ac) throws SQLException
+```
+
+> @return The busy timeout value for the connection.
+> @see <a
+> href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
+
+```java
+public int getBusyTimeout()
+```
+
+> Sets the timeout value for the connection. A timeout value less than or equal to zero turns
+> off all busy handlers.
+>
+> @see <a
+> href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
+> @param timeoutMillis The timeout value in milliseconds.
+> @throws SQLException
+
+```java
+public void setBusyTimeout(int timeoutMillis) throws SQLException
+```
+
+```java
+public void setLimit(SQLiteLimits limit, int value) throws SQLException
+```
+
+```java
+public void getLimit(SQLiteLimits limit) throws SQLException
+```
+
+```java
+    @Override
+public boolean isClosed() throws SQLException
+```
+
+> @see java.sql.Connection#close()
+
+```java
+    @Override
+public void close() throws SQLException
+```
+
+> @return Compile-time library version numbers.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_source_id.html">https://www.sqlite.org/c3ref/c_source_id.html</a>
+
+```java
+public String libversion() throws SQLException
+```
+
+> @see java.sql.Connection#commit()
+
+```java
+    @Override
+public void commit() throws SQLException
+```
+
+> @see java.sql.Connection#rollback()
+
+```java
+    @Override
+public void rollback() throws SQLException
+```
+
+> Add a listener for DB update events, see https://www.sqlite.org/c3ref/update_hook.html
+>
+> @param listener The listener to receive update events
+
+```java
+public void addUpdateListener(SQLiteUpdateListener listener)
+```
+
+> Remove a listener registered for DB update events.
+>
+> @param listener The listener to no longer receive update events
+
+```java
+public void removeUpdateListener(SQLiteUpdateListener listener)
+```
+
+> Add a listener for DB commit/rollback events, see
+> https://www.sqlite.org/c3ref/commit_hook.html
+>
+> @param listener The listener to receive commit events
+
+```java
+public void addCommitListener(SQLiteCommitListener listener)
+```
+
+> Remove a listener registered for DB commit/rollback events.
+>
+> @param listener The listener to no longer receive commit/rollback events.
+
+```java
+public void removeCommitListener(SQLiteCommitListener listener)
+```
+
+```java
+final String newFilename = ...
+```
+
+> Returns a byte array representing the schema content. This method is intended for in-memory
+> schemas. Serialized databases are limited to 2gb.
+>
+> @param schema The schema to serialize
+> @return A byte[] holding the database content
+
+```java
+public byte[] serialize(String schema) throws SQLException
+```
+
+> Deserialize the schema using the given byte array. This method is intended for in-memory
+> database. The call will replace the content of an existing schema. To make sure there is an
+> existing schema, first execute ATTACH ':memory:' AS schema_name
+>
+> @param schema The schema to serialize
+> @param buff The buffer to deserialize
+
+```java
+public void deserialize(String schema, byte[] buff) throws SQLException
+```
+
+#### `org/sqlite/SQLiteConnectionConfig.java`
+
+> Connection local configurations
+
+```java
+public class SQLiteConnectionConfig implements Cloneable
+```
+
+```java
+public static SQLiteConnectionConfig fromPragmaTable(Properties pragmaTable)
+```
+
+```java
+public SQLiteConnectionConfig copyConfig()
+```
+
+```java
+public long getDateMultiplier()
+```
+
+```java
+public SQLiteConfig.DateClass getDateClass()
+```
+
+```java
+public void setDateClass(SQLiteConfig.DateClass dateClass)
+```
+
+```java
+public SQLiteConfig.DatePrecision getDatePrecision()
+```
+
+```java
+public void setDatePrecision(SQLiteConfig.DatePrecision datePrecision)
+```
+
+```java
+public String getDateStringFormat()
+```
+
+```java
+public void setDateStringFormat(String dateStringFormat)
+```
+
+```java
+public FastDateFormat getDateFormat()
+```
+
+```java
+public boolean isAutoCommit()
+```
+
+```java
+public void setAutoCommit(boolean autoCommit)
+```
+
+```java
+public int getTransactionIsolation()
+```
+
+```java
+public void setTransactionIsolation(int transactionIsolation)
+```
+
+```java
+public SQLiteConfig.TransactionMode getTransactionMode()
+```
+
+```java
+    @SuppressWarnings("deprecation")
+public void setTransactionMode(SQLiteConfig.TransactionMode transactionMode)
+```
+
+#### `org/sqlite/SQLiteDataSource.java`
+
+> Provides {@link DataSource} API for configuring SQLite database connection
+>
+> @author leo
+
+```java
+public class SQLiteDataSource implements DataSource
+```
+
+> Sets a data source's configuration.
+>
+> @param config The configuration.
+
+```java
+public void setConfig(SQLiteConfig config)
+```
+
+> @return The configuration for the data source.
+
+```java
+public SQLiteConfig getConfig()
+```
+
+> Sets the location of the database file.
+>
+> @param url The location of the database file.
+
+```java
+public void setUrl(String url)
+```
+
+> @return The location of the database file.
+
+```java
+public String getUrl()
+```
+
+> Sets the database name.
+>
+> @param databaseName The name of the database
+
+```java
+public void setDatabaseName(String databaseName)
+```
+
+> @return The name of the database if one was set.
+> @see SQLiteDataSource#setDatabaseName(String)
+
+```java
+public String getDatabaseName()
+```
+
+> Enables or disables the sharing of the database cache and schema data structures between
+> connections to the same database.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/c3ref/enable_shared_cache.html">https://www.sqlite.org/c3ref/enable_shared_cache.html</a>
+
+```java
+public void setSharedCache(boolean enable)
+```
+
+> Enables or disables extension loading.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/c3ref/load_extension.html">https://www.sqlite.org/c3ref/load_extension.html</a>
+
+```java
+public void setLoadExtension(boolean enable)
+```
+
+> Sets the database to be opened in read-only mode
+>
+> @param readOnly True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+
+```java
+public void setReadOnly(boolean readOnly)
+```
+
+> Sets the amount of time that the connection's busy handler will wait when a table is locked.
+>
+> @param milliseconds The number of milliseconds to wait.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_busy_timeout">https://www.sqlite.org/pragma.html#pragma_busy_timeout</a>
+
+```java
+public void setBusyTimeout(int milliseconds)
+```
+
+> Sets the suggested maximum number of database disk pages that SQLite will hold in memory at
+> once per open database file.
+>
+> @param numberOfPages The number of database disk pages.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_cache_size">https://www.sqlite.org/pragma.html#pragma_cache_size</a>
+
+```java
+public void setCacheSize(int numberOfPages)
+```
+
+> Enables or disables case sensitivity for the built-in LIKE operator.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/compile.html#case_sensitive_like">https://www.sqlite.org/compile.html#case_sensitive_like</a>
+
+```java
+public void setCaseSensitiveLike(boolean enable)
+```
+
+> Enables or disables the count-changes flag. When enabled INSERT, UPDATE and DELETE statements
+> return the number of rows they modified.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_count_changes">https://www.sqlite.org/pragma.html#pragma_count_changes</a>
+
+```java
+public void setCountChanges(boolean enable)
+```
+
+> Sets the default maximum number of database disk pages that SQLite will hold in memory at
+> once per open database file.
+>
+> @param numberOfPages The default suggested cache size.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_cache_size">https://www.sqlite.org/pragma.html#pragma_cache_size</a>
+
+```java
+public void setDefaultCacheSize(int numberOfPages)
+```
+
+> Sets the text encoding used by the main database.
+>
+> @param encoding One of "UTF-8", "UTF-16le" (little-endian UTF-16) or "UTF-16be" (big-endian
+> UTF-16).
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_encoding">
+> https://www.sqlite.org/pragma.html#pragma_encoding</a>
+
+```java
+public void setEncoding(String encoding)
+```
+
+> Enables or disables the enforcement of foreign key constraints.
+>
+> @param enforce True to enable; false to disable.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_foreign_keys">
+> https://www.sqlite.org/pragma.html#pragma_foreign_keys</a>
+
+```java
+public void setEnforceForeignKeys(boolean enforce)
+```
+
+> Enables or disables the full_column_names flag. This flag together with the
+> short_column_names flag determine the way SQLite assigns names to result columns of SELECT
+> statements.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_full_column_names">https://www.sqlite.org/pragma.html#pragma_full_column_names</a>
+
+```java
+public void setFullColumnNames(boolean enable)
+```
+
+> Enables or disables the fullfsync flag. This flag determines whether or not the F_FULLFSYNC
+> syncing method is used on systems that support it.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_fullfsync">https://www.sqlite.org/pragma.html#pragma_fullfsync</a>
+
+```java
+public void setFullSync(boolean enable)
+```
+
+> Set the incremental_vacuum value that causes up to N pages to be removed from the <a
+> href="https://www.sqlite.org/fileformat2.html#freelist">https://www.sqlite.org/fileformat2.html#freelist</a>.
+>
+> @param numberOfPagesToBeRemoved
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_incremental_vacuum">
+> https://www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
+
+```java
+public void setIncrementalVacuum(int numberOfPagesToBeRemoved)
+```
+
+> Sets the journal mode for databases associated with the current database connection.
+>
+> @param mode One of DELETE, TRUNCATE, PERSIST, MEMORY, WAL or OFF.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_journal_mode">
+> https://www.sqlite.org/pragma.html#pragma_journal_mode</a>
+
+```java
+public void setJournalMode(String mode)
+```
+
+> Sets the limit of the size of rollback-journal and WAL files left in the file-system after
+> transactions or checkpoints.
+>
+> @param limit The default journal size limit is -1 (no limit).
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit">
+> https://www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
+
+```java
+public void setJournalSizeLimit(int limit)
+```
+
+> Set the value of the legacy_file_format flag. When this flag is on, new databases are created
+> in a file format that is readable and writable by all versions of SQLite going back to 3.0.0.
+> When the flag is off, new databases are created using the latest file format which might not
+> be readable or writable by versions of SQLite prior to 3.3.0.
+>
+> @param use True to turn on; false to turn off.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_legacy_file_format">https://www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
+
+```java
+public void setLegacyFileFormat(boolean use)
+```
+
+> Sets the value of the legacy_alter_table flag. When this flag is on, the ALTER TABLE RENAME
+> command (for changing the name of a table) works as it did in SQLite 3.24.0 (2018-06-04) and
+> earlier.When the flag is off, using the ALTER TABLE RENAME command will mean that all
+> references to the table anywhere in the schema will be converted to the new name.
+>
+> @param flag True to turn on legacy alter table behaviour; false to turn off.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_legacy_alter_table</a>
+
+```java
+public void setLegacyAlterTable(boolean flag)
+```
+
+> Sets the database connection locking-mode.
+>
+> @param mode Either NORMAL or EXCLUSIVE.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_locking_mode">
+> https://www.sqlite.org/pragma.html#pragma_locking_mode</a>
+
+```java
+public void setLockingMode(String mode)
+```
+
+> Set the page size of the database.
+>
+> @param numBytes The page size must be a power of two between 512 and 65536 inclusive.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_page_size">
+> https://www.sqlite.org/pragma.html#pragma_page_size</a>
+
+```java
+public void setPageSize(int numBytes)
+```
+
+> Set the maximum number of pages in the database file.
+>
+> @param numPages The maximum page count cannot be reduced below the current database size.
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_max_page_count">
+> https://www.sqlite.org/pragma.html#pragma_max_page_count</a>
+
+```java
+public void setMaxPageCount(int numPages)
+```
+
+> Set READ UNCOMMITTED isolation
+>
+> @param useReadUncommittedIsolationMode True to turn on; false to turn off.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_read_uncommitted">https://www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
+
+```java
+public void setReadUncommitted(boolean useReadUncommittedIsolationMode)
+```
+
+> Enables or disables the recursive trigger capability. Changing the recursive_triggers setting
+> affects the execution of all statements prepared using the database connection, including
+> those prepared before the setting was changed.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_recursive_triggers">https://www.sqlite.org/pragma.html#pragma_recursive_triggers</a>
+
+```java
+public void setRecursiveTriggers(boolean enable)
+```
+
+> Enables or disables the reverse_unordered_selects flag. When enabled it causes SELECT
+> statements without an ORDER BY clause to emit their results in the reverse order of what they
+> normally would.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
+
+```java
+public void setReverseUnorderedSelects(boolean enable)
+```
+
+> Enables or disables the short_column_names flag. This flag affects the way SQLite names
+> columns of data returned by SELECT statements.
+>
+> @param enable True to enable; false to disable.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_short_column_names">https://www.sqlite.org/pragma.html#pragma_short_column_names</a>
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_fullfsync">https://www.sqlite.org/pragma.html#pragma_fullfsync</a>
+
+```java
+public void setShortColumnNames(boolean enable)
+```
+
+> Sets the setting of the "synchronous" flag.
+>
+> @param mode One of OFF, NORMAL or FULL;
+> @see <a href="https://www.sqlite.org/pragma.html#pragma_synchronous">
+> https://www.sqlite.org/pragma.html#pragma_synchronous</a>
+
+```java
+public void setSynchronous(String mode)
+```
+
+> Set the temp_store type which is used to determine where temporary tables and indices are
+> stored.
+>
+> @param storeType One of "DEFAULT", "FILE", "MEMORY"
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_temp_store">https://www.sqlite.org/pragma.html#pragma_temp_store</a>
+
+```java
+public void setTempStore(String storeType)
+```
+
+> Set the value of the sqlite3_temp_directory global variable, which many operating-system
+> interface backends use to determine where to store temporary tables and indices.
+>
+> @param directoryName The temporary directory name.
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_temp_store_directory">https://www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
+
+```java
+public void setTempStoreDirectory(String directoryName)
+```
+
+> Sets the mode that will be used to start transactions for this database.
+>
+> @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
+> @see <a
+> href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
+
+```java
+public void setTransactionMode(String transactionMode)
+```
+
+> Sets the value of the user-version. It is a big-endian 32-bit signed integer stored in the
+> database header at offset 60.
+>
+> @param version
+> @see <a
+> href="https://www.sqlite.org/pragma.html#pragma_schema_version">https://www.sqlite.org/pragma.html#pragma_schema_version</a>
+
+```java
+public void setUserVersion(int version)
+```
+
+> @see javax.sql.DataSource#getConnection()
+
+```java
+public Connection getConnection() throws SQLException
+```
+
+> @see javax.sql.DataSource#getConnection(java.lang.String, java.lang.String)
+
+```java
+public SQLiteConnection getConnection(String username, String password) throws SQLException
+```
+
+> @see javax.sql.DataSource#getLogWriter()
+
+```java
+public PrintWriter getLogWriter() throws SQLException
+```
+
+> @see javax.sql.DataSource#getLoginTimeout()
+
+```java
+public int getLoginTimeout() throws SQLException
+```
+
+```java
+public Logger getParentLogger() throws SQLFeatureNotSupportedException
+```
+
+> @see javax.sql.DataSource#setLogWriter(java.io.PrintWriter)
+
+```java
+public void setLogWriter(PrintWriter out) throws SQLException
+```
+
+> @see javax.sql.DataSource#setLoginTimeout(int)
+
+```java
+public void setLoginTimeout(int seconds) throws SQLException
+```
+
+> Determines if this object wraps a given class.
+>
+> @param iface The class to check.
+> @return True if it is an instance of the current class; false otherwise.
+> @throws SQLException
+
+```java
+public boolean isWrapperFor(Class<?> iface) throws SQLException
+```
+
+> Casts this object to the given class.
+>
+> @param iface The class to cast to.
+> @return The casted class.
+> @throws SQLException
+
+```java
+    @SuppressWarnings("unchecked")
+public <T> T unwrap(Class<T> iface) throws SQLException
+```
+
+#### `org/sqlite/SQLiteErrorCode.java`
+
+> SQLite3 error code
+>
+> @author leo
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_abort.html">https://www.sqlite.org/c3ref/c_abort.html</a>
+
+```java
+public enum SQLiteErrorCode
+```
+
+```java
+public final int code ;
+```
+
+```java
+public final String message ;
+```
+
+> @param errorCode Error code.
+> @return Error message.
+
+```java
+public static SQLiteErrorCode getErrorCode(int errorCode)
+```
+
+> @see java.lang.Enum#toString()
+
+```java
+    @Override
+public String toString()
+```
+
+#### `org/sqlite/SQLiteException.java`
+
+```java
+public class SQLiteException extends SQLException
+```
+
+```java
+public SQLiteErrorCode getResultCode()
+```
+
+#### `org/sqlite/SQLiteJDBCLoader.java`
+
+> Set the system properties, org.sqlite.lib.path, org.sqlite.lib.name, appropriately so that the
+> SQLite JDBC driver can find *.dll, *.dylib and *.so files, according to the current OS (win,
+> linux, mac).
+>
+> <p>The library files are automatically extracted from this project's package (JAR).
+>
+> <p>usage: call {@link #initialize()} before using SQLite JDBC driver.
+>
+> @author leo
+
+```java
+public class SQLiteJDBCLoader
+```
+
+> Loads SQLite native JDBC library.
+>
+> @return True if SQLite native library is successfully loaded; false otherwise.
+
+```java
+public static synchronized boolean initialize() throws Exception
+```
+
+> Deleted old native libraries e.g. on Windows the DLL file is not removed on VM-Exit (bug #80)
+
+```java
+static void cleanup()
+```
+
+> Checks if the SQLite JDBC driver is set to native mode.
+>
+> @return True if the SQLite JDBC driver is set to native Java mode; false otherwise.
+
+```java
+public static boolean isNativeMode() throws Exception
+```
+
+> Computes the MD5 value of the input stream.
+>
+> @param input InputStream.
+> @return Encrypted string for the InputStream.
+> @throws IOException
+> @throws NoSuchAlgorithmException
+
+```java
+static String md5sum(InputStream input) throws IOException
+```
+
+> @return The major version of the SQLite JDBC driver.
+
+```java
+public static int getMajorVersion()
+```
+
+> @return The minor version of the SQLite JDBC driver.
+
+```java
+public static int getMinorVersion()
+```
+
+> @return The version of the SQLite JDBC driver.
+
+```java
+public static String getVersion()
+```
+
+> This class will load the version from resources during <clinit>. By initializing this at
+> build-time in native-image, the resources do not need to be included in the native
+> executable, and we're eliminating the IO operations as well.
+
+```java
+public static final class VersionHolder
+```
+
+#### `org/sqlite/SQLiteLimits.java`
+
+```java
+public enum SQLiteLimits
+```
+
+```java
+public int getId()
+```
+
+#### `org/sqlite/SQLiteOpenMode.java`
+
+> Database file open modes of SQLite.
+>
+> <p>See also https://www.sqlite.org/c3ref/open.html
+>
+> @author leo
+
+```java
+public enum SQLiteOpenMode
+```
+
+```java
+public final int flag ;
+```
+
+#### `org/sqlite/SQLiteUpdateListener.java`
+
+> https://www.sqlite.org/c3ref/update_hook.html
+
+```java
+public interface SQLiteUpdateListener
+```
+
+```java
+public enum Type
+```
+
+#### `org/sqlite/core/Codes.java`
+
+```java
+public interface Codes
+```
+
+> Successful result
+
+```java
+public static final int SQLITE_OK = ...
+```
+
+> SQL error or missing database
+
+```java
+public static final int SQLITE_ERROR = ...
+```
+
+> An internal logic error in SQLite
+
+```java
+public static final int SQLITE_INTERNAL = ...
+```
+
+> Access permission denied
+
+```java
+public static final int SQLITE_PERM = ...
+```
+
+> Callback routine requested an abort
+
+```java
+public static final int SQLITE_ABORT = ...
+```
+
+> The database file is locked
+
+```java
+public static final int SQLITE_BUSY = ...
+```
+
+> A table in the database is locked
+
+```java
+public static final int SQLITE_LOCKED = ...
+```
+
+> A malloc() failed
+
+```java
+public static final int SQLITE_NOMEM = ...
+```
+
+> Attempt to write a readonly database
+
+```java
+public static final int SQLITE_READONLY = ...
+```
+
+> Operation terminated by sqlite_interrupt()
+
+```java
+public static final int SQLITE_INTERRUPT = ...
+```
+
+> Some kind of disk I/O error occurred
+
+```java
+public static final int SQLITE_IOERR = ...
+```
+
+> The database disk image is malformed
+
+```java
+public static final int SQLITE_CORRUPT = ...
+```
+
+> (Internal Only) Table or record not found
+
+```java
+public static final int SQLITE_NOTFOUND = ...
+```
+
+> Insertion failed because database is full
+
+```java
+public static final int SQLITE_FULL = ...
+```
+
+> Unable to open the database file
+
+```java
+public static final int SQLITE_CANTOPEN = ...
+```
+
+> Database lock protocol error
+
+```java
+public static final int SQLITE_PROTOCOL = ...
+```
+
+> (Internal Only) Database table is empty
+
+```java
+public static final int SQLITE_EMPTY = ...
+```
+
+> The database schema changed
+
+```java
+public static final int SQLITE_SCHEMA = ...
+```
+
+> Too much data for one row of a table
+
+```java
+public static final int SQLITE_TOOBIG = ...
+```
+
+> Abort due to constraint violation
+
+```java
+public static final int SQLITE_CONSTRAINT = ...
+```
+
+> Data type mismatch
+
+```java
+public static final int SQLITE_MISMATCH = ...
+```
+
+> Library used incorrectly
+
+```java
+public static final int SQLITE_MISUSE = ...
+```
+
+> Uses OS features not supported on host
+
+```java
+public static final int SQLITE_NOLFS = ...
+```
+
+> Authorization denied
+
+```java
+public static final int SQLITE_AUTH = ...
+```
+
+> sqlite_step() has another row ready
+
+```java
+public static final int SQLITE_ROW = ...
+```
+
+> sqlite_step() has finished executing
+
+```java
+public static final int SQLITE_DONE = ...
+```
+
+```java
+public static final int SQLITE_INTEGER = ...
+```
+
+```java
+public static final int SQLITE_FLOAT = ...
+```
+
+```java
+public static final int SQLITE_TEXT = ...
+```
+
+```java
+public static final int SQLITE_BLOB = ...
+```
+
+```java
+public static final int SQLITE_NULL = ...
+```
+
+#### `org/sqlite/core/CoreDatabaseMetaData.java`
+
+```java
+public abstract class CoreDatabaseMetaData implements DatabaseMetaData
+```
+
+> @deprecated Not exactly sure what this function does, as it is not implementing any
+> interface, and is not used anywhere in the code. Deprecated since 3.43.0.0.
+
+```java
+    @Deprecated
+public abstract ResultSet getGeneratedKeys() throws SQLException ;
+```
+
+> @throws SQLException
+
+```java
+public synchronized void close() throws SQLException
+```
+
+#### `org/sqlite/core/CorePreparedStatement.java`
+
+```java
+public abstract class CorePreparedStatement extends JDBC4Statement
+```
+
+> @see org.sqlite.jdbc3.JDBC3Statement#executeBatch()
+
+```java
+    @Override
+public int[] executeBatch() throws SQLException
+```
+
+> @see org.sqlite.jdbc3.JDBC3Statement#executeLargeBatch()
+
+```java
+    @Override
+public long[] executeLargeBatch() throws SQLException
+```
+
+> @see org.sqlite.jdbc3.JDBC3Statement#clearBatch() ()
+
+```java
+    @Override
+public void clearBatch() throws SQLException
+```
+
+#### `org/sqlite/core/CoreResultSet.java`
+
+> Implements a JDBC ResultSet.
+
+```java
+public abstract class CoreResultSet implements Codes
+```
+
+> If the result set does not have any rows.
+
+```java
+public boolean emptyResultSet = ...
+```
+
+> If the result set is open. Doesn't mean it has results.
+
+```java
+public boolean open = ...
+```
+
+> Maximum number of rows as set by a Statement
+
+```java
+public long maxRows ;
+```
+
+> if null, the RS is closed()
+
+```java
+public String[] cols = ...
+```
+
+> same as cols, but used by Meta interface
+
+```java
+public String[] colsMeta = ...
+```
+
+```java
+public boolean closeStmt ;
+```
+
+> Checks the status of the result set.
+>
+> @return True if has results and can iterate them; false otherwise.
+
+```java
+public boolean isOpen()
+```
+
+> Takes col in [1,x] form, returns in [0,x-1] form
+>
+> @param col
+> @return
+> @throws SQLException
+
+```java
+public int checkCol(int col) throws SQLException
+```
+
+> @throws SQLException
+
+```java
+public void checkMeta() throws SQLException
+```
+
+```java
+public void close() throws SQLException
+```
+
+#### `org/sqlite/core/CoreStatement.java`
+
+```java
+public abstract class CoreStatement implements Codes
+```
+
+```java
+public final SQLiteConnection conn ;
+```
+
+```java
+public SafeStmtPtr pointer ;
+```
+
+```java
+public DB getDatabase()
+```
+
+```java
+public SQLiteConnectionConfig getConnectionConfig()
+```
+
+```java
+public abstract ResultSet executeQuery(String sql, boolean closeStmt) throws SQLException ;
+```
+
+> SQLite's last_insert_rowid() function is DB-specific. However, in this implementation we
+> ensure the Generated Key result set is statement-specific by executing the query immediately
+> after an insert operation is performed. The caller is simply responsible for calling
+> updateGeneratedKeys on the statement object right after execute in a synchronized(connection)
+> block.
+
+```java
+public void updateGeneratedKeys() throws SQLException
+```
+
+> This implementation uses SQLite's last_insert_rowid function to obtain the row ID. It cannot
+> provide multiple values when inserting multiple rows. Suggestion is to use a <a
+> href=https://www.sqlite.org/lang_returning.html>RETURNING</a> clause instead.
+>
+> @see java.sql.Statement#getGeneratedKeys()
+
+```java
+public ResultSet getGeneratedKeys() throws SQLException
+```
+
+#### `org/sqlite/core/DB.java`
+
+```java
+public abstract class DB implements Codes
+```
+
+```java
+public String getUrl()
+```
+
+```java
+public boolean isClosed()
+```
+
+```java
+public SQLiteConfig getConfig()
+```
+
+> Aborts any pending operation and returns at its earliest opportunity.
+>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/interrupt.html">https://www.sqlite.org/c3ref/interrupt.html</a>
+
+```java
+public abstract void interrupt() throws SQLException ;
+```
+
+> Sets a <a href="https://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
+> for a specified amount of time when a table is locked.
+>
+> @param ms Time to sleep in milliseconds.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
+
+```java
+public abstract void busy_timeout(int ms) throws SQLException ;
+```
+
+> Sets a <a href="https://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
+> for a specified amount of time when a table is locked.
+>
+> @param busyHandler
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/busy_handler.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
+
+```java
+public abstract void busy_handler(BusyHandler busyHandler) throws SQLException ;
+```
+
+> Return English-language text that describes the error as either UTF-8 or UTF-16.
+>
+> @return Error description in English.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/errcode.html">https://www.sqlite.org/c3ref/errcode.html</a>
+
+```java
+abstract String errmsg() throws SQLException ;
+```
+
+> Returns the value for SQLITE_VERSION, SQLITE_VERSION_NUMBER, and SQLITE_SOURCE_ID C
+> preprocessor macros that are associated with the library.
+>
+> @return Compile-time SQLite version information.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/libversion.html">https://www.sqlite.org/c3ref/libversion.html</a>
+> @see <a
+> href="https://www.sqlite.org/c3ref/c_source_id.html">https://www.sqlite.org/c3ref/c_source_id.html</a>
+
+```java
+public abstract String libversion() throws SQLException ;
+```
+
+> @return Number of rows that were changed, inserted or deleted by the last SQL statement
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/changes.html">https://www.sqlite.org/c3ref/changes.html</a>
+
+```java
+public abstract long changes() throws SQLException ;
+```
+
+> @return Number of row changes caused by INSERT, UPDATE or DELETE statements since the
+> database connection was opened.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/total_changes.html">https://www.sqlite.org/c3ref/total_changes.html</a>
+
+```java
+public abstract long total_changes() throws SQLException ;
+```
+
+> Enables or disables the sharing of the database cache and schema data structures between
+> connections to the same database.
+>
+> @param enable True to enable; false otherwise.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/enable_shared_cache.html">https://www.sqlite.org/c3ref/enable_shared_cache.html</a>
+> @see org.sqlite.SQLiteErrorCode
+
+```java
+public abstract int shared_cache(boolean enable) throws SQLException ;
+```
+
+> Enables or disables loading of SQLite extensions.
+>
+> @param enable True to enable; false otherwise.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/load_extension.html">https://www.sqlite.org/c3ref/load_extension.html</a>
+
+```java
+public abstract int enable_load_extension(boolean enable) throws SQLException ;
+```
+
+> Executes an SQL statement using the process of compiling, evaluating, and destroying the
+> prepared statement object.
+>
+> @param sql SQL statement to be executed.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
+
+```java
+public final synchronized void exec(String sql, boolean autoCommit) throws SQLException
+```
+
+> Creates an SQLite interface to a database for the given connection.
+>
+> @param file The database.
+> @param openFlags File opening configurations (<a
+> href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>)
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/open.html">https://www.sqlite.org/c3ref/open.html</a>
+
+```java
+public final synchronized void open(String file, int openFlags) throws SQLException
+```
+
+> Closes a database connection and finalizes any remaining statements before the closing
+> operation.
+>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/close.html">https://www.sqlite.org/c3ref/close.html</a>
+
+```java
+public final synchronized void close() throws SQLException
+```
+
+> Complies the an SQL statement.
+>
+> @param stmt The SQL statement to compile.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/prepare.html">https://www.sqlite.org/c3ref/prepare.html</a>
+
+```java
+public final synchronized void prepare(CoreStatement stmt) throws SQLException
+```
+
+```java
+final boolean added = ...
+```
+
+> Destroys a statement.
+>
+> @param safePtr the pointer wrapper to remove from internal structures
+> @param ptr the raw pointer to free
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException if finalization fails
+> @see <a
+> href="https://www.sqlite.org/c3ref/finalize.html">https://www.sqlite.org/c3ref/finalize.html</a>
+
+```java
+public synchronized int finalize(SafeStmtPtr safePtr, long ptr) throws SQLException
+```
+
+> Complies, evaluates, executes and commits an SQL statement.
+>
+> @param sql An SQL statement.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
+
+```java
+public abstract int _exec(String sql) throws SQLException ;
+```
+
+> Evaluates a statement.
+>
+> @param stmt Pointer to the statement.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/step.html">https://www.sqlite.org/c3ref/step.html</a>
+
+```java
+public abstract int step(long stmt) throws SQLException ;
+```
+
+> Sets a prepared statement object back to its initial state, ready to be re-executed.
+>
+> @param stmt Pointer to the statement.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/reset.html">https://www.sqlite.org/c3ref/reset.html</a>
+
+```java
+public abstract int reset(long stmt) throws SQLException ;
+```
+
+> Reset all bindings on a prepared statement (reset all host parameters to NULL).
+>
+> @param stmt Pointer to the statement.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/clear_bindings.html">https://www.sqlite.org/c3ref/clear_bindings.html</a>
+
+```java
+public abstract int clear_bindings(long stmt) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @return Number of parameters in a prepared SQL.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_parameter_count.html">https://www.sqlite.org/c3ref/bind_parameter_count.html</a>
+
+```java
+abstract int bind_parameter_count(long stmt) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @return Number of columns in the result set returned by the prepared statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_count.html">https://www.sqlite.org/c3ref/column_count.html</a>
+
+```java
+public abstract int column_count(long stmt) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return Datatype code for the initial data type of the result column.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract int column_type(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return Declared type of the table column for prepared statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_decltype.html">https://www.sqlite.org/c3ref/column_decltype.html</a>
+
+```java
+public abstract String column_decltype(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return Original text of column name which is the declared in the CREATE TABLE statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_database_name.html">https://www.sqlite.org/c3ref/column_database_name.html</a>
+
+```java
+public abstract String column_table_name(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col The number of column.
+> @return Name assigned to a particular column in the result set of a SELECT statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_name.html">https://www.sqlite.org/c3ref/column_name.html</a>
+
+```java
+public abstract String column_name(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return Value of the column as text data type in the result set of a SELECT statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract String column_text(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return BLOB value of the column in the result set of a SELECT statement
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract byte[] column_blob(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return DOUBLE value of the column in the result set of a SELECT statement
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract double column_double(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return LONG value of the column in the result set of a SELECT statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract long column_long(long stmt, int col) throws SQLException ;
+```
+
+> @param stmt Pointer to the statement.
+> @param col Number of column.
+> @return INT value of column in the result set of a SELECT statement.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
+
+```java
+public abstract int column_int(long stmt, int col) throws SQLException ;
+```
+
+> Binds NULL value to prepared statements with the pointer to the statement object and the
+> index of the SQL parameter to be set to NULL.
+>
+> @param stmt Pointer to the statement.
+> @param pos The index of the SQL parameter to be set to NULL.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+abstract int bind_null(long stmt, int pos) throws SQLException ;
+```
+
+> Binds int value to prepared statements with the pointer to the statement object, the index of
+> the SQL parameter to be set and the value to bind to the parameter.
+>
+> @param stmt Pointer to the statement.
+> @param pos The index of the SQL parameter to be set.
+> @param v Value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+abstract int bind_int(long stmt, int pos, int v) throws SQLException ;
+```
+
+> Binds long value to prepared statements with the pointer to the statement object, the index
+> of the SQL parameter to be set and the value to bind to the parameter.
+>
+> @param stmt Pointer to the statement.
+> @param pos The index of the SQL parameter to be set.
+> @param v Value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+abstract int bind_long(long stmt, int pos, long v) throws SQLException ;
+```
+
+> Binds double value to prepared statements with the pointer to the statement object, the index
+> of the SQL parameter to be set and the value to bind to the parameter.
+>
+> @param stmt Pointer to the statement.
+> @param pos Index of the SQL parameter to be set.
+> @param v Value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+abstract int bind_double(long stmt, int pos, double v) throws SQLException ;
+```
+
+> Binds text value to prepared statements with the pointer to the statement object, the index
+> of the SQL parameter to be set and the value to bind to the parameter.
+>
+> @param stmt Pointer to the statement.
+> @param pos Index of the SQL parameter to be set.
+> @param v value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+abstract int bind_text(long stmt, int pos, String v) throws SQLException ;
+```
+
+> Binds blob value to prepared statements with the pointer to the statement object, the index
+> of the SQL parameter to be set and the value to bind to the parameter.
+>
+> @param stmt Pointer to the statement.
+> @param pos Index of the SQL parameter to be set.
+> @param v Value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+abstract int bind_blob(long stmt, int pos, byte[] v) throws SQLException ;
+```
+
+> Sets the result of an SQL function as NULL with the pointer to the SQLite database context.
+>
+> @param context Pointer to the SQLite database context.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_null(long context) throws SQLException ;
+```
+
+> Sets the result of an SQL function as text data type with the pointer to the SQLite database
+> context and the the result value of String.
+>
+> @param context Pointer to the SQLite database context.
+> @param val Result value of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_text(long context, String val) throws SQLException ;
+```
+
+> Sets the result of an SQL function as blob data type with the pointer to the SQLite database
+> context and the the result value of byte array.
+>
+> @param context Pointer to the SQLite database context.
+> @param val Result value of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_blob(long context, byte[] val) throws SQLException ;
+```
+
+> Sets the result of an SQL function as double data type with the pointer to the SQLite
+> database context and the the result value of double.
+>
+> @param context Pointer to the SQLite database context.
+> @param val Result value of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_double(long context, double val) throws SQLException ;
+```
+
+> Sets the result of an SQL function as long data type with the pointer to the SQLite database
+> context and the the result value of long.
+>
+> @param context Pointer to the SQLite database context.
+> @param val Result value of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_long(long context, long val) throws SQLException ;
+```
+
+> Sets the result of an SQL function as int data type with the pointer to the SQLite database
+> context and the the result value of int.
+>
+> @param context Pointer to the SQLite database context.
+> @param val Result value of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_int(long context, int val) throws SQLException ;
+```
+
+> Sets the result of an SQL function as an error with the pointer to the SQLite database
+> context and the the error of String.
+>
+> @param context Pointer to the SQLite database context.
+> @param err Error result of an SQL function.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
+
+```java
+public abstract void result_error(long context, String err) throws SQLException ;
+```
+
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter value of the given SQLite function or aggregate in text data type.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract String value_text(Function f, int arg) throws SQLException ;
+```
+
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter value of the given SQLite function or aggregate in blob data type.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract byte[] value_blob(Function f, int arg) throws SQLException ;
+```
+
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter value of the given SQLite function or aggregate in double data type
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract double value_double(Function f, int arg) throws SQLException ;
+```
+
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter value of the given SQLite function or aggregate in long data type.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract long value_long(Function f, int arg) throws SQLException ;
+```
+
+> Accesses the parameter values on the function or aggregate in int data type with the function
+> object and the parameter value.
+>
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter value of the given SQLite function or aggregate.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract int value_int(Function f, int arg) throws SQLException ;
+```
+
+> @param f SQLite function object.
+> @param arg Pointer to the parameter of the SQLite function or aggregate.
+> @return Parameter datatype of the function or aggregate in int data type.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
+
+```java
+public abstract int value_type(Function f, int arg) throws SQLException ;
+```
+
+> Create a user defined function with given function name and the function object.
+>
+> @param name The function name to be created.
+> @param f SQLite function object.
+> @param flags Extra flags to use when creating the function, such as {@link
+> Function#FLAG_DETERMINISTIC}
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/create_function.html">https://www.sqlite.org/c3ref/create_function.html</a>
+
+```java
+public abstract int create_function(String name, Function f, int nArgs, int flags)
+```
+
+> De-registers a user defined function
+>
+> @param name Name of the function to de-registered.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int destroy_function(String name) throws SQLException ;
+```
+
+> Create a user defined collation with given collation name and the collation object.
+>
+> @param name The collation name to be created.
+> @param c SQLite collation object.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/create_collation.html">https://www.sqlite.org/c3ref/create_collation.html</a>
+
+```java
+public abstract int create_collation(String name, Collation c) throws SQLException ;
+```
+
+> Create a user defined collation with given collation name and the collation object.
+>
+> @param name The collation name to be created.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int destroy_collation(String name) throws SQLException ;
+```
+
+> @param dbName Database name to be backed up.
+> @param destFileName Target backup file name.
+> @param observer ProgressObserver object.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int backup(String dbName, String destFileName, ProgressObserver observer)
+```
+
+> @param dbName Database name to be backed up.
+> @param destFileName Target backup file name.
+> @param observer ProgressObserver object.
+> @param sleepTimeMillis time to wait during a backup/restore operation if sqlite3_backup_step
+> returns SQLITE_BUSY before continuing
+> @param nTimeouts the number of times sqlite3_backup_step can return SQLITE_BUSY before
+> failing
+> @param pagesPerStep the number of pages to copy in each sqlite3_backup_step. If this is
+> negative, the entire DB is copied at once.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int backup(
+            String dbName,
+            String destFileName,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+> @param dbName Database name for restoring data.
+> @param sourceFileName Source file name.
+> @param observer ProgressObserver object.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int restore(String dbName, String sourceFileName, ProgressObserver observer)
+```
+
+> @param dbName the name of the db to restore
+> @param sourceFileName the filename of the source db to restore
+> @param observer ProgressObserver object.
+> @param sleepTimeMillis time to wait during a backup/restore operation if sqlite3_backup_step
+> returns SQLITE_BUSY before continuing
+> @param nTimeouts the number of times sqlite3_backup_step can return SQLITE_BUSY before
+> failing
+> @param pagesPerStep the number of pages to copy in each sqlite3_backup_step. If this is
+> negative, the entire DB is copied at once.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+
+```java
+public abstract int restore(
+            String dbName,
+            String sourceFileName,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+> @param id The id of the limit.
+> @param value The new value of the limit.
+> @return The prior value of the limit
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/limit.html">https://www.sqlite.org/c3ref/limit.html</a>
+
+```java
+public abstract int limit(int id, int value) throws SQLException ;
+```
+
+```java
+public interface ProgressObserver
+```
+
+> Progress handler
+
+```java
+public abstract void register_progress_handler(int vmCalls, ProgressHandler progressHandler)
+```
+
+```java
+public abstract void clear_progress_handler() throws SQLException ;
+```
+
+> Returns an array describing the attributes (not null, primary key and auto increment) of
+> columns.
+>
+> @param stmt Pointer to the statement.
+> @return Column attribute array.<br>
+> index[col][0] = true if column constrained NOT NULL;<br>
+> index[col][1] = true if column is part of the primary key; <br>
+> index[col][2] = true if column is auto-increment.
+> @throws SQLException
+
+```java
+abstract boolean[][] column_metadata(long stmt) throws SQLException ;
+```
+
+> Returns an array of column names in the result set of the SELECT statement.
+>
+> @param stmt Stmt object.
+> @return String array of column names.
+> @throws SQLException
+
+```java
+public final synchronized String[] column_names(long stmt) throws SQLException
+```
+
+> Bind values to prepared statements
+>
+> @param stmt Pointer to the statement.
+> @param pos Index of the SQL parameter to be set to NULL.
+> @param v Value to bind to the parameter.
+> @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
+
+```java
+final synchronized int sqlbind(long stmt, int pos, Object v) throws SQLException
+```
+
+> Submits a batch of commands to the database for execution.
+>
+> @see java.sql.Statement#executeBatch()
+> @param stmt Pointer of Stmt object.
+> @param count Number of SQL statements.
+> @param vals Array of parameter values.
+> @return Array of the number of rows changed or inserted or deleted for each command if all
+> commands execute successfully;
+> @throws SQLException if statement is not open or is being used elsewhere
+
+```java
+final synchronized long[] executeBatch(
+            SafeStmtPtr stmt, int count, Object[] vals, boolean autoCommit) throws SQLException
+```
+
+```java
+final int params = ...
+```
+
+> @see <a
+> href="https://www.sqlite.org/c_interface.html#sqlite_exec">https://www.sqlite.org/c_interface.html#sqlite_exec</a>
+> @param stmt Stmt object.
+> @param vals Array of parameter values.
+> @return True if a row of ResultSet is ready; false otherwise.
+> @throws SQLException
+
+```java
+public final synchronized boolean execute(CoreStatement stmt, Object[] vals)
+```
+
+```java
+final int params = ...
+```
+
+> Executes the given SQL statement using the one-step query execution interface.
+>
+> @param sql SQL statement to be executed.
+> @return True if a row of ResultSet is ready; false otherwise.
+> @throws SQLException
+> @see <a
+> href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
+
+```java
+final synchronized boolean execute(String sql, boolean autoCommit) throws SQLException
+```
+
+> Execute an SQL INSERT, UPDATE or DELETE statement with the Stmt object and an array of
+> parameter values of the SQL statement..
+>
+> @param stmt Stmt object.
+> @param vals Array of parameter values.
+> @return Number of database rows that were changed or inserted or deleted by the most recently
+> completed SQL.
+> @throws SQLException
+
+```java
+public final synchronized long executeUpdate(CoreStatement stmt, Object[] vals)
+```
+
+```java
+abstract void set_commit_listener(boolean enabled) ;
+```
+
+```java
+abstract void set_update_listener(boolean enabled) ;
+```
+
+```java
+public synchronized void addUpdateListener(SQLiteUpdateListener listener)
+```
+
+```java
+public synchronized void addCommitListener(SQLiteCommitListener listener)
+```
+
+```java
+public synchronized void removeUpdateListener(SQLiteUpdateListener listener)
+```
+
+```java
+public synchronized void removeCommitListener(SQLiteCommitListener listener)
+```
+
+> Throws SQLException with error message.
+>
+> @throws SQLException
+
+```java
+final void throwex() throws SQLException
+```
+
+> Throws SQLException with error code.
+>
+> @param errorCode Error code to be passed.
+> @throws SQLException Formatted SQLException with error code.
+
+```java
+public final void throwex(int errorCode) throws SQLException
+```
+
+> Throws SQL Exception with error code and message.
+>
+> @param errorCode Error code to be passed.
+> @param errorMessage Error message to be passed.
+> @throws SQLException Formatted SQLException with error code and message.
+
+```java
+static void throwex(int errorCode, String errorMessage) throws SQLException
+```
+
+> Throws formatted SQLException with error code and message.
+>
+> @param errorCode Error code to be passed.
+> @param errorMessage Error message to be passed.
+> @return Formatted SQLException with error code and message.
+
+```java
+public static SQLiteException newSQLException(int errorCode, String errorMessage)
+```
+
+> SQLite and the JDBC API have very different ideas about the meaning of auto-commit. Under
+> JDBC, when executeUpdate() returns in auto-commit mode (the default), the programmer assumes
+> the data has been written to disk. In SQLite however, a call to sqlite3_step() with an INSERT
+> statement can return SQLITE_OK, and yet the data is still in limbo.
+>
+> <p>This limbo appears when another statement on the database is active, e.g. a SELECT. SQLite
+> auto-commit waits until the final read statement finishes, and then writes whatever updates
+> have already been OKed. So if a program crashes before the reads are complete, data is lost.
+> E.g:
+>
+> <p>select begins insert select continues select finishes
+>
+> <p>Works as expected, however
+>
+> <p>select beings insert select continues crash
+>
+> <p>Results in the data never being written to disk.
+>
+> <p>As a solution, we call "commit" after every statement in auto-commit mode.
+>
+> @throws SQLException
+
+```java
+final void ensureAutoCommit(boolean autoCommit) throws SQLException
+```
+
+```java
+public abstract byte[] serialize(String schema) throws SQLException ;
+```
+
+```java
+public abstract void deserialize(String schema, byte[] buff) throws SQLException ;
+```
+
+#### `org/sqlite/core/NativeDB.java`
+
+> This class provides a thin JNI layer over the SQLite3 C API.
+
+```java
+public final class NativeDB extends DB
+```
+
+> Loads the SQLite interface backend.
+>
+> @return True if the SQLite JDBC driver is successfully loaded; false otherwise.
+
+```java
+public static boolean load() throws Exception
+```
+
+```java
+synchronized native void _open_utf8(byte[] fileUtf8, int openFlags) throws SQLException ;
+```
+
+> @see org.sqlite.core.DB#_exec(java.lang.String)
+
+```java
+    @Override
+public synchronized int _exec(String sql) throws SQLException
+```
+
+```java
+synchronized native int _exec_utf8(byte[] sqlUtf8) throws SQLException ;
+```
+
+> @see org.sqlite.core.DB#shared_cache(boolean)
+
+```java
+    @Override
+public synchronized native int shared_cache(boolean enable) ;
+```
+
+> @see org.sqlite.core.DB#enable_load_extension(boolean)
+
+```java
+    @Override
+public synchronized native int enable_load_extension(boolean enable) ;
+```
+
+> @see org.sqlite.core.DB#interrupt()
+
+```java
+    @Override
+public native void interrupt() ;
+```
+
+> @see org.sqlite.core.DB#busy_timeout(int)
+
+```java
+    @Override
+public synchronized native void busy_timeout(int ms) ;
+```
+
+> @see org.sqlite.core.DB#busy_handler(BusyHandler)
+
+```java
+    @Override
+public synchronized native void busy_handler(BusyHandler busyHandler) ;
+```
+
+```java
+synchronized native long prepare_utf8(byte[] sqlUtf8) throws SQLException ;
+```
+
+> @see org.sqlite.core.DB#errmsg()
+
+```java
+    @Override
+synchronized String errmsg()
+```
+
+```java
+synchronized native ByteBuffer errmsg_utf8() ;
+```
+
+> @see org.sqlite.core.DB#libversion()
+
+```java
+    @Override
+public synchronized String libversion()
+```
+
+```java
+native ByteBuffer libversion_utf8() ;
+```
+
+> @see org.sqlite.core.DB#changes()
+
+```java
+    @Override
+public synchronized native long changes() ;
+```
+
+> @see org.sqlite.core.DB#total_changes()
+
+```java
+    @Override
+public synchronized native long total_changes() ;
+```
+
+> @see org.sqlite.core.DB#step(long)
+
+```java
+    @Override
+public synchronized native int step(long stmt) ;
+```
+
+> @see org.sqlite.core.DB#reset(long)
+
+```java
+    @Override
+public synchronized native int reset(long stmt) ;
+```
+
+> @see org.sqlite.core.DB#clear_bindings(long)
+
+```java
+    @Override
+public synchronized native int clear_bindings(long stmt) ;
+```
+
+> @see org.sqlite.core.DB#bind_parameter_count(long)
+
+```java
+    @Override
+synchronized native int bind_parameter_count(long stmt) ;
+```
+
+> @see org.sqlite.core.DB#column_count(long)
+
+```java
+    @Override
+public synchronized native int column_count(long stmt) ;
+```
+
+> @see org.sqlite.core.DB#column_type(long, int)
+
+```java
+    @Override
+public synchronized native int column_type(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_decltype(long, int)
+
+```java
+    @Override
+public synchronized String column_decltype(long stmt, int col)
+```
+
+```java
+synchronized native ByteBuffer column_decltype_utf8(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_table_name(long, int)
+
+```java
+    @Override
+public synchronized String column_table_name(long stmt, int col)
+```
+
+```java
+synchronized native ByteBuffer column_table_name_utf8(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_name(long, int)
+
+```java
+    @Override
+public synchronized String column_name(long stmt, int col)
+```
+
+```java
+synchronized native ByteBuffer column_name_utf8(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_text(long, int)
+
+```java
+    @Override
+public synchronized String column_text(long stmt, int col)
+```
+
+```java
+synchronized native ByteBuffer column_text_utf8(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_blob(long, int)
+
+```java
+    @Override
+public synchronized native byte[] column_blob(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_double(long, int)
+
+```java
+    @Override
+public synchronized native double column_double(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_long(long, int)
+
+```java
+    @Override
+public synchronized native long column_long(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#column_int(long, int)
+
+```java
+    @Override
+public synchronized native int column_int(long stmt, int col) ;
+```
+
+> @see org.sqlite.core.DB#bind_null(long, int)
+
+```java
+    @Override
+synchronized native int bind_null(long stmt, int pos) ;
+```
+
+> @see org.sqlite.core.DB#bind_int(long, int, int)
+
+```java
+    @Override
+synchronized native int bind_int(long stmt, int pos, int v) ;
+```
+
+> @see org.sqlite.core.DB#bind_long(long, int, long)
+
+```java
+    @Override
+synchronized native int bind_long(long stmt, int pos, long v) ;
+```
+
+> @see org.sqlite.core.DB#bind_double(long, int, double)
+
+```java
+    @Override
+synchronized native int bind_double(long stmt, int pos, double v) ;
+```
+
+> @see org.sqlite.core.DB#bind_text(long, int, java.lang.String)
+
+```java
+    @Override
+synchronized int bind_text(long stmt, int pos, String v)
+```
+
+```java
+synchronized native int bind_text_utf8(long stmt, int pos, byte[] vUtf8) ;
+```
+
+> @see org.sqlite.core.DB#bind_blob(long, int, byte[])
+
+```java
+    @Override
+synchronized native int bind_blob(long stmt, int pos, byte[] v) ;
+```
+
+> @see org.sqlite.core.DB#result_null(long)
+
+```java
+    @Override
+public synchronized native void result_null(long context) ;
+```
+
+> @see org.sqlite.core.DB#result_text(long, java.lang.String)
+
+```java
+    @Override
+public synchronized void result_text(long context, String val)
+```
+
+```java
+synchronized native void result_text_utf8(long context, byte[] valUtf8) ;
+```
+
+> @see org.sqlite.core.DB#result_blob(long, byte[])
+
+```java
+    @Override
+public synchronized native void result_blob(long context, byte[] val) ;
+```
+
+> @see org.sqlite.core.DB#result_double(long, double)
+
+```java
+    @Override
+public synchronized native void result_double(long context, double val) ;
+```
+
+> @see org.sqlite.core.DB#result_long(long, long)
+
+```java
+    @Override
+public synchronized native void result_long(long context, long val) ;
+```
+
+> @see org.sqlite.core.DB#result_int(long, int)
+
+```java
+    @Override
+public synchronized native void result_int(long context, int val) ;
+```
+
+> @see org.sqlite.core.DB#result_error(long, java.lang.String)
+
+```java
+    @Override
+public synchronized void result_error(long context, String err)
+```
+
+```java
+synchronized native void result_error_utf8(long context, byte[] errUtf8) ;
+```
+
+> @see org.sqlite.core.DB#value_text(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized String value_text(Function f, int arg)
+```
+
+```java
+synchronized native ByteBuffer value_text_utf8(Function f, int argUtf8) ;
+```
+
+> @see org.sqlite.core.DB#value_blob(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized native byte[] value_blob(Function f, int arg) ;
+```
+
+> @see org.sqlite.core.DB#value_double(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized native double value_double(Function f, int arg) ;
+```
+
+> @see org.sqlite.core.DB#value_long(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized native long value_long(Function f, int arg) ;
+```
+
+> @see org.sqlite.core.DB#value_int(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized native int value_int(Function f, int arg) ;
+```
+
+> @see org.sqlite.core.DB#value_type(org.sqlite.Function, int)
+
+```java
+    @Override
+public synchronized native int value_type(Function f, int arg) ;
+```
+
+> @see org.sqlite.core.DB#create_function(java.lang.String, org.sqlite.Function, int, int)
+
+```java
+    @Override
+public synchronized int create_function(String name, Function func, int nArgs, int flags)
+```
+
+```java
+synchronized native int create_function_utf8(
+            byte[] nameUtf8, Function func, int nArgs, int flags) ;
+```
+
+> @see org.sqlite.core.DB#destroy_function(java.lang.String)
+
+```java
+    @Override
+public synchronized int destroy_function(String name) throws SQLException
+```
+
+```java
+synchronized native int destroy_function_utf8(byte[] nameUtf8) ;
+```
+
+> @see org.sqlite.core.DB#create_collation(String, Collation)
+
+```java
+    @Override
+public synchronized int create_collation(String name, Collation coll) throws SQLException
+```
+
+```java
+synchronized native int create_collation_utf8(byte[] nameUtf8, Collation coll) ;
+```
+
+> @see org.sqlite.core.DB#destroy_collation(String)
+
+```java
+    @Override
+public synchronized int destroy_collation(String name) throws SQLException
+```
+
+```java
+synchronized native int destroy_collation_utf8(byte[] nameUtf8) ;
+```
+
+```java
+    @Override
+public synchronized native int limit(int id, int value) throws SQLException ;
+```
+
+```java
+final byte[] nameUtf8 = ...
+```
+
+> @see org.sqlite.core.DB#backup(java.lang.String, java.lang.String,
+> org.sqlite.core.DB.ProgressObserver)
+
+```java
+    @Override
+public int backup(String dbName, String destFileName, ProgressObserver observer)
+```
+
+> @see org.sqlite.core.DB#backup(String, String, org.sqlite.core.DB.ProgressObserver, int, int,
+> int)
+
+```java
+    @Override
+public int backup(
+            String dbName,
+            String destFileName,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+```java
+synchronized native int backup(
+            byte[] dbNameUtf8,
+            byte[] destFileNameUtf8,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+> @see org.sqlite.core.DB#restore(java.lang.String, java.lang.String,
+> org.sqlite.core.DB.ProgressObserver)
+
+```java
+    @Override
+public synchronized int restore(String dbName, String sourceFileName, ProgressObserver observer)
+```
+
+> @see org.sqlite.core.DB#restore(String, String, ProgressObserver, int, int, int)
+
+```java
+    @Override
+public synchronized int restore(
+            String dbName,
+            String sourceFileName,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+```java
+synchronized native int restore(
+            byte[] dbNameUtf8,
+            byte[] sourceFileName,
+            ProgressObserver observer,
+            int sleepTimeMillis,
+            int nTimeouts,
+            int pagesPerStep)
+```
+
+> Provides metadata for table columns.
+>
+> @returns For each column returns: <br>
+> res[col][0] = true if column constrained NOT NULL<br>
+> res[col][1] = true if column is part of the primary key<br>
+> res[col][2] = true if column is auto-increment.
+> @see org.sqlite.core.DB#column_metadata(long)
+
+```java
+    @Override
+synchronized native boolean[][] column_metadata(long stmt) ;
+```
+
+```java
+    @Override
+synchronized native void set_commit_listener(boolean enabled) ;
+```
+
+```java
+    @Override
+synchronized native void set_update_listener(boolean enabled) ;
+```
+
+> Throws an SQLException. Called from native code
+>
+> @param msg Message for the SQLException.
+> @throws SQLException the generated SQLException
+
+```java
+static void throwex(String msg) throws SQLException
+```
+
+```java
+static byte[] stringToUtf8ByteArray(String str)
+```
+
+```java
+static String utf8ByteBufferToString(ByteBuffer buffer)
+```
+
+```java
+public synchronized native void register_progress_handler(
+            int vmCalls, ProgressHandler progressHandler) throws SQLException ;
+```
+
+```java
+public synchronized native void clear_progress_handler() throws SQLException ;
+```
+
+```java
+    @Override
+public synchronized native byte[] serialize(String schema) throws SQLException ;
+```
+
+```java
+    @Override
+public synchronized native void deserialize(String schema, byte[] buff) throws SQLException ;
+```
+
+#### `org/sqlite/core/SafeStmtPtr.java`
+
+> A class for safely wrapping calls to a native pointer to a statement, ensuring no other thread
+> has access to the pointer while it is run
+
+```java
+public class SafeStmtPtr
+```
+
+> Check whether this pointer has been closed
+>
+> @return whether this pointer has been closed
+
+```java
+public boolean isClosed()
+```
+
+> Close this pointer
+>
+> @return the return code of the close callback function
+> @throws SQLException if the close callback throws an SQLException, or the pointer is locked
+> elsewhere
+
+```java
+public int close() throws SQLException
+```
+
+> Run a callback with the wrapped pointer safely.
+>
+> @param run the function to run
+> @return the return of the passed in function
+> @throws SQLException if the pointer is utilized elsewhere
+
+```java
+public <E extends Throwable> int safeRunInt(SafePtrIntFunction<E> run) throws SQLException, E
+```
+
+> Run a callback with the wrapped pointer safely.
+>
+> @param run the function to run
+> @return the return of the passed in function
+> @throws SQLException if the pointer is utilized elsewhere
+
+```java
+public <E extends Throwable> long safeRunLong(SafePtrLongFunction<E> run)
+```
+
+> Run a callback with the wrapped pointer safely.
+>
+> @param run the function to run
+> @return the return of the passed in function
+> @throws SQLException if the pointer is utilized elsewhere
+
+```java
+public <E extends Throwable> double safeRunDouble(SafePtrDoubleFunction<E> run)
+```
+
+> Run a callback with the wrapped pointer safely.
+>
+> @param run the function to run
+> @return the return code of the function
+> @throws SQLException if the pointer is utilized elsewhere
+
+```java
+public <T, E extends Throwable> T safeRun(SafePtrFunction<T, E> run) throws SQLException, E
+```
+
+> Run a callback with the wrapped pointer safely.
+>
+> @param run the function to run
+> @throws SQLException if the pointer is utilized elsewhere
+
+```java
+public <E extends Throwable> void safeRunConsume(SafePtrConsumer<E> run)
+```
+
+```java
+    @Override
+public boolean equals(Object o)
+```
+
+```java
+    @Override
+public int hashCode()
+```
+
+```java
+    @FunctionalInterface
+public interface SafePtrIntFunction<E extends Throwable>
+```
+
+```java
+    @FunctionalInterface
+public interface SafePtrLongFunction<E extends Throwable>
+```
+
+```java
+    @FunctionalInterface
+public interface SafePtrDoubleFunction<E extends Throwable>
+```
+
+```java
+    @FunctionalInterface
+public interface SafePtrFunction<T, E extends Throwable>
+```
+
+```java
+    @FunctionalInterface
+public interface SafePtrConsumer<E extends Throwable>
+```
+
+#### `org/sqlite/date/DateFormatUtils.java`
+
+> Date and time formatting utilities and constants.
+>
+> <p>Formatting is performed using the thread-safe org.apache.commons.lang3.time.FastDateFormat
+> class.
+>
+> <p>Note that the JDK has a bug wherein calling Calendar.get(int) will override any previously
+> called Calendar.clear() calls. See LANG-755.
+>
+> @since 2.0
+> @version $Id$
+
+```java
+public class DateFormatUtils
+```
+
+> ISO 8601 formatter for date-time without time zone. The format used is {@code
+> yyyy-MM-dd'T'HH:mm:ss}.
+
+```java
+public static final FastDateFormat ISO_DATETIME_FORMAT = ...
+```
+
+> ISO 8601 formatter for date-time with time zone. The format used is {@code
+> yyyy-MM-dd'T'HH:mm:ssZZ}.
+
+```java
+public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT = ...
+```
+
+> ISO 8601 formatter for date without time zone. The format used is {@code yyyy-MM-dd}.
+
+```java
+public static final FastDateFormat ISO_DATE_FORMAT = ...
+```
+
+> ISO 8601-like formatter for date with time zone. The format used is {@code yyyy-MM-ddZZ}.
+> This pattern does not comply with the formal ISO 8601 specification as the standard does not
+> allow a time zone without a time.
+
+```java
+public static final FastDateFormat ISO_DATE_TIME_ZONE_FORMAT = ...
+```
+
+> ISO 8601 formatter for time without time zone. The format used is {@code 'T'HH:mm:ss}.
+
+```java
+public static final FastDateFormat ISO_TIME_FORMAT = ...
+```
+
+> ISO 8601 formatter for time with time zone. The format used is {@code 'T'HH:mm:ssZZ}.
+
+```java
+public static final FastDateFormat ISO_TIME_TIME_ZONE_FORMAT = ...
+```
+
+> ISO 8601-like formatter for time without time zone. The format used is {@code HH:mm:ss}. This
+> pattern does not comply with the formal ISO 8601 specification as the standard requires the
+> 'T' prefix for times.
+
+```java
+public static final FastDateFormat ISO_TIME_NO_T_FORMAT = ...
+```
+
+> ISO 8601-like formatter for time with time zone. The format used is {@code HH:mm:ssZZ}. This
+> pattern does not comply with the formal ISO 8601 specification as the standard requires the
+> 'T' prefix for times.
+
+```java
+public static final FastDateFormat ISO_TIME_NO_T_TIME_ZONE_FORMAT = ...
+```
+
+> SMTP (and probably other) date headers. The format used is {@code EEE, dd MMM yyyy HH:mm:ss
+> Z} in US locale.
+
+```java
+public static final FastDateFormat SMTP_DATETIME_FORMAT = ...
+```
+
+> Formats a date/time into a specific pattern using the UTC time zone.
+>
+> @param millis the date to format expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @return the formatted date
+
+```java
+public static String formatUTC(final long millis, final String pattern)
+```
+
+> Formats a date/time into a specific pattern using the UTC time zone.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null
+> @return the formatted date
+
+```java
+public static String formatUTC(final Date date, final String pattern)
+```
+
+> Formats a date/time into a specific pattern using the UTC time zone.
+>
+> @param millis the date to format expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String formatUTC(final long millis, final String pattern, final Locale locale)
+```
+
+> Formats a date/time into a specific pattern using the UTC time zone.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String formatUTC(final Date date, final String pattern, final Locale locale)
+```
+
+> Formats a date/time into a specific pattern.
+>
+> @param millis the date to format expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @return the formatted date
+
+```java
+public static String format(final long millis, final String pattern)
+```
+
+> Formats a date/time into a specific pattern.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null
+> @return the formatted date
+
+```java
+public static String format(final Date date, final String pattern)
+```
+
+> Formats a calendar into a specific pattern.
+>
+> @param calendar the calendar to format, not null
+> @param pattern the pattern to use to format the calendar, not null
+> @return the formatted calendar
+> @see FastDateFormat#format(Calendar)
+> @since 2.4
+
+```java
+public static String format(final Calendar calendar, final String pattern)
+```
+
+> Formats a date/time into a specific pattern in a time zone.
+>
+> @param millis the time expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(final long millis, final String pattern, final TimeZone timeZone)
+```
+
+> Formats a date/time into a specific pattern in a time zone.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(final Date date, final String pattern, final TimeZone timeZone)
+```
+
+> Formats a calendar into a specific pattern in a time zone.
+>
+> @param calendar the calendar to format, not null
+> @param pattern the pattern to use to format the calendar, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @return the formatted calendar
+> @see FastDateFormat#format(Calendar)
+> @since 2.4
+
+```java
+public static String format(
+            final Calendar calendar, final String pattern, final TimeZone timeZone)
+```
+
+> Formats a date/time into a specific pattern in a locale.
+>
+> @param millis the date to format expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(final long millis, final String pattern, final Locale locale)
+```
+
+> Formats a date/time into a specific pattern in a locale.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(final Date date, final String pattern, final Locale locale)
+```
+
+> Formats a calendar into a specific pattern in a locale.
+>
+> @param calendar the calendar to format, not null
+> @param pattern the pattern to use to format the calendar, not null
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted calendar
+> @see FastDateFormat#format(Calendar)
+> @since 2.4
+
+```java
+public static String format(
+            final Calendar calendar, final String pattern, final Locale locale)
+```
+
+> Formats a date/time into a specific pattern in a time zone and locale.
+>
+> @param millis the date to format expressed in milliseconds
+> @param pattern the pattern to use to format the date, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(
+            final long millis, final String pattern, final TimeZone timeZone, final Locale locale)
+```
+
+> Formats a date/time into a specific pattern in a time zone and locale.
+>
+> @param date the date to format, not null
+> @param pattern the pattern to use to format the date, not null, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted date
+
+```java
+public static String format(
+            final Date date, final String pattern, final TimeZone timeZone, final Locale locale)
+```
+
+```java
+final FastDateFormat df = ...
+```
+
+> Formats a calendar into a specific pattern in a time zone and locale.
+>
+> @param calendar the calendar to format, not null
+> @param pattern the pattern to use to format the calendar, not null
+> @param timeZone the time zone to use, may be <code>null</code>
+> @param locale the locale to use, may be <code>null</code>
+> @return the formatted calendar
+> @see FastDateFormat#format(Calendar)
+> @since 2.4
+
+```java
+public static String format(
+            final Calendar calendar,
+            final String pattern,
+            final TimeZone timeZone,
+            final Locale locale)
+```
+
+```java
+final FastDateFormat df = ...
+```
+
+#### `org/sqlite/date/DateParser.java`
+
+> DateParser is the "missing" interface for the parsing methods of {@link java.text.DateFormat}.
+>
+> @since 3.2
+
+```java
+public interface DateParser
+```
+
+#### `org/sqlite/date/DatePrinter.java`
+
+> DatePrinter is the "missing" interface for the format methods of {@link java.text.DateFormat}.
+>
+> @since 3.2
+
+```java
+public interface DatePrinter
+```
+
+#### `org/sqlite/date/ExceptionUtils.java`
+
+> Provides utilities for manipulating and examining <code>Throwable</code> objects.
+>
+> @since 1.0
+
+```java
+public class ExceptionUtils
+```
+
+> Throw a checked exception without adding the exception to the throws clause of the calling
+> method. This method prevents throws clause pollution and reduces the clutter of "Caused by"
+> exceptions in the stacktrace.
+>
+> <p>The use of this technique may be controversial, but exceedingly useful to library
+> developers. <code>
+> public int propagateExample { // note that there is no throws clause
+> try {
+> return invocation(); // throws IOException
+> } catch (Exception e) {
+> return ExceptionUtils.rethrow(e);  // propagates a checked exception
+> }
+> }
+> </code>
+>
+> <p>This is an alternative to the more conservative approach of wrapping the checked exception
+> in a RuntimeException: <code>
+> public int wrapExample { // note that there is no throws clause
+> try {
+> return invocation(); // throws IOException
+> } catch (Error e) {
+> throw e;
+> } catch (RuntimeException e) {
+> throw e;  // wraps a checked exception
+> } catch (Exception e) {
+> throw new UndeclaredThrowableException(e);  // wraps a checked exception
+> }
+> }
+> </code>
+>
+> <p>One downside to using this approach is that the java compiler will not allow invoking code
+> to specify a checked exception in a catch clause unless there is some code path within the
+> try block that has invoked a method declared with that checked exception. If the invoking
+> site wishes to catch the shaded checked exception, it must either invoke the shaded code
+> through a method re-declaring the desired checked exception, or catch Exception and use the
+> instanceof operator. Either of these techniques are required when interacting with non-java
+> jvm code such as Jython, Scala, or Groovy, since these languages do not consider any
+> exceptions as checked.
+>
+> @since 3.5
+> @see {{@link #wrapAndThrow(Throwable)}
+> @param throwable The throwable to rethrow.
+> @return R Never actually returns, this generic type matches any type which the calling site
+> requires. "Returning" the results of this method, as done in the propagateExample above,
+> will satisfy the java compiler requirement that all code paths return a value.
+> @throws throwable
+
+```java
+public static <R> R rethrow(Throwable throwable)
+```
+
+#### `org/sqlite/date/FastDateFormat.java`
+
+> FastDateFormat is a fast and thread-safe version of {@link java.text.SimpleDateFormat}.
+>
+> <p>To obtain an instance of FastDateFormat, use one of the static factory methods: {@link
+> #getInstance(String, TimeZone, Locale)}, {@link #getDateInstance(int, TimeZone, Locale)}, {@link
+> #getTimeInstance(int, TimeZone, Locale)}, or {@link #getDateTimeInstance(int, int, TimeZone,
+> Locale)}
+>
+> <p>Since FastDateFormat is thread safe, you can use a static member instance: <code>
+> private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getDateTimeInstance(FastDateFormat.LONG, FastDateFormat.SHORT);
+> </code>
+>
+> <p>This class can be used as a direct replacement to {@code SimpleDateFormat} in most formatting
+> and parsing situations. This class is especially useful in multi-threaded server environments.
+> {@code SimpleDateFormat} is not thread-safe in any JDK version, nor will it be as Sun have closed
+> the bug/RFE.
+>
+> <p>All patterns are compatible with SimpleDateFormat (except time zones and some year patterns -
+> see below).
+>
+> <p>Since 3.2, FastDateFormat supports parsing as well as printing.
+>
+> <p>Java 1.4 introduced a new pattern letter, {@code 'Z'}, to represent time zones in RFC822
+> format (eg. {@code +0800} or {@code -1100}). This pattern letter can be used here (on all JDK
+> versions).
+>
+> <p>In addition, the pattern {@code 'ZZ'} has been made to represent ISO 8601 full format time
+> zones (eg. {@code +08:00} or {@code -11:00}). This introduces a minor incompatibility with Java
+> 1.4, but at a gain of useful functionality.
+>
+> <p>Javadoc cites for the year pattern: <i>For formatting, if the number of pattern letters is 2,
+> the year is truncated to 2 digits; otherwise it is interpreted as a number.</i> Starting with
+> Java 1.7 a pattern of 'Y' or 'YYY' will be formatted as '2003', while it was '03' in former Java
+> versions. FastDateFormat implements the behavior of Java 7.
+>
+> @since 2.0
+> @version $Id$
+
+```java
+public class FastDateFormat extends Format implements DateParser, DatePrinter
+```
+
+> FULL locale dependent date or time style.
+
+```java
+public static final int FULL = ...
+```
+
+> LONG locale dependent date or time style.
+
+```java
+public static final int LONG = ...
+```
+
+> MEDIUM locale dependent date or time style.
+
+```java
+public static final int MEDIUM = ...
+```
+
+> SHORT locale dependent date or time style.
+
+```java
+public static final int SHORT = ...
+```
+
+> Gets a formatter instance using the default pattern in the default locale.
+>
+> @return a date/time formatter
+
+```java
+public static FastDateFormat getInstance()
+```
+
+> Gets a formatter instance using the specified pattern in the default locale.
+>
+> @param pattern {@link java.text.SimpleDateFormat} compatible pattern
+> @return a pattern based date/time formatter
+> @throws IllegalArgumentException if pattern is invalid
+
+```java
+public static FastDateFormat getInstance(final String pattern)
+```
+
+> Gets a formatter instance using the specified pattern and time zone.
+>
+> @param pattern {@link java.text.SimpleDateFormat} compatible pattern
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @return a pattern based date/time formatter
+> @throws IllegalArgumentException if pattern is invalid
+
+```java
+public static FastDateFormat getInstance(final String pattern, final TimeZone timeZone)
+```
+
+> Gets a formatter instance using the specified pattern and locale.
+>
+> @param pattern {@link java.text.SimpleDateFormat} compatible pattern
+> @param locale optional locale, overrides system locale
+> @return a pattern based date/time formatter
+> @throws IllegalArgumentException if pattern is invalid
+
+```java
+public static FastDateFormat getInstance(final String pattern, final Locale locale)
+```
+
+> Gets a formatter instance using the specified pattern, time zone and locale.
+>
+> @param pattern {@link java.text.SimpleDateFormat} compatible pattern
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @param locale optional locale, overrides system locale
+> @return a pattern based date/time formatter
+> @throws IllegalArgumentException if pattern is invalid or {@code null}
+
+```java
+public static FastDateFormat getInstance(
+            final String pattern, final TimeZone timeZone, final Locale locale)
+```
+
+> Gets a date formatter instance using the specified style in the default time zone and locale.
+>
+> @param style date style: FULL, LONG, MEDIUM, or SHORT
+> @return a localized standard date formatter
+> @throws IllegalArgumentException if the Locale has no date pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateInstance(final int style)
+```
+
+> Gets a date formatter instance using the specified style and locale in the default time zone.
+>
+> @param style date style: FULL, LONG, MEDIUM, or SHORT
+> @param locale optional locale, overrides system locale
+> @return a localized standard date formatter
+> @throws IllegalArgumentException if the Locale has no date pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateInstance(final int style, final Locale locale)
+```
+
+> Gets a date formatter instance using the specified style and time zone in the default locale.
+>
+> @param style date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @return a localized standard date formatter
+> @throws IllegalArgumentException if the Locale has no date pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateInstance(final int style, final TimeZone timeZone)
+```
+
+> Gets a date formatter instance using the specified style, time zone and locale.
+>
+> @param style date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @param locale optional locale, overrides system locale
+> @return a localized standard date formatter
+> @throws IllegalArgumentException if the Locale has no date pattern defined
+
+```java
+public static FastDateFormat getDateInstance(
+            final int style, final TimeZone timeZone, final Locale locale)
+```
+
+> Gets a time formatter instance using the specified style in the default time zone and locale.
+>
+> @param style time style: FULL, LONG, MEDIUM, or SHORT
+> @return a localized standard time formatter
+> @throws IllegalArgumentException if the Locale has no time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getTimeInstance(final int style)
+```
+
+> Gets a time formatter instance using the specified style and locale in the default time zone.
+>
+> @param style time style: FULL, LONG, MEDIUM, or SHORT
+> @param locale optional locale, overrides system locale
+> @return a localized standard time formatter
+> @throws IllegalArgumentException if the Locale has no time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getTimeInstance(final int style, final Locale locale)
+```
+
+> Gets a time formatter instance using the specified style and time zone in the default locale.
+>
+> @param style time style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted time
+> @return a localized standard time formatter
+> @throws IllegalArgumentException if the Locale has no time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getTimeInstance(final int style, final TimeZone timeZone)
+```
+
+> Gets a time formatter instance using the specified style, time zone and locale.
+>
+> @param style time style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted time
+> @param locale optional locale, overrides system locale
+> @return a localized standard time formatter
+> @throws IllegalArgumentException if the Locale has no time pattern defined
+
+```java
+public static FastDateFormat getTimeInstance(
+            final int style, final TimeZone timeZone, final Locale locale)
+```
+
+> Gets a date/time formatter instance using the specified style in the default time zone and
+> locale.
+>
+> @param dateStyle date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeStyle time style: FULL, LONG, MEDIUM, or SHORT
+> @return a localized standard date/time formatter
+> @throws IllegalArgumentException if the Locale has no date/time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateTimeInstance(final int dateStyle, final int timeStyle)
+```
+
+> Gets a date/time formatter instance using the specified style and locale in the default time
+> zone.
+>
+> @param dateStyle date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeStyle time style: FULL, LONG, MEDIUM, or SHORT
+> @param locale optional locale, overrides system locale
+> @return a localized standard date/time formatter
+> @throws IllegalArgumentException if the Locale has no date/time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateTimeInstance(
+            final int dateStyle, final int timeStyle, final Locale locale)
+```
+
+> Gets a date/time formatter instance using the specified style and time zone in the default
+> locale.
+>
+> @param dateStyle date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeStyle time style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @return a localized standard date/time formatter
+> @throws IllegalArgumentException if the Locale has no date/time pattern defined
+> @since 2.1
+
+```java
+public static FastDateFormat getDateTimeInstance(
+            final int dateStyle, final int timeStyle, final TimeZone timeZone)
+```
+
+> Gets a date/time formatter instance using the specified style, time zone and locale.
+>
+> @param dateStyle date style: FULL, LONG, MEDIUM, or SHORT
+> @param timeStyle time style: FULL, LONG, MEDIUM, or SHORT
+> @param timeZone optional time zone, overrides time zone of formatted date
+> @param locale optional locale, overrides system locale
+> @return a localized standard date/time formatter
+> @throws IllegalArgumentException if the Locale has no date/time pattern defined
+
+```java
+public static FastDateFormat getDateTimeInstance(
+            final int dateStyle,
+            final int timeStyle,
+            final TimeZone timeZone,
+            final Locale locale)
+```
+
+> Formats a {@code Date}, {@code Calendar} or {@code Long} (milliseconds) object.
+>
+> @param obj the object to format
+> @param toAppendTo the buffer to append to
+> @param pos the position - ignored
+> @return the buffer passed in
+
+```java
+    @Override
+public StringBuffer format(
+            final Object obj, final StringBuffer toAppendTo, final FieldPosition pos)
+```
+
+> Formats a millisecond {@code long} value.
+>
+> @param millis the millisecond value to format
+> @return the formatted string
+> @since 2.1
+
+```java
+public String format(final long millis)
+```
+
+> Formats a {@code Date} object using a {@code GregorianCalendar}.
+>
+> @param date the date to format
+> @return the formatted string
+
+```java
+public String format(final Date date)
+```
+
+> Formats a {@code Calendar} object.
+>
+> @param calendar the calendar to format
+> @return the formatted string
+
+```java
+public String format(final Calendar calendar)
+```
+
+> Formats a millisecond {@code long} value into the supplied {@code StringBuffer}.
+>
+> @param millis the millisecond value to format
+> @param buf the buffer to format into
+> @return the specified string buffer
+> @since 2.1
+
+```java
+public StringBuffer format(final long millis, final StringBuffer buf)
+```
+
+> Formats a {@code Date} object into the supplied {@code StringBuffer} using a {@code
+> GregorianCalendar}.
+>
+> @param date the date to format
+> @param buf the buffer to format into
+> @return the specified string buffer
+
+```java
+public StringBuffer format(final Date date, final StringBuffer buf)
+```
+
+> Formats a {@code Calendar} object into the supplied {@code StringBuffer}.
+>
+> @param calendar the calendar to format
+> @param buf the buffer to format into
+> @return the specified string buffer
+
+```java
+public StringBuffer format(final Calendar calendar, final StringBuffer buf)
+```
+
+```java
+public Date parse(final String source) throws ParseException
+```
+
+```java
+public Date parse(final String source, final ParsePosition pos)
+```
+
+```java
+public Object parseObject(final String source, final ParsePosition pos)
+```
+
+> Gets the pattern used by this formatter.
+>
+> @return the pattern, {@link java.text.SimpleDateFormat} compatible
+
+```java
+public String getPattern()
+```
+
+> Gets the time zone used by this formatter.
+>
+> <p>This zone is always used for {@code Date} formatting.
+>
+> @return the time zone
+
+```java
+public TimeZone getTimeZone()
+```
+
+> Gets the locale used by this formatter.
+>
+> @return the locale
+
+```java
+public Locale getLocale()
+```
+
+> Gets an estimate for the maximum string length that the formatter will produce.
+>
+> <p>The actual formatted length will almost always be less than or equal to this amount.
+>
+> @return the maximum formatted length
+
+```java
+public int getMaxLengthEstimate()
+```
+
+> Compares two objects for equality.
+>
+> @param obj the object to compare to
+> @return {@code true} if equal
+
+```java
+    @Override
+public boolean equals(final Object obj)
+```
+
+```java
+final FastDateFormat other = ...
+```
+
+> Returns a hashcode compatible with equals.
+>
+> @return a hashcode compatible with equals
+
+```java
+    @Override
+public int hashCode()
+```
+
+> Gets a debugging string version of this formatter.
+>
+> @return a debugging string
+
+```java
+    @Override
+public String toString()
+```
+
+#### `org/sqlite/date/FastDateParser.java`
+
+> FastDateParser is a fast and thread-safe version of {@link java.text.SimpleDateFormat}.
+>
+> <p>To obtain a proxy to a FastDateParser, use {@link FastDateFormat#getInstance(String, TimeZone,
+> Locale)} or another variation of the factory methods of {@link FastDateFormat}.
+>
+> <p>Since FastDateParser is thread safe, you can use a static member instance: <code>
+> private static final DateParser DATE_PARSER = FastDateFormat.getInstance("yyyy-MM-dd");
+> </code>
+>
+> <p>This class can be used as a direct replacement for <code>SimpleDateFormat</code> in most
+> parsing situations. This class is especially useful in multi-threaded server environments. <code>
+> SimpleDateFormat</code> is not thread-safe in any JDK version, nor will it be as Sun has closed
+> the <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335">bug</a>/RFE.
+>
+> <p>Only parsing is supported by this class, but all patterns are compatible with
+> SimpleDateFormat.
+>
+> <p>The class operates in lenient mode, so for example a time of 90 minutes is treated as 1 hour
+> 30 minutes.
+>
+> <p>Timing tests indicate this class is as about as fast as SimpleDateFormat in single thread
+> applications and about 25% faster in multi-thread applications.
+>
+> @version $Id$
+> @since 3.2
+> @see FastDatePrinter
+
+```java
+public class FastDateParser implements DateParser, Serializable
+```
+
+```java
+static final Locale JAPANESE_IMPERIAL = ...
+```
+
+```java
+final Calendar definingCalendar = ...
+```
+
+```java
+final StringBuilder regex = ...
+```
+
+```java
+final List<Strategy> collector = ...
+```
+
+```java
+final Matcher patternMatcher = ...
+```
+
+```java
+final String nextFormatField = ...
+```
+
+```java
+public String getPattern()
+```
+
+```java
+public TimeZone getTimeZone()
+```
+
+```java
+public Locale getLocale()
+```
+
+> Compare another object for equality with this object.
+>
+> @param obj the object to compare to
+> @return <code>true</code>if equal to this instance
+
+```java
+    @Override
+public boolean equals(final Object obj)
+```
+
+```java
+final FastDateParser other = ...
+```
+
+> Return a hashcode compatible with equals.
+>
+> @return a hashcode compatible with equals
+
+```java
+    @Override
+public int hashCode()
+```
+
+> Get a string version of this formatter.
+>
+> @return a debugging string
+
+```java
+    @Override
+public String toString()
+```
+
+```java
+final Calendar definingCalendar = ...
+```
+
+```java
+public Object parseObject(final String source) throws ParseException
+```
+
+```java
+public Date parse(final String source) throws ParseException
+```
+
+```java
+final Date date = ...
+```
+
+```java
+public Object parseObject(final String source, final ParsePosition pos)
+```
+
+> This implementation updates the ParsePosition if the parse succeeds. However, unlike the
+> method {@link java.text.SimpleDateFormat#parse(String, ParsePosition)} it is not able to set
+> the error Index - i.e. {@link ParsePosition#getErrorIndex()} - if the parse fails.
+>
+> <p>To determine if the parse has succeeded, the caller must check if the current parse
+> position given by {@link ParsePosition#getIndex()} has been updated. If the input buffer has
+> been fully parsed, then the index will point to just after the end of the input buffer.
+>
+> <p>See org.apache.commons.lang3.time.DateParser#parse(java.lang.String,
+> java.text.ParsePosition) {@inheritDoc}
+
+```java
+public Date parse(final String source, final ParsePosition pos)
+```
+
+```java
+final int offset = ...
+```
+
+```java
+final Matcher matcher = ...
+```
+
+```java
+final Calendar cal = ...
+```
+
+```java
+final Strategy strategy = ...
+```
+
+```java
+final int trial = ...
+```
+
+> Generate a <code>Pattern</code> regular expression to the <code>StringBuilder</code>
+> which will accept this field
+>
+> @param parser The parser calling this strategy
+> @param regex The <code>StringBuilder</code> to append to
+> @return true, if this field will set the calendar; false, if this field is a constant
+> value
+
+```java
+abstract boolean addRegex(FastDateParser parser, StringBuilder regex) ;
+```
+
+```java
+final ConcurrentMap<Locale, Strategy> cache = ...
+```
+
+```java
+final Strategy inCache = ...
+```
+
+```java
+final Map<String, Integer> keyValues = ...
+```
+
+```java
+final Integer iVal = ...
+```
+
+```java
+final StringBuilder sb = ...
+```
+
+```java
+final String[][] zones = ...
+```
+
+```java
+final TimeZone tz = ...
+```
+
+```java
+final StringBuilder sb = ...
+```
+
+> Factory method for ISO8601TimeZoneStrategies.
+>
+> @param tokenLen a token indicating the length of the TimeZone String to be formatted.
+> @return a ISO8601TimeZoneStrategy that can format TimeZone String of length {@code
+> tokenLen}. If no such strategy exists, an IllegalArgumentException will be thrown.
+
+```java
+static Strategy getStrategy(int tokenLen)
+```
+
+#### `org/sqlite/date/FastDatePrinter.java`
+
+> FastDatePrinter is a fast and thread-safe version of {@link java.text.SimpleDateFormat}.
+>
+> <p>To obtain a FastDatePrinter, use {@link FastDateFormat#getInstance(String, TimeZone, Locale)}
+> or another variation of the factory methods of {@link FastDateFormat}.
+>
+> <p>Since FastDatePrinter is thread safe, you can use a static member instance: <code>
+> private static final DatePrinter DATE_PRINTER = FastDateFormat.getInstance("yyyy-MM-dd");
+> </code>
+>
+> <p>This class can be used as a direct replacement to {@code SimpleDateFormat} in most formatting
+> situations. This class is especially useful in multi-threaded server environments. {@code
+> SimpleDateFormat} is not thread-safe in any JDK version, nor will it be as Sun have closed the
+> bug/RFE.
+>
+> <p>Only formatting is supported by this class, but all patterns are compatible with
+> SimpleDateFormat (except time zones and some year patterns - see below).
+>
+> <p>Java 1.4 introduced a new pattern letter, {@code 'Z'}, to represent time zones in RFC822
+> format (eg. {@code +0800} or {@code -1100}). This pattern letter can be used here (on all JDK
+> versions).
+>
+> <p>In addition, the pattern {@code 'ZZ'} has been made to represent ISO 8601 full format time
+> zones (eg. {@code +08:00} or {@code -11:00}). This introduces a minor incompatibility with Java
+> 1.4, but at a gain of useful functionality.
+>
+> <p>Starting with JDK7, ISO 8601 support was added using the pattern {@code 'X'}. To maintain
+> compatibility, {@code 'ZZ'} will continue to be supported, but using one of the {@code 'X'}
+> formats is recommended.
+>
+> <p>Javadoc cites for the year pattern: <i>For formatting, if the number of pattern letters is 2,
+> the year is truncated to 2 digits; otherwise it is interpreted as a number.</i> Starting with
+> Java 1.7 a pattern of 'Y' or 'YYY' will be formatted as '2003', while it was '03' in former Java
+> versions. FastDatePrinter implements the behavior of Java 7.
+>
+> @version $Id$
+> @since 3.2
+> @see FastDateParser
+
+```java
+public class FastDatePrinter implements DatePrinter, Serializable
+```
+
+> FULL locale dependent date or time style.
+
+```java
+public static final int FULL = ...
+```
+
+> LONG locale dependent date or time style.
+
+```java
+public static final int LONG = ...
+```
+
+> MEDIUM locale dependent date or time style.
+
+```java
+public static final int MEDIUM = ...
+```
+
+> SHORT locale dependent date or time style.
+
+```java
+public static final int SHORT = ...
+```
+
+```java
+final List<Rule> rulesList = ...
+```
+
+```java
+final DateFormatSymbols symbols = ...
+```
+
+```java
+final List<Rule> rules = ...
+```
+
+```java
+final String[] ERAs = ...
+```
+
+```java
+final String[] months = ...
+```
+
+```java
+final String[] shortMonths = ...
+```
+
+```java
+final String[] weekdays = ...
+```
+
+```java
+final String[] shortWeekdays = ...
+```
+
+```java
+final String[] AmPmStrings = ...
+```
+
+```java
+final int length = ...
+```
+
+```java
+final int[] indexRef = ...
+```
+
+```java
+final String token = ...
+```
+
+```java
+final int tokenLen = ...
+```
+
+```java
+final char c = ...
+```
+
+```java
+final String sub = ...
+```
+
+```java
+final StringBuilder buf = ...
+```
+
+```java
+final int length = ...
+```
+
+```java
+final char peek = ...
+```
+
+> Formats a {@code Date}, {@code Calendar} or {@code Long} (milliseconds) object.
+>
+> @param obj the object to format
+> @param toAppendTo the buffer to append to
+> @param pos the position - ignored
+> @return the buffer passed in
+
+```java
+public StringBuffer format(
+            final Object obj, final StringBuffer toAppendTo, final FieldPosition pos)
+```
+
+```java
+public String format(final long millis)
+```
+
+```java
+final Calendar c = ...
+```
+
+```java
+public String format(final Date date)
+```
+
+```java
+final Calendar c = ...
+```
+
+```java
+public String format(final Calendar calendar)
+```
+
+```java
+public StringBuffer format(final long millis, final StringBuffer buf)
+```
+
+```java
+public StringBuffer format(final Date date, final StringBuffer buf)
+```
+
+```java
+final Calendar c = ...
+```
+
+```java
+public StringBuffer format(final Calendar calendar, final StringBuffer buf)
+```
+
+```java
+public String getPattern()
+```
+
+```java
+public TimeZone getTimeZone()
+```
+
+```java
+public Locale getLocale()
+```
+
+> Gets an estimate for the maximum string length that the formatter will produce.
+>
+> <p>The actual formatted length will almost always be less than or equal to this amount.
+>
+> @return the maximum formatted length
+
+```java
+public int getMaxLengthEstimate()
+```
+
+> Compares two objects for equality.
+>
+> @param obj the object to compare to
+> @return {@code true} if equal
+
+```java
+    @Override
+public boolean equals(final Object obj)
+```
+
+```java
+final FastDatePrinter other = ...
+```
+
+> Returns a hashcode compatible with equals.
+>
+> @return a hashcode compatible with equals
+
+```java
+    @Override
+public int hashCode()
+```
+
+> Gets a debugging string version of this formatter.
+>
+> @return a debugging string
+
+```java
+    @Override
+public String toString()
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+```java
+final int len = ...
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, final int value)
+```
+
+```java
+static final UnpaddedMonthField INSTANCE = ...
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, final int value)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, int value)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, final int value)
+```
+
+```java
+static final TwoDigitYearField INSTANCE = ...
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, final int value)
+```
+
+```java
+static final TwoDigitMonthField INSTANCE = ...
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public final void appendTo(final StringBuffer buffer, final int value)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final int value)
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final int value)
+```
+
+> Gets the time zone display name, using a cache for performance.
+>
+> @param tz the zone to query
+> @param daylight true if daylight savings
+> @param style the style to use {@code TimeZone.LONG} or {@code TimeZone.SHORT}
+> @param locale the locale to use
+> @return the textual name of the time zone
+
+```java
+static String getTimeZoneDisplay(
+            final TimeZone tz, final boolean daylight, final int style, final Locale locale)
+```
+
+```java
+final TimeZoneDisplayKey key = ...
+```
+
+```java
+final String prior = ...
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+```java
+final TimeZone zone = ...
+```
+
+```java
+static final TimeZoneNumberRule INSTANCE_COLON = ...
+```
+
+```java
+static final TimeZoneNumberRule INSTANCE_NO_COLON = ...
+```
+
+```java
+static final TimeZoneNumberRule INSTANCE_ISO_8601 = ...
+```
+
+```java
+final boolean mColon ;
+```
+
+```java
+final boolean mISO8601 ;
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+```java
+final int hours = ...
+```
+
+```java
+final int minutes = ...
+```
+
+```java
+static final Iso8601_Rule ISO8601_HOURS = ...
+```
+
+```java
+static final Iso8601_Rule ISO8601_HOURS_MINUTES = ...
+```
+
+```java
+static final Iso8601_Rule ISO8601_HOURS_COLON_MINUTES = ...
+```
+
+> Factory method for Iso8601_Rules.
+>
+> @param tokenLen a token indicating the length of the TimeZone String to be formatted.
+> @return a Iso8601_Rule that can format TimeZone String of length {@code tokenLen}. If no
+> such rule exists, an IllegalArgumentException will be thrown.
+
+```java
+static Iso8601_Rule getRule(int tokenLen)
+```
+
+```java
+final int length ;
+```
+
+> {@inheritDoc}
+
+```java
+public int estimateLength()
+```
+
+> {@inheritDoc}
+
+```java
+public void appendTo(final StringBuffer buffer, final Calendar calendar)
+```
+
+```java
+final int hours = ...
+```
+
+```java
+final int minutes = ...
+```
+
+> {@inheritDoc}
+
+```java
+        @Override
+public int hashCode()
+```
+
+> {@inheritDoc}
+
+```java
+        @Override
+public boolean equals(final Object obj)
+```
+
+```java
+final TimeZoneDisplayKey other = ...
+```
+
+#### `org/sqlite/date/FormatCache.java`
+
+> FormatCache is a cache and factory for {@link Format}s.
+>
+> @since 3.0
+> @version $Id: FormatCache 892161 2009-12-18 07:21:10Z $
+
+```java
+abstract class FormatCache<F extends Format>
+```
+
+> No date or no time. Used in same parameters as DateFormat.SHORT or DateFormat.LONG
+
+```java
+static final int NONE = ...
+```
+
+> Gets a formatter instance using the default pattern in the default timezone and locale.
+>
+> @return a date/time formatter
+
+```java
+public F getInstance()
+```
+
+> Gets a formatter instance using the specified pattern, time zone and locale.
+>
+> @param pattern {@link java.text.SimpleDateFormat} compatible pattern, non-null
+> @param timeZone the time zone, null means use the default TimeZone
+> @param locale the locale, null means use the default Locale
+> @return a pattern based date/time formatter
+> @throws IllegalArgumentException if pattern is invalid or <code>null</code>
+
+```java
+public F getInstance(final String pattern, TimeZone timeZone, Locale locale)
+```
+
+```java
+final MultipartKey key = ...
+```
+
+```java
+final F previousValue = ...
+```
+
+```java
+final String pattern = ...
+```
+
+> Gets a date/time format for the specified styles and locale.
+>
+> @param dateStyle date style: FULL, LONG, MEDIUM, or SHORT, null indicates no date in format
+> @param timeStyle time style: FULL, LONG, MEDIUM, or SHORT, null indicates no time in format
+> @param locale The non-null locale of the desired format
+> @return a localized standard date/time format
+> @throws IllegalArgumentException if the Locale has no date/time pattern defined
+
+```java
+static String getPatternForStyle(
+            final Integer dateStyle, final Integer timeStyle, final Locale locale)
+```
+
+```java
+final MultipartKey key = ...
+```
+
+```java
+final String previous = ...
+```
+
+> {@inheritDoc}
+
+```java
+        @Override
+public boolean equals(final Object obj)
+```
+
+> {@inheritDoc}
+
+```java
+        @Override
+public int hashCode()
+```
+
+#### `org/sqlite/javax/SQLiteConnectionPoolDataSource.java`
+
+```java
+public class SQLiteConnectionPoolDataSource extends SQLiteDataSource
+        implements javax.sql.ConnectionPoolDataSource
+```
+
+> @see javax.sql.ConnectionPoolDataSource#getPooledConnection()
+
+```java
+public PooledConnection getPooledConnection() throws SQLException
+```
+
+> @see javax.sql.ConnectionPoolDataSource#getPooledConnection(java.lang.String,
+> java.lang.String)
+
+```java
+public PooledConnection getPooledConnection(String user, String password) throws SQLException
+```
+
+#### `org/sqlite/javax/SQLitePooledConnection.java`
+
+```java
+public class SQLitePooledConnection extends JDBC4PooledConnection
+```
+
+```java
+public SQLiteConnection getPhysicalConn()
+```
+
+> @see javax.sql.PooledConnection#close()
+
+```java
+public void close() throws SQLException
+```
+
+> @see javax.sql.PooledConnection#getConnection()
+
+```java
+public Connection getConnection() throws SQLException
+```
+
+```java
+public Object invoke(Object proxy, Method method, Object[] args)
+```
+
+> @see javax.sql.PooledConnection#addConnectionEventListener(javax.sql.ConnectionEventListener)
+
+```java
+public void addConnectionEventListener(ConnectionEventListener listener)
+```
+
+> @see
+> javax.sql.PooledConnection#removeConnectionEventListener(javax.sql.ConnectionEventListener)
+
+```java
+public void removeConnectionEventListener(ConnectionEventListener listener)
+```
+
+```java
+public List<ConnectionEventListener> getListeners()
+```
+
+```java
+    @Override
+public Statement createStatement() throws SQLException
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(String sql) throws SQLException
+```
+
+```java
+    @Override
+public CallableStatement prepareCall(String sql) throws SQLException
+```
+
+```java
+    @Override
+public String nativeSQL(String sql) throws SQLException
+```
+
+```java
+    @Override
+public void setAutoCommit(boolean autoCommit) throws SQLException
+```
+
+```java
+    @Override
+public boolean getAutoCommit() throws SQLException
+```
+
+```java
+    @Override
+public void commit() throws SQLException
+```
+
+```java
+    @Override
+public void rollback() throws SQLException
+```
+
+```java
+    @Override
+public void close() throws SQLException
+```
+
+```java
+    @Override
+public boolean isClosed()
+```
+
+```java
+    @Override
+public DatabaseMetaData getMetaData() throws SQLException
+```
+
+```java
+    @Override
+public void setReadOnly(boolean readOnly) throws SQLException
+```
+
+```java
+    @Override
+public boolean isReadOnly() throws SQLException
+```
+
+```java
+    @Override
+public void setCatalog(String catalog) throws SQLException
+```
+
+```java
+    @Override
+public String getCatalog() throws SQLException
+```
+
+```java
+    @Override
+public void setTransactionIsolation(int level) throws SQLException
+```
+
+```java
+    @Override
+public int getTransactionIsolation()
+```
+
+```java
+    @Override
+public SQLWarning getWarnings() throws SQLException
+```
+
+```java
+    @Override
+public void clearWarnings() throws SQLException
+```
+
+```java
+    @Override
+public Statement createStatement(int resultSetType, int resultSetConcurrency)
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(
+            String sql, int resultSetType, int resultSetConcurrency) throws SQLException
+```
+
+```java
+    @Override
+public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+```
+
+```java
+    @Override
+public Map<String, Class<?>> getTypeMap() throws SQLException
+```
+
+```java
+    @Override
+public void setTypeMap(Map<String, Class<?>> map) throws SQLException
+```
+
+```java
+    @Override
+public void setHoldability(int holdability) throws SQLException
+```
+
+```java
+    @Override
+public int getHoldability() throws SQLException
+```
+
+```java
+    @Override
+public Savepoint setSavepoint() throws SQLException
+```
+
+```java
+    @Override
+public Savepoint setSavepoint(String name) throws SQLException
+```
+
+```java
+    @Override
+public void rollback(Savepoint savepoint) throws SQLException
+```
+
+```java
+    @Override
+public void releaseSavepoint(Savepoint savepoint) throws SQLException
+```
+
+```java
+    @Override
+public Statement createStatement(
+            int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(
+            String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+```
+
+```java
+    @Override
+public CallableStatement prepareCall(
+            String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException
+```
+
+```java
+    @Override
+public PreparedStatement prepareStatement(String sql, String[] columnNames)
+```
+
+```java
+    @Override
+public Clob createClob() throws SQLException
+```
+
+```java
+    @Override
+public Blob createBlob() throws SQLException
+```
+
+```java
+    @Override
+public NClob createNClob() throws SQLException
+```
+
+```java
+    @Override
+public SQLXML createSQLXML() throws SQLException
+```
+
+```java
+    @Override
+public boolean isValid(int timeout) throws SQLException
+```
+
+```java
+    @Override
+public void setClientInfo(String name, String value) throws SQLClientInfoException
+```
+
+```java
+    @Override
+public void setClientInfo(Properties properties) throws SQLClientInfoException
+```
+
+```java
+    @Override
+public String getClientInfo(String name) throws SQLException
+```
+
+```java
+    @Override
+public Properties getClientInfo() throws SQLException
+```
+
+```java
+    @Override
+public Array createArrayOf(String typeName, Object[] elements) throws SQLException
+```
+
+```java
+    @Override
+public Struct createStruct(String typeName, Object[] attributes) throws SQLException
+```
+
+```java
+    @Override
+public void setSchema(String schema) throws SQLException
+```
+
+```java
+    @Override
+public String getSchema() throws SQLException
+```
+
+```java
+    @Override
+public void abort(Executor executor) throws SQLException
+```
+
+```java
+    @Override
+public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
+```
+
+```java
+    @Override
+public int getNetworkTimeout() throws SQLException
+```
+
+```java
+    @Override
+public <T> T unwrap(Class<T> iface) throws SQLException
+```
+
+```java
+    @Override
+public boolean isWrapperFor(Class<?> iface) throws SQLException
+```
+
+```java
+    @Override
+public int getBusyTimeout()
+```
+
+```java
+    @Override
+public void setBusyTimeout(int timeoutMillis)
+```
+
+```java
+    @Override
+public DB getDatabase()
+```
+
+#### `org/sqlite/jdbc3/JDBC3Connection.java`
+
+```java
+public abstract class JDBC3Connection extends SQLiteConnection
+```
+
+> This will try to enforce the transaction mode if SQLiteConfig#isExplicitReadOnly is true and
+> auto commit is disabled.
+>
+> <ul>
+> <li>If this connection is read only, the PRAGMA query_only will be set
+> <li>If this connection is not read only:
+> <ul>
+> <li>if no statement has been executed, PRAGMA query_only will be set to false, and an
+> IMMEDIATE transaction will be started
+> <li>if a statement has already been executed, an exception is thrown
+> </ul>
+> </ul>
+>
+> @throws SQLException if a statement has already been executed on this connection, then the
+> transaction cannot be upgraded to write
+
+```java
+    @SuppressWarnings("deprecation")
+public void tryEnforceTransactionMode() throws SQLException
+```
+
+> @see java.sql.Connection#getCatalog()
+
+```java
+public String getCatalog() throws SQLException
+```
+
+> @see java.sql.Connection#setCatalog(java.lang.String)
+
+```java
+public void setCatalog(String catalog) throws SQLException
+```
+
+> @see java.sql.Connection#getHoldability()
+
+```java
+public int getHoldability() throws SQLException
+```
+
+> @see java.sql.Connection#setHoldability(int)
+
+```java
+public void setHoldability(int h) throws SQLException
+```
+
+> @see java.sql.Connection#getTypeMap()
+
+```java
+public Map<String, Class<?>> getTypeMap() throws SQLException
+```
+
+> @see java.sql.Connection#setTypeMap(java.util.Map)
+
+```java
+public void setTypeMap(Map map) throws SQLException
+```
+
+> @see java.sql.Connection#isReadOnly()
+
+```java
+public boolean isReadOnly()
+```
+
+> @see java.sql.Connection#setReadOnly(boolean)
+
+```java
+public void setReadOnly(boolean ro) throws SQLException
+```
+
+> @see java.sql.Connection#nativeSQL(java.lang.String)
+
+```java
+public String nativeSQL(String sql)
+```
+
+> @see java.sql.Connection#clearWarnings()
+
+```java
+public void clearWarnings() throws SQLException
+```
+
+> @see java.sql.Connection#getWarnings()
+
+```java
+public SQLWarning getWarnings() throws SQLException
+```
+
+> @see java.sql.Connection#createStatement()
+
+```java
+public Statement createStatement() throws SQLException
+```
+
+> @see java.sql.Connection#createStatement(int, int)
+
+```java
+public Statement createStatement(int rsType, int rsConcurr) throws SQLException
+```
+
+> @see java.sql.Connection#createStatement(int, int, int)
+
+```java
+public abstract Statement createStatement(int rst, int rsc, int rsh) throws SQLException ;
+```
+
+> @see java.sql.Connection#prepareCall(java.lang.String)
+
+```java
+public CallableStatement prepareCall(String sql) throws SQLException
+```
+
+> @see java.sql.Connection#prepareCall(java.lang.String, int, int)
+
+```java
+public CallableStatement prepareCall(String sql, int rst, int rsc) throws SQLException
+```
+
+> @see java.sql.Connection#prepareCall(java.lang.String, int, int, int)
+
+```java
+public CallableStatement prepareCall(String sql, int rst, int rsc, int rsh)
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String)
+
+```java
+public PreparedStatement prepareStatement(String sql) throws SQLException
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String, int)
+
+```java
+public PreparedStatement prepareStatement(String sql, int autoC) throws SQLException
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String, int[])
+
+```java
+public PreparedStatement prepareStatement(String sql, int[] colInds) throws SQLException
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String, java.lang.String[])
+
+```java
+public PreparedStatement prepareStatement(String sql, String[] colNames) throws SQLException
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String, int, int)
+
+```java
+public PreparedStatement prepareStatement(String sql, int rst, int rsc) throws SQLException
+```
+
+> @see java.sql.Connection#prepareStatement(java.lang.String, int, int, int)
+
+```java
+public abstract PreparedStatement prepareStatement(String sql, int rst, int rsc, int rsh)
+```
+
+> @see java.sql.Connection#setSavepoint()
+
+```java
+public Savepoint setSavepoint() throws SQLException
+```
+
+> @see java.sql.Connection#setSavepoint(java.lang.String)
+
+```java
+public Savepoint setSavepoint(String name) throws SQLException
+```
+
+> @see java.sql.Connection#releaseSavepoint(java.sql.Savepoint)
+
+```java
+public void releaseSavepoint(Savepoint savepoint) throws SQLException
+```
+
+> @see java.sql.Connection#rollback(java.sql.Savepoint)
+
+```java
+public void rollback(Savepoint savepoint) throws SQLException
+```
+
+```java
+public Struct createStruct(String t, Object[] attr) throws SQLException
+```
+
+#### `org/sqlite/jdbc3/JDBC3DatabaseMetaData.java`
+
+```java
+public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData
+```
+
+```java
+final Properties sqliteJdbcProp = ...
+```
+
+> @see java.sql.DatabaseMetaData#getConnection()
+
+```java
+public Connection getConnection()
+```
+
+> @see java.sql.DatabaseMetaData#getDatabaseMajorVersion()
+
+```java
+public int getDatabaseMajorVersion() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getDatabaseMinorVersion()
+
+```java
+public int getDatabaseMinorVersion() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getDriverMajorVersion()
+
+```java
+public int getDriverMajorVersion()
+```
+
+> @see java.sql.DatabaseMetaData#getDriverMinorVersion()
+
+```java
+public int getDriverMinorVersion()
+```
+
+> @see java.sql.DatabaseMetaData#getJDBCMajorVersion()
+
+```java
+public int getJDBCMajorVersion()
+```
+
+> @see java.sql.DatabaseMetaData#getJDBCMinorVersion()
+
+```java
+public int getJDBCMinorVersion()
+```
+
+> @see java.sql.DatabaseMetaData#getDefaultTransactionIsolation()
+
+```java
+public int getDefaultTransactionIsolation()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxBinaryLiteralLength()
+
+```java
+public int getMaxBinaryLiteralLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxCatalogNameLength()
+
+```java
+public int getMaxCatalogNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxCharLiteralLength()
+
+```java
+public int getMaxCharLiteralLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnNameLength()
+
+```java
+public int getMaxColumnNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnsInGroupBy()
+
+```java
+public int getMaxColumnsInGroupBy()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnsInIndex()
+
+```java
+public int getMaxColumnsInIndex()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnsInOrderBy()
+
+```java
+public int getMaxColumnsInOrderBy()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnsInSelect()
+
+```java
+public int getMaxColumnsInSelect()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxColumnsInTable()
+
+```java
+public int getMaxColumnsInTable()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxConnections()
+
+```java
+public int getMaxConnections()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxCursorNameLength()
+
+```java
+public int getMaxCursorNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxIndexLength()
+
+```java
+public int getMaxIndexLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxProcedureNameLength()
+
+```java
+public int getMaxProcedureNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxRowSize()
+
+```java
+public int getMaxRowSize()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxSchemaNameLength()
+
+```java
+public int getMaxSchemaNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxStatementLength()
+
+```java
+public int getMaxStatementLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxStatements()
+
+```java
+public int getMaxStatements()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxTableNameLength()
+
+```java
+public int getMaxTableNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxTablesInSelect()
+
+```java
+public int getMaxTablesInSelect()
+```
+
+> @see java.sql.DatabaseMetaData#getMaxUserNameLength()
+
+```java
+public int getMaxUserNameLength()
+```
+
+> @see java.sql.DatabaseMetaData#getResultSetHoldability()
+
+```java
+public int getResultSetHoldability()
+```
+
+> @see java.sql.DatabaseMetaData#getSQLStateType()
+
+```java
+public int getSQLStateType()
+```
+
+> @see java.sql.DatabaseMetaData#getDatabaseProductName()
+
+```java
+public String getDatabaseProductName()
+```
+
+> @see java.sql.DatabaseMetaData#getDatabaseProductVersion()
+
+```java
+public String getDatabaseProductVersion() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getDriverName()
+
+```java
+public String getDriverName()
+```
+
+> @see java.sql.DatabaseMetaData#getDriverVersion()
+
+```java
+public String getDriverVersion()
+```
+
+> @see java.sql.DatabaseMetaData#getExtraNameCharacters()
+
+```java
+public String getExtraNameCharacters()
+```
+
+> @see java.sql.DatabaseMetaData#getCatalogSeparator()
+
+```java
+public String getCatalogSeparator()
+```
+
+> @see java.sql.DatabaseMetaData#getCatalogTerm()
+
+```java
+public String getCatalogTerm()
+```
+
+> @see java.sql.DatabaseMetaData#getSchemaTerm()
+
+```java
+public String getSchemaTerm()
+```
+
+> @see java.sql.DatabaseMetaData#getProcedureTerm()
+
+```java
+public String getProcedureTerm()
+```
+
+> @see java.sql.DatabaseMetaData#getSearchStringEscape()
+
+```java
+public String getSearchStringEscape()
+```
+
+> @see java.sql.DatabaseMetaData#getIdentifierQuoteString()
+
+```java
+public String getIdentifierQuoteString()
+```
+
+> @see java.sql.DatabaseMetaData#getSQLKeywords()
+> @see <a href="https://www.sqlite.org/lang_keywords.html">SQLite Keywords</a>
+
+```java
+public String getSQLKeywords()
+```
+
+> @see java.sql.DatabaseMetaData#getNumericFunctions()
+
+```java
+public String getNumericFunctions()
+```
+
+> @see java.sql.DatabaseMetaData#getStringFunctions()
+
+```java
+public String getStringFunctions()
+```
+
+> @see java.sql.DatabaseMetaData#getSystemFunctions()
+
+```java
+public String getSystemFunctions()
+```
+
+> @see java.sql.DatabaseMetaData#getTimeDateFunctions()
+
+```java
+public String getTimeDateFunctions()
+```
+
+> @see java.sql.DatabaseMetaData#getURL()
+
+```java
+public String getURL()
+```
+
+> @see java.sql.DatabaseMetaData#getUserName()
+
+```java
+public String getUserName()
+```
+
+> @see java.sql.DatabaseMetaData#allProceduresAreCallable()
+
+```java
+public boolean allProceduresAreCallable()
+```
+
+> @see java.sql.DatabaseMetaData#allTablesAreSelectable()
+
+```java
+public boolean allTablesAreSelectable()
+```
+
+> @see java.sql.DatabaseMetaData#dataDefinitionCausesTransactionCommit()
+
+```java
+public boolean dataDefinitionCausesTransactionCommit()
+```
+
+> @see java.sql.DatabaseMetaData#dataDefinitionIgnoredInTransactions()
+
+```java
+public boolean dataDefinitionIgnoredInTransactions()
+```
+
+> @see java.sql.DatabaseMetaData#doesMaxRowSizeIncludeBlobs()
+
+```java
+public boolean doesMaxRowSizeIncludeBlobs()
+```
+
+> @see java.sql.DatabaseMetaData#deletesAreDetected(int)
+
+```java
+public boolean deletesAreDetected(int type)
+```
+
+> @see java.sql.DatabaseMetaData#insertsAreDetected(int)
+
+```java
+public boolean insertsAreDetected(int type)
+```
+
+> @see java.sql.DatabaseMetaData#isCatalogAtStart()
+
+```java
+public boolean isCatalogAtStart()
+```
+
+> @see java.sql.DatabaseMetaData#locatorsUpdateCopy()
+
+```java
+public boolean locatorsUpdateCopy()
+```
+
+> @see java.sql.DatabaseMetaData#nullPlusNonNullIsNull()
+
+```java
+public boolean nullPlusNonNullIsNull()
+```
+
+> @see java.sql.DatabaseMetaData#nullsAreSortedAtEnd()
+
+```java
+public boolean nullsAreSortedAtEnd()
+```
+
+> @see java.sql.DatabaseMetaData#nullsAreSortedAtStart()
+
+```java
+public boolean nullsAreSortedAtStart()
+```
+
+> @see java.sql.DatabaseMetaData#nullsAreSortedHigh()
+
+```java
+public boolean nullsAreSortedHigh()
+```
+
+> @see java.sql.DatabaseMetaData#nullsAreSortedLow()
+
+```java
+public boolean nullsAreSortedLow()
+```
+
+> @see java.sql.DatabaseMetaData#othersDeletesAreVisible(int)
+
+```java
+public boolean othersDeletesAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#othersInsertsAreVisible(int)
+
+```java
+public boolean othersInsertsAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#othersUpdatesAreVisible(int)
+
+```java
+public boolean othersUpdatesAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#ownDeletesAreVisible(int)
+
+```java
+public boolean ownDeletesAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#ownInsertsAreVisible(int)
+
+```java
+public boolean ownInsertsAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#ownUpdatesAreVisible(int)
+
+```java
+public boolean ownUpdatesAreVisible(int type)
+```
+
+> @see java.sql.DatabaseMetaData#storesLowerCaseIdentifiers()
+
+```java
+public boolean storesLowerCaseIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#storesLowerCaseQuotedIdentifiers()
+
+```java
+public boolean storesLowerCaseQuotedIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#storesMixedCaseIdentifiers()
+
+```java
+public boolean storesMixedCaseIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#storesMixedCaseQuotedIdentifiers()
+
+```java
+public boolean storesMixedCaseQuotedIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#storesUpperCaseIdentifiers()
+
+```java
+public boolean storesUpperCaseIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#storesUpperCaseQuotedIdentifiers()
+
+```java
+public boolean storesUpperCaseQuotedIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#supportsAlterTableWithAddColumn()
+
+```java
+public boolean supportsAlterTableWithAddColumn()
+```
+
+> @see java.sql.DatabaseMetaData#supportsAlterTableWithDropColumn()
+
+```java
+public boolean supportsAlterTableWithDropColumn()
+```
+
+> @see java.sql.DatabaseMetaData#supportsANSI92EntryLevelSQL()
+
+```java
+public boolean supportsANSI92EntryLevelSQL()
+```
+
+> @see java.sql.DatabaseMetaData#supportsANSI92FullSQL()
+
+```java
+public boolean supportsANSI92FullSQL()
+```
+
+> @see java.sql.DatabaseMetaData#supportsANSI92IntermediateSQL()
+
+```java
+public boolean supportsANSI92IntermediateSQL()
+```
+
+> @see java.sql.DatabaseMetaData#supportsBatchUpdates()
+
+```java
+public boolean supportsBatchUpdates()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCatalogsInDataManipulation()
+
+```java
+public boolean supportsCatalogsInDataManipulation()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCatalogsInIndexDefinitions()
+
+```java
+public boolean supportsCatalogsInIndexDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCatalogsInPrivilegeDefinitions()
+
+```java
+public boolean supportsCatalogsInPrivilegeDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCatalogsInProcedureCalls()
+
+```java
+public boolean supportsCatalogsInProcedureCalls()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCatalogsInTableDefinitions()
+
+```java
+public boolean supportsCatalogsInTableDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsColumnAliasing()
+
+```java
+public boolean supportsColumnAliasing()
+```
+
+> @see java.sql.DatabaseMetaData#supportsConvert()
+
+```java
+public boolean supportsConvert()
+```
+
+> @see java.sql.DatabaseMetaData#supportsConvert(int, int)
+
+```java
+public boolean supportsConvert(int fromType, int toType)
+```
+
+> @see java.sql.DatabaseMetaData#supportsCorrelatedSubqueries()
+
+```java
+public boolean supportsCorrelatedSubqueries()
+```
+
+> @see java.sql.DatabaseMetaData#supportsDataDefinitionAndDataManipulationTransactions()
+
+```java
+public boolean supportsDataDefinitionAndDataManipulationTransactions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsDataManipulationTransactionsOnly()
+
+```java
+public boolean supportsDataManipulationTransactionsOnly()
+```
+
+> @see java.sql.DatabaseMetaData#supportsDifferentTableCorrelationNames()
+
+```java
+public boolean supportsDifferentTableCorrelationNames()
+```
+
+> @see java.sql.DatabaseMetaData#supportsExpressionsInOrderBy()
+
+```java
+public boolean supportsExpressionsInOrderBy()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMinimumSQLGrammar()
+
+```java
+public boolean supportsMinimumSQLGrammar()
+```
+
+> @see java.sql.DatabaseMetaData#supportsCoreSQLGrammar()
+
+```java
+public boolean supportsCoreSQLGrammar()
+```
+
+> @see java.sql.DatabaseMetaData#supportsExtendedSQLGrammar()
+
+```java
+public boolean supportsExtendedSQLGrammar()
+```
+
+> @see java.sql.DatabaseMetaData#supportsLimitedOuterJoins()
+
+```java
+public boolean supportsLimitedOuterJoins()
+```
+
+> @see java.sql.DatabaseMetaData#supportsFullOuterJoins()
+
+```java
+public boolean supportsFullOuterJoins() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#supportsGetGeneratedKeys()
+
+```java
+public boolean supportsGetGeneratedKeys()
+```
+
+> @see java.sql.DatabaseMetaData#supportsGroupBy()
+
+```java
+public boolean supportsGroupBy()
+```
+
+> @see java.sql.DatabaseMetaData#supportsGroupByBeyondSelect()
+
+```java
+public boolean supportsGroupByBeyondSelect()
+```
+
+> @see java.sql.DatabaseMetaData#supportsGroupByUnrelated()
+
+```java
+public boolean supportsGroupByUnrelated()
+```
+
+> @see java.sql.DatabaseMetaData#supportsIntegrityEnhancementFacility()
+
+```java
+public boolean supportsIntegrityEnhancementFacility()
+```
+
+> @see java.sql.DatabaseMetaData#supportsLikeEscapeClause()
+
+```java
+public boolean supportsLikeEscapeClause()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMixedCaseIdentifiers()
+
+```java
+public boolean supportsMixedCaseIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMixedCaseQuotedIdentifiers()
+
+```java
+public boolean supportsMixedCaseQuotedIdentifiers()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMultipleOpenResults()
+
+```java
+public boolean supportsMultipleOpenResults()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMultipleResultSets()
+
+```java
+public boolean supportsMultipleResultSets()
+```
+
+> @see java.sql.DatabaseMetaData#supportsMultipleTransactions()
+
+```java
+public boolean supportsMultipleTransactions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsNamedParameters()
+
+```java
+public boolean supportsNamedParameters()
+```
+
+> @see java.sql.DatabaseMetaData#supportsNonNullableColumns()
+
+```java
+public boolean supportsNonNullableColumns()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOpenCursorsAcrossCommit()
+
+```java
+public boolean supportsOpenCursorsAcrossCommit()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOpenCursorsAcrossRollback()
+
+```java
+public boolean supportsOpenCursorsAcrossRollback()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOpenStatementsAcrossCommit()
+
+```java
+public boolean supportsOpenStatementsAcrossCommit()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOpenStatementsAcrossRollback()
+
+```java
+public boolean supportsOpenStatementsAcrossRollback()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOrderByUnrelated()
+
+```java
+public boolean supportsOrderByUnrelated()
+```
+
+> @see java.sql.DatabaseMetaData#supportsOuterJoins()
+
+```java
+public boolean supportsOuterJoins()
+```
+
+> @see java.sql.DatabaseMetaData#supportsPositionedDelete()
+
+```java
+public boolean supportsPositionedDelete()
+```
+
+> @see java.sql.DatabaseMetaData#supportsPositionedUpdate()
+
+```java
+public boolean supportsPositionedUpdate()
+```
+
+> @see java.sql.DatabaseMetaData#supportsResultSetConcurrency(int, int)
+
+```java
+public boolean supportsResultSetConcurrency(int t, int c)
+```
+
+> @see java.sql.DatabaseMetaData#supportsResultSetHoldability(int)
+
+```java
+public boolean supportsResultSetHoldability(int h)
+```
+
+> @see java.sql.DatabaseMetaData#supportsResultSetType(int)
+
+```java
+public boolean supportsResultSetType(int t)
+```
+
+> @see java.sql.DatabaseMetaData#supportsSavepoints()
+
+```java
+public boolean supportsSavepoints()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSchemasInDataManipulation()
+
+```java
+public boolean supportsSchemasInDataManipulation()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSchemasInIndexDefinitions()
+
+```java
+public boolean supportsSchemasInIndexDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSchemasInPrivilegeDefinitions()
+
+```java
+public boolean supportsSchemasInPrivilegeDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSchemasInProcedureCalls()
+
+```java
+public boolean supportsSchemasInProcedureCalls()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSchemasInTableDefinitions()
+
+```java
+public boolean supportsSchemasInTableDefinitions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSelectForUpdate()
+
+```java
+public boolean supportsSelectForUpdate()
+```
+
+> @see java.sql.DatabaseMetaData#supportsStatementPooling()
+
+```java
+public boolean supportsStatementPooling()
+```
+
+> @see java.sql.DatabaseMetaData#supportsStoredProcedures()
+
+```java
+public boolean supportsStoredProcedures()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSubqueriesInComparisons()
+
+```java
+public boolean supportsSubqueriesInComparisons()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSubqueriesInExists()
+
+```java
+public boolean supportsSubqueriesInExists()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSubqueriesInIns()
+
+```java
+public boolean supportsSubqueriesInIns()
+```
+
+> @see java.sql.DatabaseMetaData#supportsSubqueriesInQuantifieds()
+
+```java
+public boolean supportsSubqueriesInQuantifieds()
+```
+
+> @see java.sql.DatabaseMetaData#supportsTableCorrelationNames()
+
+```java
+public boolean supportsTableCorrelationNames()
+```
+
+> @see java.sql.DatabaseMetaData#supportsTransactionIsolationLevel(int)
+
+```java
+public boolean supportsTransactionIsolationLevel(int level)
+```
+
+> @see java.sql.DatabaseMetaData#supportsTransactions()
+
+```java
+public boolean supportsTransactions()
+```
+
+> @see java.sql.DatabaseMetaData#supportsUnion()
+
+```java
+public boolean supportsUnion()
+```
+
+> @see java.sql.DatabaseMetaData#supportsUnionAll()
+
+```java
+public boolean supportsUnionAll()
+```
+
+> @see java.sql.DatabaseMetaData#updatesAreDetected(int)
+
+```java
+public boolean updatesAreDetected(int type)
+```
+
+> @see java.sql.DatabaseMetaData#usesLocalFilePerTable()
+
+```java
+public boolean usesLocalFilePerTable()
+```
+
+> @see java.sql.DatabaseMetaData#usesLocalFiles()
+
+```java
+public boolean usesLocalFiles()
+```
+
+> @see java.sql.DatabaseMetaData#isReadOnly()
+
+```java
+public boolean isReadOnly() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getAttributes(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String)
+
+```java
+public ResultSet getAttributes(String c, String s, String t, String a) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getBestRowIdentifier(java.lang.String, java.lang.String,
+> java.lang.String, int, boolean)
+
+```java
+public ResultSet getBestRowIdentifier(String c, String s, String t, int scope, boolean n)
+```
+
+> @see java.sql.DatabaseMetaData#getColumnPrivileges(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String)
+
+```java
+public ResultSet getColumnPrivileges(String c, String s, String t, String colPat)
+```
+
+> @see java.sql.DatabaseMetaData#getColumns(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String)
+
+```java
+public ResultSet getColumns(String c, String s, String tblNamePattern, String colNamePattern)
+```
+
+> @see java.sql.DatabaseMetaData#getCrossReference(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String, java.lang.String, java.lang.String)
+
+```java
+public ResultSet getCrossReference(
+            String pc, String ps, String pt, String fc, String fs, String ft) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getSchemas()
+
+```java
+public ResultSet getSchemas() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getCatalogs()
+
+```java
+public ResultSet getCatalogs() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getPrimaryKeys(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getPrimaryKeys(String c, String s, String table) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getExportedKeys(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getExportedKeys(String catalog, String schema, String table)
+```
+
+```java
+final ImportedKeyFinder impFkFinder = ...
+```
+
+> @see java.sql.DatabaseMetaData#getImportedKeys(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getImportedKeys(String catalog, String schema, String table)
+```
+
+```java
+final ImportedKeyFinder impFkFinder = ...
+```
+
+> @see java.sql.DatabaseMetaData#getIndexInfo(java.lang.String, java.lang.String,
+> java.lang.String, boolean, boolean)
+
+```java
+public ResultSet getIndexInfo(String c, String s, String table, boolean u, boolean approximate)
+```
+
+> @see java.sql.DatabaseMetaData#getProcedureColumns(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String)
+
+```java
+public ResultSet getProcedureColumns(String c, String s, String p, String colPat)
+```
+
+> @see java.sql.DatabaseMetaData#getProcedures(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getProcedures(String c, String s, String p) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getSuperTables(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getSuperTables(String c, String s, String t) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getSuperTypes(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getSuperTypes(String c, String s, String t) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getTablePrivileges(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getTablePrivileges(String c, String s, String t) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getTables(java.lang.String, java.lang.String,
+> java.lang.String, java.lang.String[])
+
+```java
+public synchronized ResultSet getTables(
+            String c, String s, String tblNamePattern, String[] types) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getTableTypes()
+
+```java
+public ResultSet getTableTypes() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getTypeInfo()
+
+```java
+public ResultSet getTypeInfo() throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getUDTs(java.lang.String, java.lang.String, java.lang.String,
+> int[])
+
+```java
+public ResultSet getUDTs(String c, String s, String t, int[] types) throws SQLException
+```
+
+> @see java.sql.DatabaseMetaData#getVersionColumns(java.lang.String, java.lang.String,
+> java.lang.String)
+
+```java
+public ResultSet getVersionColumns(String c, String s, String t) throws SQLException
+```
+
+> @deprecated Not exactly sure what this function does, as it is not implementing any
+> interface, and is not used anywhere in the code. Deprecated since 3.43.0.0.
+
+```java
+    @Deprecated
+public ResultSet getGeneratedKeys() throws SQLException
+```
+
+> Not implemented yet.
+
+```java
+public Struct createStruct(String t, Object[] attr) throws SQLException
+```
+
+> Not implemented yet.
+
+```java
+public ResultSet getFunctionColumns(String a, String b, String c, String d)
+```
+
+> @return The primary key name if any.
+
+```java
+public String getName()
+```
+
+> @return Array of primary key column(s) if any.
+
+```java
+public String[] getColumns()
+```
+
+```java
+public String getFkTableName()
+```
+
+```java
+public List<ForeignKey> getFkList()
+```
+
+```java
+public String getFkName()
+```
+
+```java
+public String[] getColumnMapping(int colSeq)
+```
+
+```java
+public int getColumnMappingCount()
+```
+
+```java
+public String getPkTableName()
+```
+
+```java
+public String getFkTableName()
+```
+
+```java
+public String getOnUpdate()
+```
+
+```java
+public String getOnDelete()
+```
+
+```java
+public String getMatch()
+```
+
+```java
+            @Override
+public String toString()
+```
+
+#### `org/sqlite/jdbc3/JDBC3PreparedStatement.java`
+
+```java
+public abstract class JDBC3PreparedStatement extends CorePreparedStatement
+```
+
+> @see java.sql.PreparedStatement#clearParameters()
+
+```java
+public void clearParameters() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#execute()
+
+```java
+public boolean execute() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#executeQuery()
+
+```java
+public ResultSet executeQuery() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#executeUpdate()
+
+```java
+public int executeUpdate() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#executeLargeUpdate()
+
+```java
+public long executeLargeUpdate() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#addBatch()
+
+```java
+public void addBatch() throws SQLException
+```
+
+> @see java.sql.PreparedStatement#getParameterMetaData()
+
+```java
+public ParameterMetaData getParameterMetaData()
+```
+
+> @see java.sql.ParameterMetaData#getParameterCount()
+
+```java
+public int getParameterCount() throws SQLException
+```
+
+> @see java.sql.ParameterMetaData#getParameterClassName(int)
+
+```java
+public String getParameterClassName(int param) throws SQLException
+```
+
+> @see java.sql.ParameterMetaData#getParameterTypeName(int)
+
+```java
+public String getParameterTypeName(int pos) throws SQLException
+```
+
+> @see java.sql.ParameterMetaData#getParameterType(int)
+
+```java
+public int getParameterType(int pos) throws SQLException
+```
+
+> @see java.sql.ParameterMetaData#getParameterMode(int)
+
+```java
+public int getParameterMode(int pos)
+```
+
+> @see java.sql.ParameterMetaData#getPrecision(int)
+
+```java
+public int getPrecision(int pos)
+```
+
+> @see java.sql.ParameterMetaData#getScale(int)
+
+```java
+public int getScale(int pos)
+```
+
+> @see java.sql.ParameterMetaData#isNullable(int)
+
+```java
+public int isNullable(int pos)
+```
+
+> @see java.sql.ParameterMetaData#isSigned(int)
+
+```java
+public boolean isSigned(int pos)
+```
+
+> @return
+
+```java
+public Statement getStatement()
+```
+
+> @see java.sql.PreparedStatement#setBigDecimal(int, java.math.BigDecimal)
+
+```java
+public void setBigDecimal(int pos, BigDecimal value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setBinaryStream(int, java.io.InputStream, int)
+
+```java
+public void setBinaryStream(int pos, InputStream istream, int length) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setAsciiStream(int, java.io.InputStream, int)
+
+```java
+public void setAsciiStream(int pos, InputStream istream, int length) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setUnicodeStream(int, java.io.InputStream, int)
+
+```java
+public void setUnicodeStream(int pos, InputStream istream, int length) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setBoolean(int, boolean)
+
+```java
+public void setBoolean(int pos, boolean value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setByte(int, byte)
+
+```java
+public void setByte(int pos, byte value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setBytes(int, byte[])
+
+```java
+public void setBytes(int pos, byte[] value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setDouble(int, double)
+
+```java
+public void setDouble(int pos, double value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setFloat(int, float)
+
+```java
+public void setFloat(int pos, float value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setInt(int, int)
+
+```java
+public void setInt(int pos, int value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setLong(int, long)
+
+```java
+public void setLong(int pos, long value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setNull(int, int)
+
+```java
+public void setNull(int pos, int u1) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setNull(int, int, java.lang.String)
+
+```java
+public void setNull(int pos, int u1, String u2) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setObject(int, java.lang.Object)
+
+```java
+public void setObject(int pos, Object value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setObject(int, java.lang.Object, int)
+
+```java
+public void setObject(int p, Object v, int t) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setObject(int, java.lang.Object, int, int)
+
+```java
+public void setObject(int p, Object v, int t, int s) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setShort(int, short)
+
+```java
+public void setShort(int pos, short value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setString(int, java.lang.String)
+
+```java
+public void setString(int pos, String value) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setCharacterStream(int, java.io.Reader, int)
+
+```java
+public void setCharacterStream(int pos, Reader reader, int length) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setDate(int, java.sql.Date)
+
+```java
+public void setDate(int pos, Date x) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setDate(int, java.sql.Date, java.util.Calendar)
+
+```java
+public void setDate(int pos, Date x, Calendar cal) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setTime(int, java.sql.Time)
+
+```java
+public void setTime(int pos, Time x) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setTime(int, java.sql.Time, java.util.Calendar)
+
+```java
+public void setTime(int pos, Time x, Calendar cal) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setTimestamp(int, java.sql.Timestamp)
+
+```java
+public void setTimestamp(int pos, Timestamp x) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#setTimestamp(int, java.sql.Timestamp, java.util.Calendar)
+
+```java
+public void setTimestamp(int pos, Timestamp x, Calendar cal) throws SQLException
+```
+
+> @see java.sql.PreparedStatement#getMetaData()
+
+```java
+public ResultSetMetaData getMetaData() throws SQLException
+```
+
+```java
+public void setArray(int i, Array x) throws SQLException
+```
+
+```java
+public void setBlob(int i, Blob x) throws SQLException
+```
+
+```java
+public void setClob(int i, Clob x) throws SQLException
+```
+
+```java
+public void setRef(int i, Ref x) throws SQLException
+```
+
+```java
+public void setURL(int pos, URL x) throws SQLException
+```
+
+> @see org.sqlite.core.CoreStatement#exec(java.lang.String)
+
+```java
+    @Override
+public boolean execute(String sql) throws SQLException
+```
+
+```java
+public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+```java
+public boolean execute(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public boolean execute(String sql, String[] colnames) throws SQLException
+```
+
+> @see org.sqlite.core.CoreStatement#exec(java.lang.String)
+
+```java
+    @Override
+public int executeUpdate(String sql) throws SQLException
+```
+
+```java
+public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+```java
+public int executeUpdate(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public int executeUpdate(String sql, String[] cols) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql, String[] cols) throws SQLException
+```
+
+> @see org.sqlite.core.CoreStatement#exec(String)
+
+```java
+    @Override
+public ResultSet executeQuery(String sql) throws SQLException
+```
+
+```java
+    @Override
+public void addBatch(String sql) throws SQLException
+```
+
+#### `org/sqlite/jdbc3/JDBC3ResultSet.java`
+
+```java
+public abstract class JDBC3ResultSet extends CoreResultSet
+```
+
+> returns col in [1,x] form
+>
+> @see java.sql.ResultSet#findColumn(java.lang.String)
+
+```java
+public int findColumn(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#next()
+
+```java
+public boolean next() throws SQLException
+```
+
+> @see java.sql.ResultSet#getType()
+
+```java
+public int getType()
+```
+
+> @see java.sql.ResultSet#getFetchSize()
+
+```java
+public int getFetchSize()
+```
+
+> @see java.sql.ResultSet#setFetchSize(int)
+
+```java
+public void setFetchSize(int rows) throws SQLException
+```
+
+> @see java.sql.ResultSet#getFetchDirection()
+
+```java
+public int getFetchDirection() throws SQLException
+```
+
+> @see java.sql.ResultSet#setFetchDirection(int)
+
+```java
+public void setFetchDirection(int d) throws SQLException
+```
+
+> @see java.sql.ResultSet#isAfterLast()
+
+```java
+public boolean isAfterLast()
+```
+
+> @see java.sql.ResultSet#isBeforeFirst()
+
+```java
+public boolean isBeforeFirst()
+```
+
+> @see java.sql.ResultSet#isFirst()
+
+```java
+public boolean isFirst()
+```
+
+> @see java.sql.ResultSet#isLast()
+
+```java
+public boolean isLast() throws SQLException
+```
+
+> @see java.sql.ResultSet#getRow()
+
+```java
+public int getRow()
+```
+
+> @see java.sql.ResultSet#wasNull()
+
+```java
+public boolean wasNull() throws SQLException
+```
+
+> @see java.sql.ResultSet#getBigDecimal(int)
+
+```java
+public BigDecimal getBigDecimal(int col) throws SQLException
+```
+
+```java
+final String stringValue = ...
+```
+
+> @see java.sql.ResultSet#getBigDecimal(java.lang.String)
+
+```java
+public BigDecimal getBigDecimal(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBoolean(int)
+
+```java
+public boolean getBoolean(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBoolean(java.lang.String)
+
+```java
+public boolean getBoolean(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBinaryStream(int)
+
+```java
+public InputStream getBinaryStream(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBinaryStream(java.lang.String)
+
+```java
+public InputStream getBinaryStream(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getByte(int)
+
+```java
+public byte getByte(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getByte(java.lang.String)
+
+```java
+public byte getByte(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBytes(int)
+
+```java
+public byte[] getBytes(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getBytes(java.lang.String)
+
+```java
+public byte[] getBytes(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getCharacterStream(int)
+
+```java
+public Reader getCharacterStream(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getCharacterStream(java.lang.String)
+
+```java
+public Reader getCharacterStream(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDate(int)
+
+```java
+public Date getDate(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDate(int, java.util.Calendar)
+
+```java
+public Date getDate(int col, Calendar cal) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDate(java.lang.String)
+
+```java
+public Date getDate(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDate(java.lang.String, java.util.Calendar)
+
+```java
+public Date getDate(String col, Calendar cal) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDouble(int)
+
+```java
+public double getDouble(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getDouble(java.lang.String)
+
+```java
+public double getDouble(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getFloat(int)
+
+```java
+public float getFloat(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getFloat(java.lang.String)
+
+```java
+public float getFloat(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getInt(int)
+
+```java
+public int getInt(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getInt(java.lang.String)
+
+```java
+public int getInt(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getLong(int)
+
+```java
+public long getLong(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getLong(java.lang.String)
+
+```java
+public long getLong(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getShort(int)
+
+```java
+public short getShort(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getShort(java.lang.String)
+
+```java
+public short getShort(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getString(int)
+
+```java
+public String getString(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getString(java.lang.String)
+
+```java
+public String getString(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTime(int)
+
+```java
+public Time getTime(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTime(int, java.util.Calendar)
+
+```java
+public Time getTime(int col, Calendar cal) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTime(java.lang.String)
+
+```java
+public Time getTime(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTime(java.lang.String, java.util.Calendar)
+
+```java
+public Time getTime(String col, Calendar cal) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTimestamp(int)
+
+```java
+public Timestamp getTimestamp(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTimestamp(int, java.util.Calendar)
+
+```java
+public Timestamp getTimestamp(int col, Calendar cal) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTimestamp(java.lang.String)
+
+```java
+public Timestamp getTimestamp(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getTimestamp(java.lang.String, java.util.Calendar)
+
+```java
+public Timestamp getTimestamp(String c, Calendar ca) throws SQLException
+```
+
+> @see java.sql.ResultSet#getObject(int)
+
+```java
+public Object getObject(int col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getObject(java.lang.String)
+
+```java
+public Object getObject(String col) throws SQLException
+```
+
+> @see java.sql.ResultSet#getStatement()
+
+```java
+public Statement getStatement()
+```
+
+> @see java.sql.ResultSet#getCursorName()
+
+```java
+public String getCursorName()
+```
+
+> @see java.sql.ResultSet#getWarnings()
+
+```java
+public SQLWarning getWarnings()
+```
+
+> @see java.sql.ResultSet#clearWarnings()
+
+```java
+public void clearWarnings()
+```
+
+> @see java.sql.ResultSet#getMetaData()
+
+```java
+public ResultSetMetaData getMetaData()
+```
+
+> @see java.sql.ResultSetMetaData#getCatalogName(int)
+
+```java
+public String getCatalogName(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getColumnClassName(int)
+
+```java
+public String getColumnClassName(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getColumnCount()
+
+```java
+public int getColumnCount() throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getColumnDisplaySize(int)
+
+```java
+public int getColumnDisplaySize(int col)
+```
+
+> @see java.sql.ResultSetMetaData#getColumnLabel(int)
+
+```java
+public String getColumnLabel(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getColumnName(int)
+
+```java
+public String getColumnName(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getColumnType(int)
+
+```java
+public int getColumnType(int col) throws SQLException
+```
+
+> @return The data type from either the 'create table' statement, or CAST(expr AS TYPE)
+> otherwise sqlite3_value_type.
+> @see java.sql.ResultSetMetaData#getColumnTypeName(int)
+
+```java
+public String getColumnTypeName(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getPrecision(int)
+
+```java
+public int getPrecision(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getScale(int)
+
+```java
+public int getScale(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#getSchemaName(int)
+
+```java
+public String getSchemaName(int col)
+```
+
+> @see java.sql.ResultSetMetaData#getTableName(int)
+
+```java
+public String getTableName(int col) throws SQLException
+```
+
+```java
+final String tableName = ...
+```
+
+> @see java.sql.ResultSetMetaData#isNullable(int)
+
+```java
+public int isNullable(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#isAutoIncrement(int)
+
+```java
+public boolean isAutoIncrement(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#isCaseSensitive(int)
+
+```java
+public boolean isCaseSensitive(int col)
+```
+
+> @see java.sql.ResultSetMetaData#isCurrency(int)
+
+```java
+public boolean isCurrency(int col)
+```
+
+> @see java.sql.ResultSetMetaData#isDefinitelyWritable(int)
+
+```java
+public boolean isDefinitelyWritable(int col)
+```
+
+> @see java.sql.ResultSetMetaData#isReadOnly(int)
+
+```java
+public boolean isReadOnly(int col)
+```
+
+> @see java.sql.ResultSetMetaData#isSearchable(int)
+
+```java
+public boolean isSearchable(int col)
+```
+
+> @see java.sql.ResultSetMetaData#isSigned(int)
+
+```java
+public boolean isSigned(int col) throws SQLException
+```
+
+> @see java.sql.ResultSetMetaData#isWritable(int)
+
+```java
+public boolean isWritable(int col)
+```
+
+> @see java.sql.ResultSet#getConcurrency()
+
+```java
+public int getConcurrency()
+```
+
+> @see java.sql.ResultSet#rowDeleted()
+
+```java
+public boolean rowDeleted()
+```
+
+> @see java.sql.ResultSet#rowInserted()
+
+```java
+public boolean rowInserted()
+```
+
+> @see java.sql.ResultSet#rowUpdated()
+
+```java
+public boolean rowUpdated()
+```
+
+#### `org/sqlite/jdbc3/JDBC3Savepoint.java`
+
+```java
+public class JDBC3Savepoint implements Savepoint
+```
+
+```java
+final int id ;
+```
+
+```java
+final String name ;
+```
+
+```java
+public int getSavepointId() throws SQLException
+```
+
+```java
+public String getSavepointName() throws SQLException
+```
+
+#### `org/sqlite/jdbc3/JDBC3Statement.java`
+
+```java
+public abstract class JDBC3Statement extends CoreStatement
+```
+
+> @see java.sql.Statement#close()
+
+```java
+public void close() throws SQLException
+```
+
+> @see java.sql.Statement#execute(java.lang.String)
+
+```java
+public boolean execute(final String sql) throws SQLException
+```
+
+> @see java.sql.Statement#execute(java.lang.String, int)
+
+```java
+public boolean execute(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+> @param closeStmt Whether to close this statement when the resultset is closed.
+> @see java.sql.Statement#executeQuery(java.lang.String)
+
+```java
+public ResultSet executeQuery(String sql, boolean closeStmt) throws SQLException
+```
+
+> @see java.sql.Statement#executeQuery(java.lang.String)
+
+```java
+public ResultSet executeQuery(String sql) throws SQLException
+```
+
+```java
+static class BackupObserver implements ProgressObserver
+```
+
+```java
+public void progress(int remaining, int pageCount)
+```
+
+> @see java.sql.Statement#executeUpdate(java.lang.String)
+
+```java
+public int executeUpdate(final String sql) throws SQLException
+```
+
+> @see java.sql.Statement#executeUpdate(java.lang.String, int)
+
+```java
+public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+> @see java.sql.Statement#executeLargeUpdate(java.lang.String)
+
+```java
+public long executeLargeUpdate(String sql) throws SQLException
+```
+
+> @see java.sql.Statement#executeLargeUpdate(java.lang.String, int)
+
+```java
+public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException
+```
+
+> @see java.sql.Statement#getResultSet()
+
+```java
+public ResultSet getResultSet() throws SQLException
+```
+
+> This function has a complex behaviour best understood by carefully reading the JavaDoc for
+> getMoreResults() and considering the test StatementTest.execute().
+>
+> @see java.sql.Statement#getUpdateCount()
+
+```java
+public int getUpdateCount() throws SQLException
+```
+
+> This function has a complex behaviour best understood by carefully reading the JavaDoc for
+> getMoreResults() and considering the test StatementTest.execute().
+>
+> @see java.sql.Statement#getLargeUpdateCount()
+
+```java
+public long getLargeUpdateCount() throws SQLException
+```
+
+> @see java.sql.Statement#addBatch(java.lang.String)
+
+```java
+public void addBatch(String sql) throws SQLException
+```
+
+> @see java.sql.Statement#clearBatch()
+
+```java
+public void clearBatch() throws SQLException
+```
+
+> @see java.sql.Statement#executeBatch()
+
+```java
+public int[] executeBatch() throws SQLException
+```
+
+> @see java.sql.Statement#executeLargeBatch()
+
+```java
+public long[] executeLargeBatch() throws SQLException
+```
+
+> @see java.sql.Statement#setCursorName(java.lang.String)
+
+```java
+public void setCursorName(String name)
+```
+
+> @see java.sql.Statement#getWarnings()
+
+```java
+public SQLWarning getWarnings() throws SQLException
+```
+
+> @see java.sql.Statement#clearWarnings()
+
+```java
+public void clearWarnings() throws SQLException
+```
+
+> @see java.sql.Statement#getConnection()
+
+```java
+public Connection getConnection() throws SQLException
+```
+
+> @see java.sql.Statement#cancel()
+
+```java
+public void cancel() throws SQLException
+```
+
+> @see java.sql.Statement#getQueryTimeout()
+
+```java
+public int getQueryTimeout() throws SQLException
+```
+
+> @see java.sql.Statement#setQueryTimeout(int)
+
+```java
+public void setQueryTimeout(int seconds) throws SQLException
+```
+
+> @see java.sql.Statement#getMaxRows()
+
+```java
+public int getMaxRows() throws SQLException
+```
+
+> @see java.sql.Statement#getLargeMaxRows()
+
+```java
+public long getLargeMaxRows() throws SQLException
+```
+
+> @see java.sql.Statement#setMaxRows(int)
+
+```java
+public void setMaxRows(int max) throws SQLException
+```
+
+> @see java.sql.Statement#setLargeMaxRows(long)
+
+```java
+public void setLargeMaxRows(long max) throws SQLException
+```
+
+> @see java.sql.Statement#getMaxFieldSize()
+
+```java
+public int getMaxFieldSize() throws SQLException
+```
+
+> @see java.sql.Statement#setMaxFieldSize(int)
+
+```java
+public void setMaxFieldSize(int max) throws SQLException
+```
+
+> @see java.sql.Statement#getFetchSize()
+
+```java
+public int getFetchSize() throws SQLException
+```
+
+> @see java.sql.Statement#setFetchSize(int)
+
+```java
+public void setFetchSize(int r) throws SQLException
+```
+
+> @see java.sql.Statement#getFetchDirection()
+
+```java
+public int getFetchDirection() throws SQLException
+```
+
+> @see java.sql.Statement#setFetchDirection(int)
+
+```java
+public void setFetchDirection(int direction) throws SQLException
+```
+
+> SQLite does not support multiple results from execute().
+>
+> @see java.sql.Statement#getMoreResults()
+
+```java
+public boolean getMoreResults() throws SQLException
+```
+
+> @see java.sql.Statement#getMoreResults(int)
+
+```java
+public boolean getMoreResults(int current) throws SQLException
+```
+
+> @see java.sql.Statement#getResultSetConcurrency()
+
+```java
+public int getResultSetConcurrency() throws SQLException
+```
+
+> @see java.sql.Statement#getResultSetHoldability()
+
+```java
+public int getResultSetHoldability() throws SQLException
+```
+
+> @see java.sql.Statement#getResultSetType()
+
+```java
+public int getResultSetType() throws SQLException
+```
+
+> @see java.sql.Statement#setEscapeProcessing(boolean)
+
+```java
+public void setEscapeProcessing(boolean enable)
+```
+
+```java
+public boolean execute(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public boolean execute(String sql, String[] colnames) throws SQLException
+```
+
+```java
+public int executeUpdate(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public int executeUpdate(String sql, String[] cols) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql, int[] colinds) throws SQLException
+```
+
+```java
+public long executeLargeUpdate(String sql, String[] cols) throws SQLException
+```
+
+#### `org/sqlite/jdbc4/JDBC4Connection.java`
+
+```java
+public class JDBC4Connection extends JDBC3Connection
+```
+
+```java
+public Statement createStatement(int rst, int rsc, int rsh) throws SQLException
+```
+
+```java
+public PreparedStatement prepareStatement(String sql, int rst, int rsc, int rsh)
+```
+
+> @see java.sql.Connection#isClosed()
+
+```java
+public boolean isClosed() throws SQLException
+```
+
+```java
+public <T> T unwrap(Class<T> iface) throws ClassCastException
+```
+
+```java
+public boolean isWrapperFor(Class<?> iface)
+```
+
+```java
+public Clob createClob() throws SQLException
+```
+
+```java
+public Blob createBlob() throws SQLException
+```
+
+```java
+public NClob createNClob() throws SQLException
+```
+
+```java
+public SQLXML createSQLXML() throws SQLException
+```
+
+```java
+public boolean isValid(int timeout) throws SQLException
+```
+
+```java
+public void setClientInfo(String name, String value) throws SQLClientInfoException
+```
+
+```java
+public void setClientInfo(Properties properties) throws SQLClientInfoException
+```
+
+```java
+public String getClientInfo(String name) throws SQLException
+```
+
+```java
+public Properties getClientInfo() throws SQLException
+```
+
+```java
+public Array createArrayOf(String typeName, Object[] elements) throws SQLException
+```
+
+#### `org/sqlite/jdbc4/JDBC4DatabaseMetaData.java`
+
+```java
+public class JDBC4DatabaseMetaData extends JDBC3DatabaseMetaData
+```
+
+```java
+public <T> T unwrap(Class<T> iface) throws ClassCastException
+```
+
+```java
+public boolean isWrapperFor(Class<?> iface)
+```
+
+```java
+public RowIdLifetime getRowIdLifetime() throws SQLException
+```
+
+```java
+public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException
+```
+
+```java
+public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException
+```
+
+```java
+public boolean autoCommitFailureClosesAllResultSets() throws SQLException
+```
+
+```java
+public ResultSet getClientInfoProperties() throws SQLException
+```
+
+```java
+public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+```
+
+```java
+public ResultSet getPseudoColumns(
+            String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+```
+
+```java
+public boolean generatedKeyAlwaysReturned() throws SQLException
+```
+
+#### `org/sqlite/jdbc4/JDBC4PooledConnection.java`
+
+```java
+public abstract class JDBC4PooledConnection implements PooledConnection
+```
+
+```java
+public void addStatementEventListener(StatementEventListener listener)
+```
+
+```java
+public void removeStatementEventListener(StatementEventListener listener)
+```
+
+#### `org/sqlite/jdbc4/JDBC4PreparedStatement.java`
+
+```java
+public class JDBC4PreparedStatement extends JDBC3PreparedStatement
+        implements PreparedStatement, ParameterMetaData
+```
+
+```java
+    @Override
+public String toString()
+```
+
+```java
+public void setRowId(int parameterIndex, RowId x) throws SQLException
+```
+
+```java
+public void setNString(int parameterIndex, String value) throws SQLException
+```
+
+```java
+public void setNCharacterStream(int parameterIndex, Reader value, long length)
+```
+
+```java
+public void setNClob(int parameterIndex, NClob value) throws SQLException
+```
+
+```java
+public void setClob(int parameterIndex, Reader reader, long length) throws SQLException
+```
+
+```java
+public void setBlob(int parameterIndex, InputStream inputStream, long length)
+```
+
+```java
+public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException
+```
+
+```java
+public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException
+```
+
+```java
+public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException
+```
+
+```java
+public void setBinaryStream(int parameterIndex, InputStream x, long length)
+```
+
+```java
+public void setCharacterStream(int parameterIndex, Reader reader, long length)
+```
+
+```java
+public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException
+```
+
+```java
+public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException
+```
+
+```java
+public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException
+```
+
+```java
+public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException
+```
+
+```java
+public void setClob(int parameterIndex, Reader reader) throws SQLException
+```
+
+```java
+public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException
+```
+
+```java
+public void setNClob(int parameterIndex, Reader reader) throws SQLException
+```
+
+#### `org/sqlite/jdbc4/JDBC4ResultSet.java`
+
+```java
+public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultSetMetaData
+```
+
+```java
+    @Override
+public void close() throws SQLException
+```
+
+```java
+final boolean wasOpen = ...
+```
+
+```java
+public <T> T unwrap(Class<T> iface) throws ClassCastException
+```
+
+```java
+public boolean isWrapperFor(Class<?> iface)
+```
+
+```java
+public RowId getRowId(int columnIndex) throws SQLException
+```
+
+```java
+public RowId getRowId(String columnLabel) throws SQLException
+```
+
+```java
+public void updateRowId(int columnIndex, RowId x) throws SQLException
+```
+
+```java
+public void updateRowId(String columnLabel, RowId x) throws SQLException
+```
+
+```java
+public int getHoldability() throws SQLException
+```
+
+```java
+public boolean isClosed() throws SQLException
+```
+
+```java
+public void updateNString(int columnIndex, String nString) throws SQLException
+```
+
+```java
+public void updateNString(String columnLabel, String nString) throws SQLException
+```
+
+```java
+public void updateNClob(int columnIndex, NClob nClob) throws SQLException
+```
+
+```java
+public void updateNClob(String columnLabel, NClob nClob) throws SQLException
+```
+
+```java
+public NClob getNClob(int columnIndex) throws SQLException
+```
+
+```java
+public NClob getNClob(String columnLabel) throws SQLException
+```
+
+```java
+public SQLXML getSQLXML(int columnIndex) throws SQLException
+```
+
+```java
+public SQLXML getSQLXML(String columnLabel) throws SQLException
+```
+
+```java
+public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException
+```
+
+```java
+public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
+```
+
+```java
+public String getNString(int columnIndex) throws SQLException
+```
+
+```java
+public String getNString(String columnLabel) throws SQLException
+```
+
+```java
+public Reader getNCharacterStream(int col) throws SQLException
+```
+
+```java
+public Reader getNCharacterStream(String col) throws SQLException
+```
+
+```java
+public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+```
+
+```java
+public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+```
+
+```java
+public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
+```
+
+```java
+public void updateBinaryStream(int columnIndex, InputStream x, long length)
+```
+
+```java
+public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+```
+
+```java
+public void updateAsciiStream(String columnLabel, InputStream x, long length)
+```
+
+```java
+public void updateBinaryStream(String columnLabel, InputStream x, long length)
+```
+
+```java
+public void updateCharacterStream(String columnLabel, Reader reader, long length)
+```
+
+```java
+public void updateBlob(int columnIndex, InputStream inputStream, long length)
+```
+
+```java
+public void updateBlob(String columnLabel, InputStream inputStream, long length)
+```
+
+```java
+public void updateClob(int columnIndex, Reader reader, long length) throws SQLException
+```
+
+```java
+public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
+```
+
+```java
+public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
+```
+
+```java
+public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException
+```
+
+```java
+public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
+```
+
+```java
+public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
+```
+
+```java
+public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
+```
+
+```java
+public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
+```
+
+```java
+public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
+```
+
+```java
+public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
+```
+
+```java
+public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
+```
+
+```java
+public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
+```
+
+```java
+public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
+```
+
+```java
+public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException
+```
+
+```java
+public void updateClob(int columnIndex, Reader reader) throws SQLException
+```
+
+```java
+public void updateClob(String columnLabel, Reader reader) throws SQLException
+```
+
+```java
+public void updateNClob(int columnIndex, Reader reader) throws SQLException
+```
+
+```java
+public void updateNClob(String columnLabel, Reader reader) throws SQLException
+```
+
+```java
+public <T> T getObject(int columnIndex, Class<T> type) throws SQLException
+```
+
+```java
+public <T> T getObject(String columnLabel, Class<T> type) throws SQLException
+```
+
+```java
+public Array getArray(int i) throws SQLException
+```
+
+```java
+public Array getArray(String col) throws SQLException
+```
+
+```java
+public InputStream getAsciiStream(int col) throws SQLException
+```
+
+```java
+public InputStream getAsciiStream(String col) throws SQLException
+```
+
+```java
+    @Deprecated
+public BigDecimal getBigDecimal(int col, int s) throws SQLException
+```
+
+```java
+    @Deprecated
+public BigDecimal getBigDecimal(String col, int s) throws SQLException
+```
+
+```java
+public Blob getBlob(int col) throws SQLException
+```
+
+```java
+public Blob getBlob(String col) throws SQLException
+```
+
+```java
+public Clob getClob(int col) throws SQLException
+```
+
+```java
+public Clob getClob(String col) throws SQLException
+```
+
+```java
+    @SuppressWarnings("rawtypes")
+public Object getObject(int col, Map map) throws SQLException
+```
+
+```java
+    @SuppressWarnings("rawtypes")
+public Object getObject(String col, Map map) throws SQLException
+```
+
+```java
+public Ref getRef(int i) throws SQLException
+```
+
+```java
+public Ref getRef(String col) throws SQLException
+```
+
+```java
+public InputStream getUnicodeStream(int col) throws SQLException
+```
+
+```java
+public InputStream getUnicodeStream(String col) throws SQLException
+```
+
+```java
+public URL getURL(int col) throws SQLException
+```
+
+```java
+public URL getURL(String col) throws SQLException
+```
+
+```java
+public void insertRow() throws SQLException
+```
+
+```java
+public void moveToCurrentRow() throws SQLException
+```
+
+```java
+public void moveToInsertRow() throws SQLException
+```
+
+```java
+public boolean last() throws SQLException
+```
+
+```java
+public boolean previous() throws SQLException
+```
+
+```java
+public boolean relative(int rows) throws SQLException
+```
+
+```java
+public boolean absolute(int row) throws SQLException
+```
+
+```java
+public void afterLast() throws SQLException
+```
+
+```java
+public void beforeFirst() throws SQLException
+```
+
+```java
+public boolean first() throws SQLException
+```
+
+```java
+public void cancelRowUpdates() throws SQLException
+```
+
+```java
+public void deleteRow() throws SQLException
+```
+
+```java
+public void updateArray(int col, Array x) throws SQLException
+```
+
+```java
+public void updateArray(String col, Array x) throws SQLException
+```
+
+```java
+public void updateAsciiStream(int col, InputStream x, int l) throws SQLException
+```
+
+```java
+public void updateAsciiStream(String col, InputStream x, int l) throws SQLException
+```
+
+```java
+public void updateBigDecimal(int col, BigDecimal x) throws SQLException
+```
+
+```java
+public void updateBigDecimal(String col, BigDecimal x) throws SQLException
+```
+
+```java
+public void updateBinaryStream(int c, InputStream x, int l) throws SQLException
+```
+
+```java
+public void updateBinaryStream(String c, InputStream x, int l) throws SQLException
+```
+
+```java
+public void updateBlob(int col, Blob x) throws SQLException
+```
+
+```java
+public void updateBlob(String col, Blob x) throws SQLException
+```
+
+```java
+public void updateBoolean(int col, boolean x) throws SQLException
+```
+
+```java
+public void updateBoolean(String col, boolean x) throws SQLException
+```
+
+```java
+public void updateByte(int col, byte x) throws SQLException
+```
+
+```java
+public void updateByte(String col, byte x) throws SQLException
+```
+
+```java
+public void updateBytes(int col, byte[] x) throws SQLException
+```
+
+```java
+public void updateBytes(String col, byte[] x) throws SQLException
+```
+
+```java
+public void updateCharacterStream(int c, Reader x, int l) throws SQLException
+```
+
+```java
+public void updateCharacterStream(String c, Reader r, int l) throws SQLException
+```
+
+```java
+public void updateClob(int col, Clob x) throws SQLException
+```
+
+```java
+public void updateClob(String col, Clob x) throws SQLException
+```
+
+```java
+public void updateDate(int col, Date x) throws SQLException
+```
+
+```java
+public void updateDate(String col, Date x) throws SQLException
+```
+
+```java
+public void updateDouble(int col, double x) throws SQLException
+```
+
+```java
+public void updateDouble(String col, double x) throws SQLException
+```
+
+```java
+public void updateFloat(int col, float x) throws SQLException
+```
+
+```java
+public void updateFloat(String col, float x) throws SQLException
+```
+
+```java
+public void updateInt(int col, int x) throws SQLException
+```
+
+```java
+public void updateInt(String col, int x) throws SQLException
+```
+
+```java
+public void updateLong(int col, long x) throws SQLException
+```
+
+```java
+public void updateLong(String col, long x) throws SQLException
+```
+
+```java
+public void updateNull(int col) throws SQLException
+```
+
+```java
+public void updateNull(String col) throws SQLException
+```
+
+```java
+public void updateObject(int c, Object x) throws SQLException
+```
+
+```java
+public void updateObject(int c, Object x, int s) throws SQLException
+```
+
+```java
+public void updateObject(String col, Object x) throws SQLException
+```
+
+```java
+public void updateObject(String c, Object x, int s) throws SQLException
+```
+
+```java
+public void updateRef(int col, Ref x) throws SQLException
+```
+
+```java
+public void updateRef(String c, Ref x) throws SQLException
+```
+
+```java
+public void updateRow() throws SQLException
+```
+
+```java
+public void updateShort(int c, short x) throws SQLException
+```
+
+```java
+public void updateShort(String c, short x) throws SQLException
+```
+
+```java
+public void updateString(int c, String x) throws SQLException
+```
+
+```java
+public void updateString(String c, String x) throws SQLException
+```
+
+```java
+public void updateTime(int c, Time x) throws SQLException
+```
+
+```java
+public void updateTime(String c, Time x) throws SQLException
+```
+
+```java
+public void updateTimestamp(int c, Timestamp x) throws SQLException
+```
+
+```java
+public void updateTimestamp(String c, Timestamp x) throws SQLException
+```
+
+```java
+public void refreshRow() throws SQLException
+```
+
+```java
+public void free() throws SQLException
+```
+
+```java
+public InputStream getAsciiStream() throws SQLException
+```
+
+```java
+public Reader getCharacterStream() throws SQLException
+```
+
+```java
+public Reader getCharacterStream(long arg0, long arg1) throws SQLException
+```
+
+```java
+public String getSubString(long position, int length) throws SQLException
+```
+
+```java
+public long length() throws SQLException
+```
+
+```java
+public long position(String arg0, long arg1) throws SQLException
+```
+
+```java
+public long position(Clob arg0, long arg1) throws SQLException
+```
+
+```java
+public OutputStream setAsciiStream(long arg0) throws SQLException
+```
+
+```java
+public Writer setCharacterStream(long arg0) throws SQLException
+```
+
+```java
+public int setString(long arg0, String arg1) throws SQLException
+```
+
+```java
+public int setString(long arg0, String arg1, int arg2, int arg3) throws SQLException
+```
+
+```java
+public void truncate(long arg0) throws SQLException
+```
+
+#### `org/sqlite/jdbc4/JDBC4Statement.java`
+
+```java
+public class JDBC4Statement extends JDBC3Statement implements Statement
+```
+
+```java
+public <T> T unwrap(Class<T> iface) throws ClassCastException
+```
+
+```java
+public boolean isWrapperFor(Class<?> iface)
+```
+
+```java
+    @Override
+public void close() throws SQLException
+```
+
+```java
+public boolean isClosed()
+```
+
+```java
+public void closeOnCompletion() throws SQLException
+```
+
+```java
+public boolean isCloseOnCompletion() throws SQLException
+```
+
+```java
+public void setPoolable(boolean poolable) throws SQLException
+```
+
+```java
+public boolean isPoolable() throws SQLException
+```
+
+#### `org/sqlite/util/LibraryLoaderUtil.java`
+
+```java
+public class LibraryLoaderUtil
+```
+
+```java
+public static final String NATIVE_LIB_BASE_NAME = ...
+```
+
+> Get the OS-specific resource directory within the jar, where the relevant sqlitejdbc native
+> library is located.
+
+```java
+public static String getNativeLibResourcePath()
+```
+
+> Get the OS-specific name of the sqlitejdbc native library.
+
+```java
+public static String getNativeLibName()
+```
+
+```java
+public static boolean hasNativeLib(String path, String libraryName)
+```
+
+#### `org/sqlite/util/OSInfo.java`
+
+> Provides OS name and architecture name.
+>
+> @author leo
+
+```java
+public class OSInfo
+```
+
+```java
+public static final String X86 = ...
+```
+
+```java
+public static final String X86_64 = ...
+```
+
+```java
+public static final String IA64_32 = ...
+```
+
+```java
+public static final String IA64 = ...
+```
+
+```java
+public static final String PPC = ...
+```
+
+```java
+public static final String PPC64 = ...
+```
+
+```java
+public static final String RISCV64 = ...
+```
+
+```java
+public static void main(String[] args)
+```
+
+```java
+public static String getNativeLibFolderPathForCurrentOS()
+```
+
+```java
+public static String getOSName()
+```
+
+```java
+public static boolean isAndroid()
+```
+
+```java
+public static boolean isAndroidRuntime()
+```
+
+```java
+public static boolean isAndroidTermux()
+```
+
+```java
+public static boolean isMusl()
+```
+
+```java
+static String getHardwareName()
+```
+
+```java
+static String resolveArmArchType()
+```
+
+```java
+public static String getArchName()
+```
+
+```java
+static String translateOSNameToFolderName(String osName)
+```
+
+```java
+static String translateArchNameToFolderName(String archName)
+```
+
+#### `org/sqlite/util/ProcessRunner.java`
+
+```java
+public class ProcessRunner
+```
+
+```java
+static String getProcessOutput(Process process) throws IOException
+```
+
+#### `org/sqlite/util/QueryUtils.java`
+
+```java
+public class QueryUtils
+```
+
+> Build a SQLite query using the VALUES clause to return arbitrary values.
+>
+> @param columns list of column names
+> @param valuesList values to return as rows
+> @return SQL query as string
+
+```java
+public static String valuesQuery(List<String> columns, List<List<Object>> valuesList)
+```
+
+#### `org/sqlite/util/ResourceFinder.java`
+
+> Resource address finder for files inside the jar file
+>
+> @author leo
+
+```java
+public class ResourceFinder
+```
+
+> Gets the {@link URL} of the file resource
+>
+> @param referenceClass the base class for finding resources files. This method will search the
+> package containing the given referenceClass.
+> @param resourceFileName the resource file name relative to the package of the referenceClass
+> @return the URL of the file resource
+
+```java
+public static URL find(Class<?> referenceClass, String resourceFileName)
+```
+
+> Finds the {@link URL} of the resource
+>
+> @param basePackage the base package to find the resource
+> @param resourceFileName the resource file name relative to the package folder
+> @return the URL of the specified resource
+
+```java
+public static URL find(ClassLoader classLoader, Package basePackage, String resourceFileName)
+```
+
+> Finds the {@link URL} of the resource
+>
+> @param packageName the base package name to find the resource
+> @param resourceFileName the resource file name relative to the package folder
+> @return the URL of the specified resource
+
+```java
+public static URL find(ClassLoader classLoader, String packageName, String resourceFileName)
+```
+
+#### `org/sqlite/util/StringUtils.java`
+
+```java
+public class StringUtils
+```
+
+```java
+public static String join(List<String> list, String separator)
+```
+

--- a/docs/upickle-3.3.1.md
+++ b/docs/upickle-3.3.1.md
@@ -1,0 +1,6377 @@
+# uPickle 3.3.1 API Reference
+Generated from Maven Central `*-sources.jar` artifacts for the dependency selected in `build.mill`. Adjacent upstream Scaladoc/Javadoc comments are copied when present; implementation bodies are intentionally omitted.
+
+Summary: extracted `1220` non-private declaration signatures from `70` source files.
+
+## Coordinates
+- Direct dependency: `com.lihaoyi::upickle:3.3.1`
+- Upstream docs: https://com-lihaoyi.github.io/upickle/
+- Source artifacts included:
+  - `com.lihaoyi:upickle_3:3.3.1`
+  - `com.lihaoyi:upickle-core_3:3.3.1`
+  - `com.lihaoyi:upickle-implicits_3:3.3.1`
+  - `com.lihaoyi:ujson_3:3.3.1`
+  - `com.lihaoyi:upack_3:3.3.1`
+
+## Common imports
+
+```scala
+import upickle.default.{ReadWriter, macroRW, read, write, readwriter}
+```
+
+## Usage notes
+
+JSON / MessagePack read-write library. This doc includes the direct `upickle` façade plus common transitive API modules that define `Reader`, `Writer`, `ReadWriter`, macros, `ujson`, and `upack` values.
+
+```scala
+import upickle.default.{ReadWriter, macroRW, read, write}
+
+case class LockedFile(mavenPath: String, sha256: String, size: Long)
+object LockedFile:
+  given ReadWriter[LockedFile] = macroRW
+
+val json = write(LockedFile("com/example/app/1.0.0/app.pom", "sha256-...", 123), indent = 2)
+val file = read[LockedFile](json)
+```
+
+## API signatures from upstream source
+
+### `com.lihaoyi:upickle_3:3.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/upickle_3/3.3.1/upickle_3-3.3.1-sources.jar
+
+#### `upickle/Api.scala`
+
+> An instance of the upickle API. There's a default instance at
+> `upickle.default`, but you can also implement it yourself to customize
+> its behavior. Override the `annotate` methods to control how a sealed
+> trait instance is tagged during reading and writing.
+
+```scala
+trait Api
+    extends upickle.core.Types
+    with implicits.Readers
+    with implicits.Writers
+    with implicits.CaseClassReadWriters
+    with WebJson
+    with JsReadWriters
+    with MsgReadWriters
+    with Annotator
+```
+
+> Reads the given MessagePack input into a Scala value
+
+```scala
+def readBinary[T: Reader](s: upack.Readable, trace: Boolean = false): T = ...
+```
+
+> Reads the given JSON input into a Scala value
+
+```scala
+def read[T: Reader](s: ujson.Readable, trace: Boolean = false): T = ...
+```
+
+```scala
+def reader[T: Reader] = ...
+```
+
+> Write the given Scala value as a JSON string
+
+```scala
+def write[T: Writer](t: T,
+                       indent: Int = -1,
+                       escapeUnicode: Boolean = false,
+                       sortKeys: Boolean = false): String = ...
+```
+
+```scala
+def write[T: Writer](t: T,
+                       indent: Int,
+                       escapeUnicode: Boolean): String = ...
+```
+
+> Write the given Scala value as a MessagePack binary
+
+```scala
+def writeBinary[T: Writer](t: T,
+                             sortKeys: Boolean = false): Array[Byte] = ...
+```
+
+```scala
+def writeBinary[T: Writer](t: T): Array[Byte] = ...
+```
+
+> Write the given Scala value as a JSON struct
+
+```scala
+def writeJs[T: Writer](t: T): ujson.Value = ...
+```
+
+> Write the given Scala value as a MessagePack struct
+
+```scala
+def writeMsg[T: Writer](t: T): upack.Msg = ...
+```
+
+> Write the given Scala value as a JSON string to the given Writer
+
+```scala
+def writeTo[T: Writer](t: T,
+                         out: java.io.Writer,
+                         indent: Int = -1,
+                         escapeUnicode: Boolean = false,
+                         sortKeys: Boolean = false): Unit = ...
+```
+
+```scala
+def writeTo[T: Writer](t: T,
+                         out: java.io.Writer,
+                         indent: Int,
+                         escapeUnicode: Boolean): Unit = ...
+```
+
+```scala
+def writeToOutputStream[T: Writer](t: T,
+                                     out: java.io.OutputStream,
+                                     indent: Int = -1,
+                                     escapeUnicode: Boolean = false,
+                                     sortKeys: Boolean = false): Unit = ...
+```
+
+```scala
+def writeToOutputStream[T: Writer](t: T,
+                                     out: java.io.OutputStream,
+                                     indent: Int,
+                                     escapeUnicode: Boolean): Unit = ...
+```
+
+```scala
+def writeToByteArray[T: Writer](t: T,
+                                  indent: Int = -1,
+                                  escapeUnicode: Boolean = false,
+                                  sortKeys: Boolean = false): Array[Byte] = ...
+```
+
+```scala
+def writeToByteArray[T: Writer](t: T,
+                                  indent: Int,
+                                  escapeUnicode: Boolean): Array[Byte] = ...
+```
+
+> Write the given Scala value as a JSON string via a `geny.Writable`
+
+```scala
+def stream[T: Writer](t: T,
+                        indent: Int = -1,
+                        escapeUnicode: Boolean = false,
+                        sortKeys: Boolean = false): geny.Writable = ...
+```
+
+```scala
+def stream[T: Writer](t: T,
+                        indent: Int,
+                        escapeUnicode: Boolean): geny.Writable = ...
+```
+
+> Write the given Scala value as a MessagePack binary to the given OutputStream
+
+```scala
+def writeBinaryTo[T: Writer](t: T,
+                               out: java.io.OutputStream,
+                               sortKeys: Boolean = false): Unit = ...
+```
+
+```scala
+def writeBinaryTo[T: Writer](t: T,
+                               out: java.io.OutputStream): Unit = ...
+```
+
+```scala
+def writeBinaryToByteArray[T: Writer](t: T,
+                                        sortKeys: Boolean = false): Array[Byte] = ...
+```
+
+```scala
+def writeBinaryToByteArray[T: Writer](t: T): Array[Byte] = ...
+```
+
+> Write the given Scala value as a MessagePack binary via a `geny.Writable`
+
+```scala
+def streamBinary[T: Writer](t: T, sortKeys: Boolean = false): geny.Writable = ...
+```
+
+```scala
+def streamBinary[T: Writer](t: T): geny.Writable = ...
+```
+
+```scala
+def writer[T: Writer] = ...
+```
+
+```scala
+def readwriter[T: ReadWriter] = ...
+```
+
+```scala
+case class transform[T: Writer](t: T) extends upack.Readable with ujson.Readable
+```
+
+```scala
+def transform[V](f: Visitor[_, V]): V = ...
+```
+
+```scala
+def to[V](f: Visitor[_, V]): V = ...
+```
+
+```scala
+def to[V](implicit f: Reader[V]): V = ...
+```
+
+> Mark a `ReadWriter[T]` as something that can be used as a key in a JSON
+> dictionary, such that `Map[T, V]` serializes to `{"a": "b", "c": "d"}`
+> rather than `[["a", "b"], ["c", "d"]]`
+
+```scala
+def stringKeyRW[T](readwriter: ReadWriter[T]): ReadWriter[T] = ...
+```
+
+> Mark a `Writer[T]` as something that can be used as a key in a JSON
+> dictionary, such that `Map[T, V]` serializes to `{"a": "b", "c": "d"}`
+> rather than `[["a", "b"], ["c", "d"]]`
+
+```scala
+def stringKeyW[T](readwriter: Writer[T]): Writer[T] = ...
+```
+
+> Configure whether you want upickle to skip unknown keys during de-serialization
+> of `case class`es. Can be overriden for the entire serializer via `override def`, and
+> further overriden for individual `case class`es via the annotation
+> `@upickle.implicits.allowUnknownKeys(b: Boolean)`
+
+```scala
+override def allowUnknownKeys: Boolean = ...
+```
+
+> The default way of accessing upickle
+
+```scala
+object default extends AttributeTagged
+```
+
+> An instance of the upickle API that follows the old serialization for
+> tagged instances of sealed traits: as a list with two items, the first
+> being the type-tag and the second being the serialized object
+
+```scala
+object legacy extends LegacyApi
+```
+
+```scala
+trait LegacyApi extends Api with Annotator
+```
+
+```scala
+override def annotate[V](rw: Reader[V], key: String, value: String) = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+override final def annotate[V](rw: Reader[V], n: String) = ...
+```
+
+```scala
+override def annotate[V](rw: ObjectWriter[V], key: String, value: String, checker: Annotator.Checker): TaggedWriter[V] = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+override final def annotate[V](rw: ObjectWriter[V], n: String, checker: Annotator.Checker): TaggedWriter[V] = ...
+```
+
+```scala
+def taggedExpectedMsg = ...
+```
+
+```scala
+sealed trait TaggedReaderState
+```
+
+```scala
+object TaggedReaderState
+```
+
+```scala
+case object Initializing extends TaggedReaderState
+```
+
+```scala
+case class Parsing(f: Reader[_]) extends TaggedReaderState
+```
+
+```scala
+case class Parsed(res: Any) extends TaggedReaderState
+```
+
+```scala
+override def taggedArrayContext[T](taggedReader: TaggedReader[T], index: Int) = ...
+```
+
+```scala
+override def taggedWrite[T, R](w: ObjectWriter[T], tagKey: String, tagValue: String, out: Visitor[_,  R], v: T): R = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+final def taggedWrite[T, R](w: ObjectWriter[T], tag: String, out: Visitor[_,  R], v: T): R = ...
+```
+
+> A `upickle.Api` that follows the default sealed-trait-instance-tagging
+> behavior of using an attribute, but allow you to control what the name
+> of the attribute is.
+
+```scala
+trait AttributeTagged extends Api with Annotator
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+def tagName = ...
+```
+
+```scala
+override def annotate[V](rw: Reader[V], key: String, value: String) = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+override final def annotate[V](rw: Reader[V], n: String) = ...
+```
+
+```scala
+override def annotate[V](rw: ObjectWriter[V], key: String, value: String, checker: Annotator.Checker): TaggedWriter[V] = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+override final def annotate[V](rw: ObjectWriter[V], n: String, checker: Annotator.Checker): TaggedWriter[V] = ...
+```
+
+```scala
+def taggedExpectedMsg = ...
+```
+
+```scala
+override def taggedObjectContext[T](taggedReader: TaggedReader[T], index: Int) = ...
+```
+
+```scala
+override def taggedWrite[T, R](w: ObjectWriter[T], tagKey: String, tagValue: String, out: Visitor[_,  R], v: T): R = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+final def taggedWrite[T, R](w: ObjectWriter[T], tag: String, out: Visitor[_,  R], v: T): R = ...
+```
+
+#### `upickle/JsReadWriters.scala`
+
+```scala
+trait JsReadWriters extends upickle.core.Types with MacroImplicits with LowPriReadWriters
+```
+
+```scala
+implicit def JsObjR: Reader[ujson.Obj] = ...
+```
+
+```scala
+implicit def JsArrR: Reader[ujson.Arr] = ...
+```
+
+```scala
+implicit def JsStrR: Reader[ujson.Str] = ...
+```
+
+```scala
+implicit def JsNumR: Reader[ujson.Num] = ...
+```
+
+```scala
+implicit def JsBoolR: Reader[ujson.Bool] = ...
+```
+
+```scala
+implicit def JsTrueR: Reader[ujson.True.type] = ...
+```
+
+```scala
+implicit def JsFalseR: Reader[ujson.False.type] = ...
+```
+
+```scala
+implicit def JsNullR: Reader[ujson.Null.type] = ...
+```
+
+```scala
+implicit def JsObjW: Writer[ujson.Obj] = ...
+```
+
+```scala
+implicit def JsArrW: Writer[ujson.Arr] = ...
+```
+
+```scala
+implicit def JsStrW: Writer[ujson.Str] = ...
+```
+
+```scala
+implicit def JsNumW: Writer[ujson.Num] = ...
+```
+
+```scala
+implicit def JsBoolW: Writer[ujson.Bool] = ...
+```
+
+```scala
+implicit def JsTrueW: Writer[ujson.True.type] = ...
+```
+
+```scala
+implicit def JsFalseW: Writer[ujson.False.type] = ...
+```
+
+```scala
+implicit def JsNullW: Writer[ujson.Null.type] = ...
+```
+
+```scala
+trait LowPriReadWriters
+```
+
+```scala
+implicit def JsValueR: Reader[ujson.Value] = ...
+```
+
+```scala
+implicit def JsValueW: Writer[ujson.Value] = ...
+```
+
+#### `upickle/MsgReadWriters.scala`
+
+```scala
+trait MsgReadWriters extends upickle.core.Types with MacroImplicits
+```
+
+```scala
+implicit val MsgValueR: Reader[upack.Msg] = ...
+```
+
+```scala
+implicit val MsgValueW: Writer[upack.Msg] = ...
+```
+
+#### `upickle/WebJson.scala`
+
+```scala
+trait WebJson extends upickle.core.Types
+```
+
+### `com.lihaoyi:upickle-core_3:3.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/upickle-core_3/3.3.1/upickle-core_3-3.3.1-sources.jar
+
+#### `BufferingByteParser.scala`
+
+> Models a growable [[buffer]] of Bytes, which are Chars or Bytes. We maintain
+> an Array[Byte] as a buffer, and read Bytes into it using [[readDataIntoBuffer]]
+> and drop old Bytes using [[dropBufferUntil]].
+>
+> In general, [[BufferingByteParser]] allows us to keep the fast path fast:
+>
+> - Reading byte-by-byte from the buffer is a bounds check and direct Array
+> access, without any indirection or polymorphism.
+> - We load Bytes in batches into the buffer, which allows us to take advantage
+> of batching APIs like `InputStream.read`
+> - We amortize the overhead of the indirect/polymorphic [[readDataIntoBuffer]]
+> call over the size of each batch
+>
+> Note that [[dropBufferUntil]] only advances a [[dropped]] index and does not
+> actually zero out the dropped Bytes; instead, we wait until we need to call
+> [[growBuffer]], and use that as a chance to copy the remaining un-dropped Bytes
+> to either the start of the current [[buffer]] or the start of a newly-allocated
+> bigger [[buffer]] (if necessary)
+
+```scala
+trait BufferingByteParser
+```
+
+```scala
+def getBuffer = ...
+```
+
+```scala
+def getFirstIdx = ...
+```
+
+```scala
+def getBufferGrowCount() = ...
+```
+
+```scala
+def getBufferCopyCount() = ...
+```
+
+```scala
+def getBufferLength() = ...
+```
+
+```scala
+def getLastIdx = ...
+```
+
+```scala
+def getByteSafe(i: Int): Byte = ...
+```
+
+```scala
+def getByteUnsafe(i: Int): Byte = ...
+```
+
+```scala
+def sliceString(i: Int, k: Int): String = ...
+```
+
+```scala
+def sliceArr(i: Int, n: Int): (Array[Byte], Int, Int) = ...
+```
+
+> Copies the non-dropped Bytes in the current [[buffer]] to the start of either
+> the current [[buffer]], or a newly-allocated larger [[buffer]] if necessary.
+
+```scala
+def growBuffer(until: Int) = ...
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int): (Array[Byte], Boolean, Int)
+```
+
+```scala
+def dropBufferUntil(i: Int): Unit = ...
+```
+
+```scala
+def unsafeCharSeqForRange(start: Int, length: Int) = ...
+```
+
+```scala
+def appendBytesToBuilder(bytes: ByteBuilder, bytesStart: Int, bytesLength: Int) = ...
+```
+
+#### `BufferingCharParser.scala`
+
+> Models a growable [[buffer]] of Chars, which are Chars or Bytes. We maintain
+> an Array[Char] as a buffer, and read Chars into it using [[readDataIntoBuffer]]
+> and drop old Chars using [[dropBufferUntil]].
+>
+> In general, [[BufferingCharParser]] allows us to keep the fast path fast:
+>
+> - Reading char-by-char from the buffer is a bounds check and direct Array
+> access, without any indirection or polymorphism.
+> - We load Chars in batches into the buffer, which allows us to take advantage
+> of batching APIs like `InputStream.read`
+> - We amortize the overhead of the indirect/polymorphic [[readDataIntoBuffer]]
+> call over the size of each batch
+>
+> Note that [[dropBufferUntil]] only advances a [[dropped]] index and does not
+> actually zero out the dropped Chars; instead, we wait until we need to call
+> [[growBuffer]], and use that as a chance to copy the remaining un-dropped Chars
+> to either the start of the current [[buffer]] or the start of a newly-allocated
+> bigger [[buffer]] (if necessary)
+
+```scala
+trait BufferingCharParser
+```
+
+```scala
+def getBuffer = ...
+```
+
+```scala
+def getFirstIdx = ...
+```
+
+```scala
+def getBufferGrowCount() = ...
+```
+
+```scala
+def getBufferCopyCount() = ...
+```
+
+```scala
+def getBufferLength() = ...
+```
+
+```scala
+def getLastIdx = ...
+```
+
+```scala
+def getCharSafe(i: Int): Char = ...
+```
+
+```scala
+def getCharUnsafe(i: Int): Char = ...
+```
+
+```scala
+def sliceString(i: Int, k: Int): String = ...
+```
+
+```scala
+def sliceArr(i: Int, n: Int): (Array[Char], Int, Int) = ...
+```
+
+> Copies the non-dropped Chars in the current [[buffer]] to the start of either
+> the current [[buffer]], or a newly-allocated larger [[buffer]] if necessary.
+
+```scala
+def growBuffer(until: Int) = ...
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Char], bufferOffset: Int): (Array[Char], Boolean, Int)
+```
+
+```scala
+def dropBufferUntil(i: Int): Unit = ...
+```
+
+```scala
+def unsafeCharSeqForRange(start: Int, length: Int) = ...
+```
+
+```scala
+def appendCharsToBuilder(chars: CharBuilder, charsStart: Int, charsLength: Int) = ...
+```
+
+#### `ByteBuilder.scala`
+
+> A fast buffer that can be used to store Bytes (Bytes or Chars).
+>
+> Generally faster than the equivalent [[StringBuilder]] or
+> [[java.io.ByteArrayOutputStream]], since:
+>
+> - It is specialized and without the overhead of polymorphism or synchronization.
+> - It allows the user to call `ensureLength` and `appendUnsafe` separately, e.g.
+> callign `ensureLength` once before `appendUnsafe`-ing multiple Bytes
+> - It provides fast methods like [[makeString]] or [[writeOutToIfLongerThan]], that
+> let you push the data elsewhere with minimal unnecessary copying
+
+```scala
+class ByteBuilder(startSize: Int = 32) extends upickle.core.ByteAppendC
+```
+
+```scala
+var arr: Array[Byte] = ...
+```
+
+```scala
+var length: Int = ...
+```
+
+```scala
+def getLength = ...
+```
+
+```scala
+def reset(): Unit = ...
+```
+
+```scala
+def ensureLength(increment: Int): Unit = ...
+```
+
+```scala
+def append(x: Int): Unit = ...
+```
+
+```scala
+def append(x: Byte): Unit = ...
+```
+
+```scala
+def appendAll(bytes: Array[Byte], bytesLength: Int): Unit = ...
+```
+
+```scala
+def appendAll(bytes: Array[Byte], bytesStart: Int, bytesLength: Int): Unit = ...
+```
+
+```scala
+def appendAllUnsafe(other: ByteBuilder): Unit = ...
+```
+
+```scala
+def appendUnsafeC(x: Char): Unit = ...
+```
+
+```scala
+def appendUnsafe(x: Byte): Unit = ...
+```
+
+```scala
+def makeString(): String = ...
+```
+
+```scala
+def writeOutToIfLongerThan(writer: upickle.core.ByteOps.Output, threshold: Int): Unit = ...
+```
+
+#### `ByteUtils.scala`
+
+```scala
+object ByteUtils
+```
+
+```scala
+def appendEscapedByte(byteBuilder: ByteBuilder, c: Char, i: Int): Boolean = ...
+```
+
+```scala
+def escapeSingleByte(byteBuilder: ByteBuilder, i: Int, c: Char) = ...
+```
+
+```scala
+def escapeSingleByteUnicodeEscape(byteBuilder: ByteBuilder, i: Int, c: Char) = ...
+```
+
+```scala
+def appendSimpleStringSection(byteBuilder: ByteBuilder,
+                               i0: Int,
+                               len: Int,
+                               s: CharSequence) = ...
+```
+
+```scala
+def appendSimpleStringSectionNoUnicode(byteBuilder: ByteBuilder,
+                                        i0: Int,
+                                        len: Int,
+                                        s: CharSequence) = ...
+```
+
+```scala
+def parseIntegralNum(arr: Array[Byte], arrOffset: Int, arrLength: Int, decIndex: Int, expIndex: Int) = ...
+```
+
+```scala
+def parseLong(cs0: Array[Byte], start0: Int, end0: Int): Long = ...
+```
+
+#### `CharBuilder.scala`
+
+> A fast buffer that can be used to store Chars (Bytes or Chars).
+>
+> Generally faster than the equivalent [[StringBuilder]] or
+> [[java.io.ByteArrayOutputStream]], since:
+>
+> - It is specialized and without the overhead of polymorphism or synchronization.
+> - It allows the user to call `ensureLength` and `appendUnsafe` separately, e.g.
+> callign `ensureLength` once before `appendUnsafe`-ing multiple Chars
+> - It provides fast methods like [[makeString]] or [[writeOutToIfLongerThan]], that
+> let you push the data elsewhere with minimal unnecessary copying
+
+```scala
+class CharBuilder(startSize: Int = 32) extends upickle.core.CharAppendC
+```
+
+```scala
+var arr: Array[Char] = ...
+```
+
+```scala
+var length: Int = ...
+```
+
+```scala
+def getLength = ...
+```
+
+```scala
+def reset(): Unit = ...
+```
+
+```scala
+def ensureLength(increment: Int): Unit = ...
+```
+
+```scala
+def append(x: Int): Unit = ...
+```
+
+```scala
+def append(x: Char): Unit = ...
+```
+
+```scala
+def appendAll(chars: Array[Char], charsLength: Int): Unit = ...
+```
+
+```scala
+def appendAll(chars: Array[Char], charsStart: Int, charsLength: Int): Unit = ...
+```
+
+```scala
+def appendAllUnsafe(other: CharBuilder): Unit = ...
+```
+
+```scala
+def appendUnsafeC(x: Char): Unit = ...
+```
+
+```scala
+def appendUnsafe(x: Char): Unit = ...
+```
+
+```scala
+def makeString(): String = ...
+```
+
+```scala
+def writeOutToIfLongerThan(writer: upickle.core.CharOps.Output, threshold: Int): Unit = ...
+```
+
+#### `CharUtils.scala`
+
+```scala
+object CharUtils
+```
+
+```scala
+def appendEscapedChar(charBuilder: CharBuilder, c: Char, i: Int): Boolean = ...
+```
+
+```scala
+def escapeSingleChar(charBuilder: CharBuilder, i: Int, c: Char) = ...
+```
+
+```scala
+def escapeSingleCharUnicodeEscape(charBuilder: CharBuilder, i: Int, c: Char) = ...
+```
+
+```scala
+def appendSimpleStringSection(charBuilder: CharBuilder,
+                               i0: Int,
+                               len: Int,
+                               s: CharSequence) = ...
+```
+
+```scala
+def appendSimpleStringSectionNoUnicode(charBuilder: CharBuilder,
+                                        i0: Int,
+                                        len: Int,
+                                        s: CharSequence) = ...
+```
+
+```scala
+def parseIntegralNum(arr: Array[Char], arrOffset: Int, arrLength: Int, decIndex: Int, expIndex: Int) = ...
+```
+
+```scala
+def parseLong(cs0: Array[Char], start0: Int, end0: Int): Long = ...
+```
+
+#### `WrapByteArrayCharSeq.scala`
+
+> A [[CharSequence]] that wraps an array of byteents without any copying.
+>
+> Note that the [[arr]] is mutable, and so the [[WrapByteArrayCharSeq]]
+> should not itself be stored: either use it immediately when given it
+> or call `.toString` if you want to store the data for later use.
+
+```scala
+class WrapByteArrayCharSeq(arr: Array[Byte], start: Int, length0: Int) extends CharSequence
+```
+
+#### `WrapCharArrayCharSeq.scala`
+
+> A [[CharSequence]] that wraps an array of charents without any copying.
+>
+> Note that the [[arr]] is mutable, and so the [[WrapCharArrayCharSeq]]
+> should not itself be stored: either use it immediately when given it
+> or call `.toString` if you want to store the data for later use.
+
+```scala
+class WrapCharArrayCharSeq(arr: Array[Char], start: Int, length0: Int) extends CharSequence
+```
+
+#### `upickle/core/BufferedValue.scala`
+
+> A reified version of [[Visitor]], allowing visitor method calls to be buffered up,
+> stored somewhere, and replayed later.
+
+```scala
+sealed trait BufferedValue
+```
+
+```scala
+def index: Int
+```
+
+```scala
+object BufferedValue extends Transformer[BufferedValue]
+```
+
+```scala
+def valueToSortKey(b: BufferedValue): String = ...
+```
+
+```scala
+def maybeSortKeysTransform[T, V](tr: Transformer[T],
+                                   t: T,
+                                   sortKeys: Boolean,
+                                   f: Visitor[_, V]): V = ...
+```
+
+```scala
+case class Str(value0: java.lang.CharSequence, index: Int) extends BufferedValue
+```
+
+```scala
+case class Obj(value0: mutable.ArrayBuffer[(BufferedValue, BufferedValue)], jsonableKeys: Boolean, index: Int) extends BufferedValue
+```
+
+```scala
+case class Arr(value: mutable.ArrayBuffer[BufferedValue], index: Int) extends BufferedValue
+```
+
+```scala
+case class Num(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) extends BufferedValue
+```
+
+```scala
+case class NumRaw(d: Double, index: Int) extends BufferedValue
+```
+
+```scala
+case class False(index: Int) extends BufferedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class True(index: Int) extends BufferedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class Null(index: Int) extends BufferedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class Binary(bytes: Array[Byte], offset: Int, len: Int, index: Int) extends BufferedValue
+```
+
+```scala
+case class Char(s: scala.Char, index: Int) extends BufferedValue
+```
+
+```scala
+case class Ext(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) extends BufferedValue
+```
+
+```scala
+case class Float32(d: Float, index: Int) extends BufferedValue
+```
+
+```scala
+case class Float64String(s: String, index: Int) extends BufferedValue
+```
+
+```scala
+case class Int32(i: Int, index: Int) extends BufferedValue
+```
+
+```scala
+case class Int64(i: Long, index: Int) extends BufferedValue
+```
+
+```scala
+case class UInt64(i: Long, index: Int) extends BufferedValue
+```
+
+```scala
+def transform[T](j: BufferedValue, f: Visitor[_, T]): T = ...
+```
+
+```scala
+object Builder extends Visitor[BufferedValue, BufferedValue]
+```
+
+```scala
+def visitArray(length: Int, i: Int) = ...
+```
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, i: Int) = ...
+```
+
+```scala
+def visitNull(i: Int) = ...
+```
+
+```scala
+def visitFalse(i: Int) = ...
+```
+
+```scala
+def visitTrue(i: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, i: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, i: Int) = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitChar(s: scala.Char, index: Int) = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+def visitFloat64String(s: String, index: Int) = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int) = ...
+```
+
+#### `upickle/core/BufferingInputStreamParser.scala`
+
+> Defines common functionality to any parser that works on a `java.io.InputStream`
+>
+> Allows you to look up individual bytes by index, take slices of byte ranges or
+> strings, and drop old portions of buffered data once you are certain you no
+> longer need them.
+>
+> The `buffer` size is managed by allowing it to grow in size until it exceeds its
+> capacity. When that happens, one of two things happen:
+>
+> - If the buffer has enough space, we left-shift the data in the
+> buffer to over-write the portion that has already been dropped.
+>
+> - If the buffer does not have enough space, we allocate a new buffer big
+> enough to hold the new data we need to store (size a power of two multiple of
+> the old size) and copy the data over, again shifted left
+> .
+
+```scala
+trait BufferingInputStreamParser extends BufferingByteParser
+```
+
+```scala
+def inputStream: java.io.InputStream
+```
+
+```scala
+def minBufferStartSize: Int
+```
+
+```scala
+def maxBufferStartSize: Int
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int) = ...
+```
+
+```scala
+object BufferingInputStreamParser
+```
+
+```scala
+val defaultMaxBufferStartSize: Int = ...
+```
+
+```scala
+val defaultMinBufferStartSize: Int = ...
+```
+
+#### `upickle/core/ElemAppendC.scala`
+
+```scala
+abstract class CharAppendC
+```
+
+```scala
+def append(x: Char): Unit
+```
+
+```scala
+def appendC(x: Char): Unit = ...
+```
+
+```scala
+abstract class ByteAppendC
+```
+
+```scala
+def append(x: Byte): Unit
+```
+
+```scala
+def appendC(x: Char): Unit = ...
+```
+
+```scala
+def convertSurrogate(firstPart: Int, secondPart: Int) = ...
+```
+
+#### `upickle/core/ElemOps.scala`
+
+```scala
+object CharOps
+```
+
+```scala
+def toInt(c: Char) = ...
+```
+
+```scala
+def toUnsignedInt(c: Char) = ...
+```
+
+```scala
+def lessThan(c1: Char, c2: Char) = ...
+```
+
+```scala
+def within(c1: Char, c2: Char, c3: Char) = ...
+```
+
+```scala
+type Output = ...
+```
+
+```scala
+def newString(arr: Array[Char], i: Int, length: Int) = ...
+```
+
+```scala
+object ByteOps
+```
+
+```scala
+def toInt(c: Byte) = ...
+```
+
+```scala
+def toUnsignedInt(c: Byte) = ...
+```
+
+```scala
+def lessThan(c1: Byte, c2: Char) = ...
+```
+
+```scala
+def within(c1: Char, c2: Byte, c3: Char) = ...
+```
+
+```scala
+type Output = ...
+```
+
+```scala
+def newString(arr: Array[Byte], i: Int, length: Int) = ...
+```
+
+#### `upickle/core/LinkedHashMap.scala`
+
+```scala
+object LinkedHashMap
+```
+
+```scala
+def apply[K, V](): LinkedHashMap[K, V] = ...
+```
+
+```scala
+def apply[K, V](items: IterableOnce[(K, V)]): LinkedHashMap[K, V] = ...
+```
+
+```scala
+implicit def factory[K, V]: Factory[(K, V), LinkedHashMap[K, V]] = ...
+```
+
+#### `upickle/core/LogVisitor.scala`
+
+> A visitor that wraps another but prints out what methods get called,
+> useful for debugging
+
+```scala
+class LogVisitor[-T, +V](downstream: Visitor[T, V], log: String => Unit = println, indent: String = "    ") extends Visitor[T, V]
+```
+
+```scala
+def visitNull(index: Int): V = ...
+```
+
+```scala
+def visitTrue(index: Int): V = ...
+```
+
+```scala
+def visitFalse(index: Int): V = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int): V = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): V = ...
+```
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, index: Int): ObjVisitor[T, V] = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int): ArrVisitor[T, V] = ...
+```
+
+```scala
+def visitFloat64(d: Double, index: Int): V = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int): V = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int): V = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int): V = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int): V = ...
+```
+
+```scala
+def visitFloat64String(s: String, index: Int): V = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int): V = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int): V = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int): V = ...
+```
+
+#### `upickle/core/NoOpVisitor.scala`
+
+> NullFacade discards all JSON AST information.
+>
+> This is the simplest possible facade. It could be useful for
+> checking JSON for correctness (via parsing) without worrying about
+> saving the data.
+>
+> It will always return () on any successful parse, no matter the
+> content.
+
+```scala
+object NoOpVisitor extends Visitor[Unit, Unit]
+```
+
+```scala
+def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+def visitNull(index: Int): Unit = ...
+```
+
+```scala
+def visitFalse(index: Int): Unit = ...
+```
+
+```scala
+def visitTrue(index: Int): Unit = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Unit = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int): Unit = ...
+```
+
+```scala
+def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+def visitInt8(i: Byte, index: Int) = ...
+```
+
+```scala
+def visitUInt8(i: Byte, index: Int) = ...
+```
+
+```scala
+def visitInt16(i: Short, index: Int) = ...
+```
+
+```scala
+def visitUInt16(i: Short, index: Int) = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+def visitUInt32(i: Int, index: Int) = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitFloat64String(s: String, index: Int) = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int) = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int) = ...
+```
+
+#### `upickle/core/ParseUtils.scala`
+
+```scala
+object ParseUtils
+```
+
+```scala
+val hexes = ...
+```
+
+```scala
+def bytesToString(bs: Array[Byte]) = ...
+```
+
+```scala
+def stringToBytes(s: String) = ...
+```
+
+```scala
+def parseIntegralNum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+def parseLong(cs: CharSequence, start: Int, end: Int): Long = ...
+```
+
+```scala
+def reject(j: Int): PartialFunction[Throwable, Nothing] = ...
+```
+
+#### `upickle/core/RenderUtils.scala`
+
+```scala
+object RenderUtils
+```
+
+```scala
+final val hexChars: Array[Int] = ...
+```
+
+```scala
+def hex(i: Int): Int = ...
+```
+
+```scala
+def toHex(nibble: Int): Char = ...
+```
+
+> Attempts to write the given [[CharSequence]] into the given [[ByteBuilder]].
+>
+> Optimistically treats the characters as ASCII characters, which can be
+> directly converted to bytes and written. Only if we encounter a unicode
+> character do we fall back to the slow path of constructing a
+> [[java.lang.String]] which we UTF-8 encode before adding the to output.
+
+```scala
+final def escapeByte(unicodeCharBuilder: upickle.core.CharBuilder,
+                       sb: upickle.core.ByteBuilder,
+                       s: CharSequence,
+                       escapeUnicode: Boolean,
+                       wrapQuotes: Boolean): Unit = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def escapeSingleByteUnicodeRaw(unicodeCharBuilder: CharBuilder,
+                                 sb: ByteBuilder,
+                                 s: CharSequence,
+                                 escapeUnicode: Boolean,
+                                 i0: Int,
+                                 len0: Int,
+                                 naiveOutLen: Int,
+                                 wrapQuotes: Boolean): Unit = ...
+```
+
+```scala
+def escapeSingleByteUnicodeRaw(unicodeCharBuilder: CharBuilder,
+                                 sb: ByteBuilder,
+                                 s: CharSequence,
+                                 escapeUnicode: Boolean,
+                                 i0: Int,
+                                 len0: Int,
+                                 wrapQuotes: Boolean): Unit = ...
+```
+
+```scala
+def escapeChar(unicodeCharBuilder: upickle.core.CharBuilder,
+                 sb: upickle.core.CharBuilder,
+                 s: CharSequence,
+                 escapeUnicode: Boolean,
+                 wrapQuotes: Boolean) = ...
+```
+
+```scala
+final def escapeChar0(i0: Int,
+                        len: Int,
+                        sb: upickle.core.CharBuilder,
+                        s: CharSequence,
+                        escapeUnicode: Boolean,
+                        wrapQuotes: Boolean): upickle.core.CharBuilder = ...
+```
+
+```scala
+def intStringSize(x0: Int): Int = ...
+```
+
+```scala
+def longStringSize(x0: Long): Int = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def escapeSingleChar(sb: upickle.core.CharBuilder,
+                       naiveOutLen: Int,
+                       i: Int,
+                       c: Char) = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def escapeSingleByte(sb: upickle.core.ByteBuilder,
+                       naiveOutLen: Int,
+                       i: Int,
+                       c: Char) = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def escapeSingleCharUnicodeEscape(naiveOutLen: Int, sb: CharBuilder, i: Int, c: Char) = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def escapeSingleByteUnicodeEscape(sb: ByteBuilder, i: Int, naiveOutLen: Int, c: Char) = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+final def escapeChar0(i0: Int,
+                        naiveOutLen: Int,
+                        len: Int,
+                        sb: upickle.core.CharBuilder,
+                        s: CharSequence,
+                        escapeUnicode: Boolean,
+                        wrapQuotes: Boolean): upickle.core.CharBuilder = ...
+```
+
+#### `upickle/core/SimpleVisitor.scala`
+
+> A visitor that throws an error for all the visit methods which it does not define,
+> letting you only define the handlers you care about.
+
+```scala
+trait SimpleVisitor[-T, +V] extends Visitor[T, V]
+```
+
+```scala
+def expectedMsg: String
+```
+
+```scala
+def visitNull(index: Int): V = ...
+```
+
+```scala
+def visitTrue(index: Int): V = ...
+```
+
+```scala
+def visitFalse(index: Int): V = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int): V = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): V = ...
+```
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, index: Int): ObjVisitor[T, V] = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int): ArrVisitor[T, V] = ...
+```
+
+```scala
+def visitFloat64(d: Double, index: Int): V = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int): V = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int): V = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int): V = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int): V = ...
+```
+
+```scala
+def visitFloat64String(s: String, index: Int): V = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int): V = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int): V = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int): V = ...
+```
+
+#### `upickle/core/StringVisitor.scala`
+
+```scala
+object StringVisitor extends SimpleVisitor[Nothing, Any]
+```
+
+```scala
+def expectedMsg = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+override def visitInt32(d: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(d: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(d: Long, index: Int) = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitTrue(index: Int) = ...
+```
+
+```scala
+override def visitFalse(index: Int) = ...
+```
+
+```scala
+override def visitChar(s: Char, index: Int) = ...
+```
+
+#### `upickle/core/TraceVisitor.scala`
+
+> Adds a JSON Path to exceptions thrown by the delegate Visitor.
+>
+> Useful for debugging failures.
+> Adds ~10% overhead depending on the parser.
+>
+> @see https://goessner.net/articles/JsonPath/
+
+```scala
+object TraceVisitor
+```
+
+```scala
+def withTrace[T, J](trace: Boolean, v: Visitor[T, J])(f: Visitor[T, J] => J): J = ...
+```
+
+> JSON Path indicating where the problem occurred.
+> Added as a suppressed exception.
+
+```scala
+class TraceException(val jsonPath: String, cause: Throwable) extends Exception(jsonPath, cause) with NoStackTrace
+```
+
+> Internally, the paths form a linked list back to the root by the visitors themselves.
+> Compared to something like a List[String] or List[Object], this does not require
+> extra String allocation or boxing unless we actually ask for the path.
+
+```scala
+trait HasPath
+```
+
+> Forms a chain toward the root.
+
+```scala
+def parent: Option[HasPath]
+```
+
+> @return name of a single level, if any, e.g. "foo"
+
+```scala
+def pathComponent: Option[String]
+```
+
+> @return the full JSONPath
+
+```scala
+def path: String = ...
+```
+
+```scala
+override def toString: String = ...
+```
+
+```scala
+object RootHasPath extends HasPath
+```
+
+```scala
+override def pathComponent: Option[String] = ...
+```
+
+```scala
+override def parent: Option[HasPath] = ...
+```
+
+```scala
+class Wrapper[T, J]
+```
+
+```scala
+def visitor(delegate: Visitor[T, J]): TraceVisitor[T, J] = ...
+```
+
+```scala
+var lastHasPath: HasPath = ...
+```
+
+```scala
+class TraceVisitor[T, J](
+  protected val delegate: Visitor[T, J],
+  parentPath: HasPath,
+  wrapper: TraceVisitor.Wrapper[T, J]
+) extends Visitor.Delegate[T, J](delegate)
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int): ObjVisitor[T, J] = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int): ArrVisitor[T, J] = ...
+```
+
+```scala
+override def toString: String = ...
+```
+
+#### `upickle/core/Transformer.scala`
+
+```scala
+trait Transformer[I]
+```
+
+```scala
+def transform[T](j: I, f: Visitor[_, T]): T
+```
+
+#### `upickle/core/Types.scala`
+
+> Basic functionality to be able to read and write objects. Kept as a trait so
+> other internal files can use it, while also mixing it into the `upickle`
+> package to form the public API1
+
+```scala
+trait Types
+```
+
+> A combined [[Reader]] and [[Writer]], along with some utility methods.
+
+```scala
+trait ReadWriter[T] extends Reader[T] with Writer[T]
+```
+
+```scala
+override def narrow[K] = ...
+```
+
+```scala
+def bimap[V](f: V => T, g: T => V): ReadWriter[V] = ...
+```
+
+```scala
+object ReadWriter
+```
+
+```scala
+abstract class Delegate[T](other: Visitor[Any, T])
+```
+
+```scala
+def merge[T](tagKey: String, rws: ReadWriter[_ <: T]*): TaggedReadWriter[T] = {
+      new TaggedReadWriter.Node(tagKey, rws.asInstanceOf[Seq[TaggedReadWriter[T]]]:_*)
+```
+
+```scala
+def merge[T](rws: ReadWriter[_ <: T]*): TaggedReadWriter[T] = merge(Annotator.defaultTagKey, rws:_*)
+```
+
+```scala
+implicit def join[T](implicit r0: Reader[T], w0: Writer[T]): ReadWriter[T] = ...
+```
+
+> A Reader that throws an error for all the visit methods which it does not define,
+> letting you only define the handlers you care about.
+
+```scala
+trait SimpleReader[T] extends Reader[T] with upickle.core.SimpleVisitor[Any, T]
+```
+
+> Represents the ability to read a value of type [[T]].
+>
+> A thin wrapper around [[Visitor]], but needs to be it's own class in order
+> to make type inference automatically pick up it's implicit values.
+
+```scala
+trait Reader[T] extends upickle.core.Visitor[Any, T]
+```
+
+```scala
+override def map[Z](f: T => Z): Reader[Z] = ...
+```
+
+```scala
+override def mapNulls[Z](f: T => Z): Reader[Z] = ...
+```
+
+```scala
+def narrow[K <: T] = this.asInstanceOf[Reader[K]]
+```
+
+```scala
+object Reader
+```
+
+```scala
+class Delegate[T, V](delegatedReader: Visitor[T, V])
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+abstract class MapReader[-T, V, Z](delegatedReader: Visitor[T, V])
+```
+
+```scala
+def mapNonNullsFunction(t: V): Z
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def merge[T](tagKey: String, readers0: Reader[_ <: T]*): TaggedReader.Node[T] = {
+      new TaggedReader.Node(tagKey, readers0.asInstanceOf[Seq[TaggedReader[T]]]:_*)
+```
+
+```scala
+def merge[T](readers0: Reader[_ <: T]*): TaggedReader.Node[T] = merge(Annotator.defaultTagKey, readers0:_*)
+```
+
+> Represents the ability to write a value of type [[T]].
+>
+> Generally nothing more than a way of applying the [[T]] to
+> a [[Visitor]], along with some utility methods
+
+```scala
+trait Writer[T] extends Transformer[T]
+```
+
+> Whether or not the type being written can be used as a key in a JSON dictionary.
+> Opt-in, and only applicable to writers that write primitive types like
+> strings, booleans, numbers, etc..
+
+```scala
+def isJsonDictKey: Boolean = ...
+```
+
+```scala
+def narrow[K] = ...
+```
+
+```scala
+def transform[V](v: T, out: Visitor[_, V]) = ...
+```
+
+```scala
+def write0[V](out: Visitor[_, V], v: T): V
+```
+
+```scala
+def write[V](out: Visitor[_, V], v: T): V = ...
+```
+
+```scala
+def comapNulls[U](f: U => T) = ...
+```
+
+```scala
+def comap[U](f: U => T) = ...
+```
+
+```scala
+object Writer
+```
+
+```scala
+class MapWriterNulls[U, T](src: Writer[T], f: U => T) extends Writer[U]
+```
+
+```scala
+override def write[R](out: Visitor[_, R], v: U): R = ...
+```
+
+```scala
+def write0[R](out: Visitor[_, R], v: U): R = ...
+```
+
+```scala
+class MapWriter[U, T](src: Writer[T], f: U => T) extends Writer[U]
+```
+
+```scala
+def write0[R](out: Visitor[_, R], v: U): R = ...
+```
+
+```scala
+def merge[T](writers: Writer[_ <: T]*) = {
+      new TaggedWriter.Node(writers.asInstanceOf[Seq[TaggedWriter[T]]]:_*)
+```
+
+```scala
+trait TaggedReader[T] extends SimpleReader[T]
+```
+
+```scala
+def findReader(s: String): Reader[T]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+object TaggedReader
+```
+
+```scala
+class Leaf[T](private[upickle] override val tagKey: String, tagValue: String, r: Reader[T]) extends TaggedReader[T]
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def this(tag: String, r: Reader[T]) = ...
+```
+
+```scala
+def findReader(s: String) = ...
+```
+
+```scala
+class Node[T](private[upickle] override val tagKey: String, rs: TaggedReader[_ <: T]*) extends TaggedReader[T]{
+      @deprecated("Not used, left for binary compatibility")
+```
+
+```scala
+def this(rs: TaggedReader[_ <: T]*) = this(Annotator.defaultTagKey, rs:_*)
+```
+
+```scala
+def findReader(s: String) = ...
+```
+
+```scala
+trait TaggedWriter[T] extends Writer[T]
+```
+
+```scala
+    @deprecated("Not used, left for binary compatibility")
+def findWriter(v: Any): (String, ObjectWriter[T])
+```
+
+```scala
+    @annotation.nowarn("msg=deprecated")
+def findWriterWithKey(v: Any): (String, String, ObjectWriter[T]) = ...
+```
+
+```scala
+def write0[R](out: Visitor[_, R], v: T): R = ...
+```
+
+```scala
+object TaggedWriter
+```
+
+```scala
+class Leaf[T](checker: Annotator.Checker, tagKey: String, tagValue: String, r: ObjectWriter[T]) extends TaggedWriter[T]
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def this(checker: Annotator.Checker, tag: String, r: ObjectWriter[T]) = ...
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def findWriter(v: Any) = ...
+```
+
+```scala
+override def findWriterWithKey(v: Any) = ...
+```
+
+```scala
+class Node[T](rs: TaggedWriter[_ <: T]*) extends TaggedWriter[T]{
+      @deprecated("Not used, left for binary compatibility")
+```
+
+```scala
+def findWriter(v: Any) = ...
+```
+
+```scala
+override def findWriterWithKey(v: Any) = ...
+```
+
+```scala
+trait TaggedReadWriter[T] extends ReadWriter[T] with TaggedReader[T] with TaggedWriter[T] with SimpleReader[T]
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+object TaggedReadWriter
+```
+
+```scala
+class Leaf[T](c: ClassTag[_], private[upickle] override val tagKey: String, tagValue: String, r: ObjectWriter[T] with Reader[T]) extends TaggedReadWriter[T]
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def this(c: ClassTag[_], tag: String, r: ObjectWriter[T] with Reader[T]) = ...
+```
+
+```scala
+def findReader(s: String) = ...
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def findWriter(v: Any) = ...
+```
+
+```scala
+override def findWriterWithKey(v: Any) = ...
+```
+
+```scala
+class Node[T](private[upickle] override val tagKey: String, rs: TaggedReadWriter[_ <: T]*) extends TaggedReadWriter[T]{
+      @deprecated("Not used, left for binary compatibility")
+```
+
+```scala
+def this(rs: TaggedReadWriter[_ <: T]*) = this(Annotator.defaultTagKey, rs:_*)
+```
+
+```scala
+def findReader(s: String) = ...
+```
+
+```scala
+      @deprecated("Not used, left for binary compatibility")
+def findWriter(v: Any) = ...
+```
+
+```scala
+override def findWriterWithKey(v: Any) = ...
+```
+
+```scala
+def taggedExpectedMsg: String
+```
+
+```scala
+def taggedArrayContext[T](taggedReader: TaggedReader[T], index: Int): ArrVisitor[Any, T] = ...
+```
+
+```scala
+def taggedObjectContext[T](taggedReader: TaggedReader[T], index: Int): ObjVisitor[Any, T] = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+def taggedWrite[T, R](w: ObjectWriter[T], tag: String, out: Visitor[_,  R], v: T): R
+```
+
+```scala
+  @annotation.nowarn("msg=deprecated")
+def taggedWrite[T, R](w: ObjectWriter[T], tagKey: String, tagValue: String, out: Visitor[_, R], v: T): R = ...
+```
+
+```scala
+trait ObjectWriter[T] extends Writer[T]
+```
+
+```scala
+def length(v: T): Int
+```
+
+```scala
+def writeToObject[R](ctx: ObjVisitor[_, R], v: T): Unit
+```
+
+> Implicit to indicate that we are currently deriving an implicit [[T]]. Used
+> to avoid the implicit being derived from picking up its own definition,
+> resulting in infinite looping/recursion
+
+```scala
+class CurrentlyDeriving[T]
+```
+
+> Wrap a CaseClassReader or CaseClassWriter reader/writer to handle $type tags during reading and writing.
+>
+> Note that Scala 3 singleton `enum` values do not have proper `ClassTag[V]`s
+> like Scala 2 `case object`s do, so we instead use a `Checker.Val` to check
+> for `.equals` equality during writes to determine which tag to use.
+
+```scala
+trait Annotator
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+def annotate[V](rw: Reader[V], n: String): TaggedReader[V]
+```
+
+```scala
+  @annotation.nowarn("msg=deprecated")
+def annotate[V](rw: Reader[V], key: String, value: String): TaggedReader[V] = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+def annotate[V](rw: ObjectWriter[V], n: String, checker: Annotator.Checker): TaggedWriter[V]
+```
+
+```scala
+  @annotation.nowarn("msg=deprecated")
+def annotate[V](rw: ObjectWriter[V], key: String, value: String, checker: Annotator.Checker): TaggedWriter[V] = ...
+```
+
+```scala
+def annotate[V](rw: ObjectWriter[V], key: String, value: String)(implicit ct: ClassTag[V]): TaggedWriter[V] = ...
+```
+
+```scala
+  @deprecated("Not used, left for binary compatibility")
+final def annotate[V](rw: ObjectWriter[V], n: String)(implicit ct: ClassTag[V]): TaggedWriter[V] = ...
+```
+
+```scala
+object Annotator
+```
+
+```scala
+def defaultTagKey = ...
+```
+
+```scala
+sealed trait Checker
+```
+
+```scala
+object Checker
+```
+
+```scala
+case class Cls(c: Class[_]) extends Checker
+```
+
+```scala
+case class Val(v: Any) extends Checker
+```
+
+#### `upickle/core/Visitor.scala`
+
+> Standard set of hooks uPickle uses to traverse over a structured data.
+> A superset of the JSON, MessagePack, and Scala object  hierarchies, since
+> it needs to support efficiently processing all of them.
+>
+> Note that some parameters are un-set (-1) when not available; e.g.
+> `visitArray`'s `length` is not set when parsing JSON input (since it cannot
+> be known up front) and the various `index` parameters are not set when
+> traversing Scala object hierarchies.
+>
+> When expecting to deal with a subset of the methods; it is common to
+> forward the ones you don't care about to the ones you do; e.g. JSON visitors
+> would forward all `visitFloat32`/`visitInt`/etc. methods to `visitFloat64`
+>
+> @see [[http://www.lihaoyi.com/post/ZeroOverheadTreeProcessingwiththeVisitorPattern.html]]
+> @tparam T ???
+> @tparam J the result of visiting elements (e.g. a json AST or side-effecting writer)
+
+```scala
+trait Visitor[-T, +J]
+```
+
+> @param index json source position at the start of the `[` being visited
+> @return a [[Visitor]] used for visiting the elements of the array
+
+```scala
+def visitArray(length: Int, index: Int): ArrVisitor[T, J]
+```
+
+> @param index json source position at the start of the `{` being visited
+> @return a [[ObjVisitor]] used for visiting the keys/values of the object
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, index: Int): ObjVisitor[T, J]
+```
+
+> @param index json source position at the start of the `null` being visited
+
+```scala
+def visitNull(index: Int): J
+```
+
+> @param index json source position at the start of the `false` being visited
+
+```scala
+def visitFalse(index: Int): J
+```
+
+> @param index json source position at the start of the `true` being visited
+
+```scala
+def visitTrue(index: Int): J
+```
+
+> Visit the number in its text representation.
+>
+> @param s        unparsed text representation of the number.
+> @param decIndex index of the `.`, relative to the start of the CharSequence, or -1 if omitted
+> @param expIndex index of `e` or `E` relative to the start of the CharSequence, or -1 if omitted
+> @param index    json source position at the start of the number being visited
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J
+```
+
+```scala
+def visitFloat64ByteParts(s: Array[Byte], arrOffset: Int, arrLength: Int, decIndex: Int, expIndex: Int, index: Int): J = ...
+```
+
+```scala
+def visitFloat64CharParts(s: Array[Char], arrOffset: Int, arrLength: Int, decIndex: Int, expIndex: Int, index: Int): J = ...
+```
+
+> Optional handler for raw double values; can be overriden for performance
+> in cases where you're translating directly between numbers to avoid the
+> overhead of stringifying and re-parsing your numbers (e.g. the WebJson
+> transformer gets raw doubles from the underlying Json.parse).
+>
+> Delegates to `visitFloat64StringParts` if not overriden
+>
+> @param d     the input number
+> @param index json source position at the start of the number being visited
+
+```scala
+def visitFloat64(d: Double, index: Int): J
+```
+
+```scala
+def visitFloat32(d: Float, index: Int): J
+```
+
+```scala
+def visitInt32(i: Int, index: Int): J
+```
+
+```scala
+def visitInt64(i: Long, index: Int): J
+```
+
+```scala
+def visitUInt64(i: Long, index: Int): J
+```
+
+> Convenience methods to help you compute the decimal-point-index and
+> exponent-index of an arbitrary numeric string
+>
+> @param s     the text string being visited
+> @param index json source position at the start of the string being visited
+
+```scala
+def visitFloat64String(s: String, index: Int): J
+```
+
+> @param s     the text string being visited
+> @param index json source position at the start of the string being visited
+
+```scala
+def visitString(s: CharSequence, index: Int): J
+```
+
+```scala
+def visitChar(s: Char, index: Int): J
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int): J
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int): J
+```
+
+```scala
+def map[Z](f: J => Z): Visitor[T, Z] = ...
+```
+
+```scala
+def mapNulls[Z](f: J => Z): Visitor[T, Z] = ...
+```
+
+> Base class for visiting elements of json arrays and objects.
+>
+> @tparam T ???
+> @tparam J the result of visiting elements (e.g. a json AST or side-effecting writer)
+
+```scala
+sealed trait ObjArrVisitor[-T, +J]
+```
+
+> Called on descent into elements.
+>
+> The returned [[Visitor]] will be used to visit this branch of the json.
+
+```scala
+def subVisitor: Visitor[_, _]
+```
+
+> Called on completion of visiting an array element or object field value, with the produced result, [[T]].
+>
+> @param v     result of visiting a value in this object or arary
+> (not the input value, this would have been passed to [[subVisitor]])
+> @param index json source character position being visited
+
+```scala
+def visitValue(v: T, index: Int): Unit
+```
+
+> Called on end of the object or array.
+>
+> @param index json source position at the start of the '}' or ']' being visited
+> @return the result of visiting this array or object
+
+```scala
+def visitEnd(index: Int): J
+```
+
+> @return true if this is a json object
+> false if this is a json array
+
+```scala
+def isObj: Boolean
+```
+
+> Casts [[T]] from _ to [[Any]].
+
+```scala
+def narrow = ...
+```
+
+```scala
+object Visitor
+```
+
+```scala
+class Delegate[T, V](delegatedReader: Visitor[T, V]) extends Visitor[T, V]
+```
+
+```scala
+override def visitNull(index: Int) = ...
+```
+
+```scala
+override def visitTrue(index: Int) = ...
+```
+
+```scala
+override def visitFalse(index: Int) = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitFloat64String(s: String, index: Int) = ...
+```
+
+```scala
+override def visitChar(s: Char, index: Int) = ...
+```
+
+```scala
+override def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+override def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+abstract class MapReader[-T, V, Z](delegatedReader: Visitor[T, V]) extends Visitor[T, Z]
+```
+
+```scala
+def mapNonNullsFunction(t: V) : Z
+```
+
+```scala
+def mapFunction(v: V): Z = ...
+```
+
+```scala
+override def visitFalse(index: Int) = ...
+```
+
+```scala
+override def visitNull(index: Int) = ...
+```
+
+```scala
+override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+override def visitTrue(index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int): ObjVisitor[T, Z] = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int): ArrVisitor[T, Z] = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitFloat64String(s: String, index: Int) = ...
+```
+
+```scala
+override def visitChar(s: Char, index: Int) = ...
+```
+
+```scala
+override def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+override def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+class MapArrContext[T, V, Z](src: ArrVisitor[T, V], f: V => Z) extends ArrVisitor[T, Z]
+```
+
+```scala
+def subVisitor: Visitor[_, _] = ...
+```
+
+```scala
+def visitValue(v: T, index: Int): Unit = ...
+```
+
+```scala
+def visitEnd(index: Int) = ...
+```
+
+```scala
+class MapObjContext[T, V, Z](src: ObjVisitor[T, V], f: V => Z) extends ObjVisitor[T, Z]
+```
+
+```scala
+def subVisitor: Visitor[_, _] = ...
+```
+
+```scala
+def visitKey(index: Int): Visitor[_, _] = ...
+```
+
+```scala
+def visitKeyValue(s: Any) = ...
+```
+
+```scala
+def visitValue(v: T, index: Int): Unit = ...
+```
+
+```scala
+def visitEnd(index: Int) = ...
+```
+
+> Visits the elements of a json object.
+
+```scala
+trait ObjVisitor[-T, +J] extends ObjArrVisitor[T, J]
+```
+
+> @param s     the value of the key
+> @param index json source position at the start of the key being visited
+
+```scala
+def visitKey(index: Int): Visitor[_, _]
+```
+
+```scala
+def visitKeyValue(v: Any): Unit
+```
+
+```scala
+def isObj = ...
+```
+
+```scala
+override def narrow: ObjVisitor[Any, J] = ...
+```
+
+> Visits the elements of a json array.
+
+```scala
+trait ArrVisitor[-T, +J] extends ObjArrVisitor[T, J]
+```
+
+```scala
+def isObj = ...
+```
+
+```scala
+override def narrow = ...
+```
+
+> Signals failure processsing JSON after parsing.
+
+```scala
+case class AbortException(clue: String,
+                          index: Int,
+                          line: Int,
+                          col: Int,
+                          cause: Throwable) extends Exception(clue + " at index " + index, cause)
+```
+
+> Throw this inside a [[Visitor]]'s handler functions to fail the processing
+> of JSON. The Facade just needs to provide the error message, and it is up
+> to the driver to ensure it is properly wrapped in a [[AbortException]]
+> with the relevant source information.
+
+```scala
+case class Abort(msg: String) extends Exception(msg)
+```
+
+#### `upickle/core/compat/LinkedHashMapCompat.scala`
+
+```scala
+trait LinkedHashMapCompat[K, V]
+```
+
+```scala
+object LinkedHashMapCompat
+```
+
+```scala
+def factory[K, V]: Factory[(K, V), LinkedHashMap[K, V]] = ...
+```
+
+#### `upickle/core/compat/SortInPlace.scala`
+
+```scala
+object SortInPlace
+```
+
+```scala
+def apply[T, B: scala.Ordering](t: collection.mutable.ArrayBuffer[T])(f: PartialFunction[T, B]): Unit = ...
+```
+
+```scala
+object DistinctBy
+```
+
+```scala
+def apply[T, V](items: collection.Seq[T])(f: T => V) = ...
+```
+
+#### `upickle/core/compat/package.scala`
+
+```scala
+package object compat
+```
+
+```scala
+type Factory[-A, +C] = ...
+```
+
+```scala
+def toIterator[T](iterable: IterableOnce[T]) = ...
+```
+
+### `com.lihaoyi:upickle-implicits_3:3.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/upickle-implicits_3/3.3.1/upickle-implicits_3-3.3.1-sources.jar
+
+#### `upickle/Generated.scala`
+
+> Auto-generated picklers and unpicklers, used for creating the 22
+> versions of tuple-picklers and case-class picklers
+
+```scala
+trait Generated extends TupleReadWriters
+```
+
+```scala
+implicit def Tuple1Writer[T1: Writer]: TupleNWriter[Tuple1[T1]] = ...
+```
+
+```scala
+implicit def Tuple1Reader[T1: Reader]: TupleNReader[Tuple1[T1]] = ...
+```
+
+```scala
+implicit def Tuple2Writer[T1: Writer, T2: Writer]: TupleNWriter[Tuple2[T1, T2]] = ...
+```
+
+```scala
+implicit def Tuple2Reader[T1: Reader, T2: Reader]: TupleNReader[Tuple2[T1, T2]] = ...
+```
+
+```scala
+implicit def Tuple3Writer[T1: Writer, T2: Writer, T3: Writer]: TupleNWriter[Tuple3[T1, T2, T3]] = ...
+```
+
+```scala
+implicit def Tuple3Reader[T1: Reader, T2: Reader, T3: Reader]: TupleNReader[Tuple3[T1, T2, T3]] = ...
+```
+
+```scala
+implicit def Tuple4Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer]: TupleNWriter[Tuple4[T1, T2, T3, T4]] = ...
+```
+
+```scala
+implicit def Tuple4Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader]: TupleNReader[Tuple4[T1, T2, T3, T4]] = ...
+```
+
+```scala
+implicit def Tuple5Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer]: TupleNWriter[Tuple5[T1, T2, T3, T4, T5]] = ...
+```
+
+```scala
+implicit def Tuple5Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader]: TupleNReader[Tuple5[T1, T2, T3, T4, T5]] = ...
+```
+
+```scala
+implicit def Tuple6Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer]: TupleNWriter[Tuple6[T1, T2, T3, T4, T5, T6]] = ...
+```
+
+```scala
+implicit def Tuple6Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader]: TupleNReader[Tuple6[T1, T2, T3, T4, T5, T6]] = ...
+```
+
+```scala
+implicit def Tuple7Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer]: TupleNWriter[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = ...
+```
+
+```scala
+implicit def Tuple7Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader]: TupleNReader[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = ...
+```
+
+```scala
+implicit def Tuple8Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer]: TupleNWriter[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = ...
+```
+
+```scala
+implicit def Tuple8Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader]: TupleNReader[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = ...
+```
+
+```scala
+implicit def Tuple9Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer]: TupleNWriter[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = ...
+```
+
+```scala
+implicit def Tuple9Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader]: TupleNReader[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = ...
+```
+
+```scala
+implicit def Tuple10Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer]: TupleNWriter[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = ...
+```
+
+```scala
+implicit def Tuple10Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader]: TupleNReader[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = ...
+```
+
+```scala
+implicit def Tuple11Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer]: TupleNWriter[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = ...
+```
+
+```scala
+implicit def Tuple11Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader]: TupleNReader[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = ...
+```
+
+```scala
+implicit def Tuple12Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer]: TupleNWriter[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = ...
+```
+
+```scala
+implicit def Tuple12Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader]: TupleNReader[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = ...
+```
+
+```scala
+implicit def Tuple13Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer]: TupleNWriter[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = ...
+```
+
+```scala
+implicit def Tuple13Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader]: TupleNReader[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = ...
+```
+
+```scala
+implicit def Tuple14Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer]: TupleNWriter[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = ...
+```
+
+```scala
+implicit def Tuple14Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader]: TupleNReader[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = ...
+```
+
+```scala
+implicit def Tuple15Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer]: TupleNWriter[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = ...
+```
+
+```scala
+implicit def Tuple15Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader]: TupleNReader[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = ...
+```
+
+```scala
+implicit def Tuple16Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer]: TupleNWriter[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = ...
+```
+
+```scala
+implicit def Tuple16Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader]: TupleNReader[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = ...
+```
+
+```scala
+implicit def Tuple17Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer]: TupleNWriter[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = ...
+```
+
+```scala
+implicit def Tuple17Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader]: TupleNReader[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = ...
+```
+
+```scala
+implicit def Tuple18Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer, T18: Writer]: TupleNWriter[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = ...
+```
+
+```scala
+implicit def Tuple18Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader, T18: Reader]: TupleNReader[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = ...
+```
+
+```scala
+implicit def Tuple19Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer, T18: Writer, T19: Writer]: TupleNWriter[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] = ...
+```
+
+```scala
+implicit def Tuple19Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader, T18: Reader, T19: Reader]: TupleNReader[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] = ...
+```
+
+```scala
+implicit def Tuple20Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer, T18: Writer, T19: Writer, T20: Writer]: TupleNWriter[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] = ...
+```
+
+```scala
+implicit def Tuple20Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader, T18: Reader, T19: Reader, T20: Reader]: TupleNReader[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] = ...
+```
+
+```scala
+implicit def Tuple21Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer, T18: Writer, T19: Writer, T20: Writer, T21: Writer]: TupleNWriter[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] = ...
+```
+
+```scala
+implicit def Tuple21Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader, T18: Reader, T19: Reader, T20: Reader, T21: Reader]: TupleNReader[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] = ...
+```
+
+```scala
+implicit def Tuple22Writer[T1: Writer, T2: Writer, T3: Writer, T4: Writer, T5: Writer, T6: Writer, T7: Writer, T8: Writer, T9: Writer, T10: Writer, T11: Writer, T12: Writer, T13: Writer, T14: Writer, T15: Writer, T16: Writer, T17: Writer, T18: Writer, T19: Writer, T20: Writer, T21: Writer, T22: Writer]: TupleNWriter[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] = ...
+```
+
+```scala
+implicit def Tuple22Reader[T1: Reader, T2: Reader, T3: Reader, T4: Reader, T5: Reader, T6: Reader, T7: Reader, T8: Reader, T9: Reader, T10: Reader, T11: Reader, T12: Reader, T13: Reader, T14: Reader, T15: Reader, T16: Reader, T17: Reader, T18: Reader, T19: Reader, T20: Reader, T21: Reader, T22: Reader]: TupleNReader[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] = ...
+```
+
+#### `upickle/implicits/CaseClassReadWriters.scala`
+
+> Basic functionality to be able to read and write objects. Kept as a trait so
+> other internal files can use it, while also mixing it into the `upickle`
+> package to form the public API1
+
+```scala
+trait CaseClassReadWriters extends upickle.core.Types
+```
+
+```scala
+def allowUnknownKeys: Boolean = ...
+```
+
+```scala
+abstract class CaseClassReader[V] extends SimpleReader[V]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+trait CaseClassWriter[V] extends ObjectWriter[V]
+```
+
+```scala
+def length(v: V): Int
+```
+
+```scala
+    @deprecated("Not used, left for binary compatibility")
+def writeToObject[R](ctx: ObjVisitor[_, R], v: V): Unit
+```
+
+```scala
+    @scala.annotation.nowarn
+def write0[R](out: Visitor[_, R], v: V): R = ...
+```
+
+```scala
+def writeSnippetMappedName[R, V](ctx: _root_.upickle.core.ObjVisitor[_, R],
+                                     mappedArgsI: CharSequence,
+                                     w: Any,
+                                     value: Any) = ...
+```
+
+```scala
+    @deprecated("Not used, left for binary compatibility")
+def writeSnippet[R, V](objectAttributeKeyWriteMap: CharSequence => CharSequence,
+                           ctx: _root_.upickle.core.ObjVisitor[_, R],
+                           mappedArgsI: String,
+                           w: Any,
+                           value: Any) = ...
+```
+
+```scala
+class SingletonReader[T](t: T) extends CaseClassReader[T]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+class SingletonWriter[T](f: T) extends CaseClassWriter[T]
+```
+
+```scala
+def length(v: T) = ...
+```
+
+```scala
+def writeToObject[R](ctx: ObjVisitor[_, R], v: T): Unit = ...
+```
+
+#### `upickle/implicits/MacroImplicits.scala`
+
+```scala
+trait MacroImplicits extends Readers with Writers with upickle.core.Annotator:
+```
+
+```scala
+inline def macroRW[T: ClassTag](using Mirror.Of[T]): ReadWriter[T] = ...
+```
+
+```scala
+inline def macroRWAll[T: ClassTag](using Mirror.Of[T]): ReadWriter[T] = ...
+```
+
+```scala
+implicit class ReadWriterExtension(r: ReadWriter.type):
+```
+
+```scala
+inline def derived[T](using Mirror.Of[T], ClassTag[T]): ReadWriter[T] = ...
+```
+
+#### `upickle/implicits/MacrosCommon.scala`
+
+```scala
+trait MacrosCommon
+```
+
+```scala
+def serializeDefaults: Boolean = ...
+```
+
+```scala
+def objectAttributeKeyReadMap(s: CharSequence): CharSequence = ...
+```
+
+```scala
+def objectAttributeKeyWriteMap(s: CharSequence): CharSequence = ...
+```
+
+```scala
+def objectTypeKeyReadMap(s: CharSequence): CharSequence = ...
+```
+
+```scala
+def objectTypeKeyWriteMap(s: CharSequence): CharSequence = ...
+```
+
+```scala
+object MacrosCommon
+```
+
+```scala
+def tagKeyFromParents[P](
+    typeName: => String,
+    sealedParents: List[P],
+    getKey: P => Option[String],
+    getName: P => String,
+    fail: String => Nothing,
+  ): String = ...
+```
+
+#### `upickle/implicits/ObjectContexts.scala`
+
+```scala
+trait BaseCaseObjectContext
+```
+
+```scala
+def storeAggregatedValue(currentIndex: Int, v: Any): Unit
+```
+
+```scala
+def visitKey(index: Int) = ...
+```
+
+```scala
+var currentIndex = ...
+```
+
+```scala
+def storeValueIfNotFound(i: Int, v: Any): Unit
+```
+
+```scala
+abstract class CaseObjectContext[V](fieldCount: Int) extends ObjVisitor[Any, V] with BaseCaseObjectContext
+```
+
+```scala
+var found = ...
+```
+
+```scala
+def visitValue(v: Any, index: Int): Unit = ...
+```
+
+```scala
+def storeValueIfNotFound(i: Int, v: Any) = ...
+```
+
+```scala
+abstract class HugeCaseObjectContext[V](fieldCount: Int) extends ObjVisitor[Any, V] with BaseCaseObjectContext
+```
+
+```scala
+var found = ...
+```
+
+```scala
+def visitValue(v: Any, index: Int): Unit = ...
+```
+
+```scala
+def storeValueIfNotFound(i: Int, v: Any) = ...
+```
+
+#### `upickle/implicits/Readers.scala`
+
+```scala
+trait Readers extends upickle.core.Types
+  with TupleReadWriters
+  with Generated
+  with ReadersVersionSpecific
+```
+
+```scala
+implicit val UnitReader: Reader[Unit] = ...
+```
+
+```scala
+implicit val BooleanReader: Reader[Boolean] = ...
+```
+
+```scala
+implicit val DoubleReader: Reader[Double] = ...
+```
+
+```scala
+implicit val IntReader: Reader[Int] = ...
+```
+
+```scala
+implicit val FloatReader: Reader[Float] = ...
+```
+
+```scala
+implicit val ShortReader: Reader[Short] = ...
+```
+
+```scala
+implicit val ByteReader: Reader[Byte] = ...
+```
+
+```scala
+implicit val StringReader: Reader[String] = ...
+```
+
+```scala
+trait SimpleStringReader[T] extends SimpleReader[T]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+def readString(s: CharSequence): T
+```
+
+```scala
+implicit val CharReader: Reader[Char] = ...
+```
+
+```scala
+implicit val UUIDReader: Reader[UUID] = ...
+```
+
+```scala
+implicit val LongReader: Reader[Long] = ...
+```
+
+```scala
+implicit val BigIntReader: Reader[BigInt] = ...
+```
+
+```scala
+implicit val BigDecimalReader: Reader[BigDecimal] = ...
+```
+
+```scala
+implicit val SymbolReader: Reader[Symbol] = ...
+```
+
+```scala
+def MapReader0[M[A, B] <: collection.Map[A, B], K, V]
+                (make: Iterable[(K, V)] => M[K, V])
+```
+
+```scala
+implicit def MapReader1[K: Reader, V: Reader]: Reader[collection.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapReader2[K: Reader, V: Reader]: Reader[collection.immutable.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapReader3[K: Reader, V: Reader]: Reader[collection.mutable.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapReader4[K: Reader, V: Reader]: Reader[collection.mutable.LinkedHashMap[K, V]] = ...
+```
+
+```scala
+implicit def SortedMapReader[K: Reader: Ordering, V: Reader]: Reader[collection.mutable.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit def MapReader6[K: Reader: Ordering, V: Reader]: Reader[collection.immutable.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit def MapReader7[K: Reader: Ordering, V: Reader]: Reader[collection.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit def OptionReader[T: Reader]: Reader[Option[T]] = ...
+```
+
+```scala
+implicit def SomeReader[T: Reader]: Reader[Some[T]] = ...
+```
+
+```scala
+implicit def NoneReader: Reader[None.type] = ...
+```
+
+```scala
+implicit def ArrayReader[T: Reader: ClassTag]: Reader[Array[T]] = ...
+```
+
+```scala
+implicit def SeqLikeReader[C[_], T](implicit r: Reader[T],
+                                      factory: Factory[T, C[T]]): Reader[C[T]] = ...
+```
+
+```scala
+class SeqLikeReader[C[_], T](implicit r: Reader[T],
+                                      factory: Factory[T, C[T]]) extends SimpleReader[C[T]]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+implicit val DurationReader: Reader[Duration] = ...
+```
+
+```scala
+implicit val InfiniteDurationReader: Reader[Duration.Infinite] = ...
+```
+
+```scala
+implicit val FiniteDurationReader: Reader[FiniteDuration] = ...
+```
+
+```scala
+implicit def EitherReader[T1: Reader, T2: Reader]: SimpleReader[Either[T1, T2]] = ...
+```
+
+```scala
+implicit def RightReader[T1: Reader, T2: Reader]: Reader[Right[T1, T2]] = ...
+```
+
+```scala
+implicit def LeftReader[T1: Reader, T2: Reader]: Reader[Left[T1, T2]] = ...
+```
+
+```scala
+implicit val JavaBooleanReader: Reader[java.lang.Boolean] = ...
+```
+
+```scala
+implicit val JavaByteReader: Reader[java.lang.Byte] = ...
+```
+
+```scala
+implicit val JavaCharReader: Reader[java.lang.Character] = ...
+```
+
+```scala
+implicit val JavaShortReader: Reader[java.lang.Short] = ...
+```
+
+```scala
+implicit val JavaIntReader: Reader[java.lang.Integer] = ...
+```
+
+```scala
+implicit val JavaLongReader: Reader[java.lang.Long] = ...
+```
+
+```scala
+implicit val JavaFloatReader: Reader[java.lang.Float] = ...
+```
+
+```scala
+implicit val JavaDoubleReader: Reader[java.lang.Double] = ...
+```
+
+#### `upickle/implicits/TupleReadWriters.scala`
+
+> Basic functionality to be able to read and write objects. Kept as a trait so
+> other internal files can use it, while also mixing it into the `upickle`
+> package to form the public API1
+
+```scala
+trait TupleReadWriters extends upickle.core.Types
+```
+
+```scala
+class TupleNWriter[V](val writers: Array[Writer[_]], val f: V => Array[Any]) extends Writer[V]
+```
+
+```scala
+def write0[R](out: Visitor[_, R], v: V): R = ...
+```
+
+```scala
+class TupleNReader[V](val readers: Array[Reader[_]], val f: Array[Any] => V) extends SimpleReader[V]
+```
+
+```scala
+override def expectedMsg = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+#### `upickle/implicits/Writers.scala`
+
+```scala
+trait Writers extends upickle.core.Types
+  with TupleReadWriters
+  with Generated
+  with WritersVersionSpecific
+  with LowPriWriters
+```
+
+```scala
+implicit val StringWriter: Writer[String] = ...
+```
+
+```scala
+implicit val UnitWriter: Writer[Unit] = ...
+```
+
+```scala
+implicit val DoubleWriter: Writer[Double] = ...
+```
+
+```scala
+implicit val IntWriter: Writer[Int] = ...
+```
+
+```scala
+implicit val FloatWriter: Writer[Float] = ...
+```
+
+```scala
+implicit val ShortWriter: Writer[Short] = ...
+```
+
+```scala
+implicit val ByteWriter: Writer[Byte] = ...
+```
+
+```scala
+implicit val BooleanWriter: Writer[Boolean] = ...
+```
+
+```scala
+implicit val CharWriter: Writer[Char] = ...
+```
+
+```scala
+implicit val UUIDWriter: Writer[UUID] = ...
+```
+
+```scala
+implicit val LongWriter: Writer[Long] = ...
+```
+
+```scala
+implicit val BigIntWriter: Writer[BigInt] = ...
+```
+
+```scala
+implicit val BigDecimalWriter: Writer[BigDecimal] = ...
+```
+
+```scala
+implicit val SymbolWriter: Writer[Symbol] = ...
+```
+
+```scala
+implicit def OptionWriter[T: Writer]: Writer[Option[T]] = ...
+```
+
+```scala
+implicit def SomeWriter[T: Writer]: Writer[Some[T]] = ...
+```
+
+```scala
+implicit def NoneWriter: Writer[None.type] = ...
+```
+
+```scala
+implicit def ArrayWriter[T](implicit r: Writer[T]): Writer[Array[T]] = ...
+```
+
+```scala
+trait SimpleMapKeyWriter[T] extends Writer[T]
+```
+
+```scala
+override def isJsonDictKey = ...
+```
+
+```scala
+def writeString(v: T): String
+```
+
+```scala
+def write0[R](out: Visitor[_, R], v: T): R = ...
+```
+
+```scala
+def MapWriter0[M[A, B] <: collection.Map[A, B], K, V]
+                (implicit kw: Writer[K], vw: Writer[V]): Writer[M[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter1[K: Writer, V: Writer]: Writer[collection.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter2[K: Writer, V: Writer]: Writer[collection.immutable.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter3[K: Writer, V: Writer]: Writer[collection.mutable.Map[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter4[K: Writer, V: Writer]: Writer[collection.mutable.LinkedHashMap[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter5[K: Writer, V: Writer]: Writer[collection.mutable.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter6[K: Writer, V: Writer]: Writer[collection.immutable.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit def MapWriter7[K: Writer, V: Writer]: Writer[collection.SortedMap[K, V]] = ...
+```
+
+```scala
+implicit val DurationWriter: Writer[Duration] = ...
+```
+
+```scala
+implicit val InfiniteDurationWriter: Writer[Duration.Infinite] = ...
+```
+
+```scala
+implicit val FiniteDurationWriter: Writer[FiniteDuration] = ...
+```
+
+```scala
+implicit def EitherWriter[T1: Writer, T2: Writer]: Writer[Either[T1, T2]] = ...
+```
+
+```scala
+implicit def RightWriter[T1: Writer, T2: Writer]: Writer[Right[T1, T2]] = ...
+```
+
+```scala
+implicit def LeftWriter[T1: Writer, T2: Writer]: Writer[Left[T1, T2]] = ...
+```
+
+```scala
+implicit val JavaBooleanWriter: Writer[java.lang.Boolean] = ...
+```
+
+```scala
+implicit val JavaByteWriter: Writer[java.lang.Byte] = ...
+```
+
+```scala
+implicit val JavaCharWriter: Writer[java.lang.Character] = ...
+```
+
+```scala
+implicit val JavaShortWriter: Writer[java.lang.Short] = ...
+```
+
+```scala
+implicit val JavaIntWriter: Writer[java.lang.Integer] = ...
+```
+
+```scala
+implicit val JavaLongWriter: Writer[java.lang.Long] = ...
+```
+
+```scala
+implicit val JavaFloatWriter: Writer[java.lang.Float] = ...
+```
+
+```scala
+implicit val JavaDoubleWriter: Writer[java.lang.Double] = ...
+```
+
+> This needs to be split into a separate trait due to https://github.com/scala/bug/issues/11768
+
+```scala
+trait LowPriWriters extends upickle.core.Types
+```
+
+```scala
+implicit def SeqLikeWriter[C[_] <: Iterable[_], T](implicit r: Writer[T]): Writer[C[T]] = new Writer[C[T]] {
+    def write0[R](out: Visitor[_, R], v: C[T]): R = ...
+```
+
+#### `upickle/implicits/key.scala`
+
+```scala
+case class key(s: String) extends StaticAnnotation
+```
+
+```scala
+case class allowUnknownKeys(b: Boolean) extends StaticAnnotation
+```
+
+#### `upickle/implicits/macros.scala`
+
+```scala
+type IsInt[A <: Int] = A
+```
+
+```scala
+def getDefaultParamsImpl0[T](using Quotes, Type[T]): Map[String, Expr[AnyRef]] = ...
+```
+
+```scala
+def extractKey[A](using Quotes)(sym: quotes.reflect.Symbol): Option[String] = ...
+```
+
+```scala
+inline def extractIgnoreUnknownKeys[T](): List[Boolean] = ...
+```
+
+```scala
+def extractIgnoreUnknownKeysImpl[T](using Quotes, Type[T]): Expr[List[Boolean]] = ...
+```
+
+```scala
+inline def paramsCount[T]: Int = ...
+```
+
+```scala
+def paramsCountImpl[T](using Quotes, Type[T]) = ...
+```
+
+```scala
+inline def storeDefaults[T](inline x: upickle.implicits.BaseCaseObjectContext): Unit = ...
+```
+
+```scala
+inline def writeLength[T](inline thisOuter: upickle.core.Types with upickle.implicits.MacrosCommon,
+                          inline v: T): Int = ...
+```
+
+```scala
+def writeLengthImpl[T](thisOuter: Expr[upickle.core.Types with upickle.implicits.MacrosCommon],
+                                       v: Expr[T])
+```
+
+```scala
+inline def checkErrorMissingKeysCount[T](): Long = ...
+```
+
+```scala
+def checkErrorMissingKeysCountImpl[T]()(using Quotes, Type[T]): Expr[Long] = ...
+```
+
+```scala
+inline def writeSnippets[R, T, WS <: Tuple](inline thisOuter: upickle.core.Types with upickle.implicits.MacrosCommon,
+                                   inline self: upickle.implicits.CaseClassReadWriters#CaseClassWriter[T],
+                                   inline v: T,
+                                   inline ctx: _root_.upickle.core.ObjVisitor[_, R]): Unit = ...
+```
+
+```scala
+def writeSnippetsImpl[R, T, WS <: Tuple](thisOuter: Expr[upickle.core.Types with upickle.implicits.MacrosCommon],
+                            self: Expr[upickle.implicits.CaseClassReadWriters#CaseClassWriter[T]],
+                            v: Expr[T],
+                            ctx: Expr[_root_.upickle.core.ObjVisitor[_, R]])
+```
+
+```scala
+inline def isMemberOfSealedHierarchy[T]: Boolean = ...
+```
+
+```scala
+def isMemberOfSealedHierarchyImpl[T](using Quotes, Type[T]): Expr[Boolean] = ...
+```
+
+```scala
+inline def tagKey[T]: String = ...
+```
+
+```scala
+def tagKeyImpl[T](using Quotes, Type[T]): Expr[String] = ...
+```
+
+```scala
+inline def tagName[T]: String = ...
+```
+
+```scala
+def tagNameImpl[T](using Quotes, Type[T]): Expr[String] = ...
+```
+
+```scala
+inline def isSingleton[T]: Boolean = ...
+```
+
+```scala
+def isSingletonImpl[T](using Quotes, Type[T]): Expr[Boolean] = ...
+```
+
+```scala
+inline def getSingleton[T]: T = ...
+```
+
+```scala
+def getSingletonImpl[T](using Quotes, Type[T]): Expr[T] = ...
+```
+
+```scala
+inline def defineEnumReaders[T0, T <: Tuple](prefix: Any): T0 = ${ defineEnumVisitorsImpl[T0, T]('prefix, "macroR") }
+inline def defineEnumWriters[T0, T <: Tuple](prefix: Any): T0 = ${ defineEnumVisitorsImpl[T0, T]('prefix, "macroW") }
+def defineEnumVisitorsImpl[T0, T <: Tuple](prefix: Expr[Any], macroX: String)(using Quotes, Type[T0], Type[T]): Expr[T0] =
+  import quotes.reflect._
+
+  def handleType(tpe: TypeRepr, name: String, skipTrait: Boolean): Option[(ValDef, Symbol)] = {
+
+    val AppliedType(typePrefix, List(arg)) = tpe: @unchecked
+
+    if (skipTrait &&
+        (arg.typeSymbol.flags.is(Flags.Trait) ||
+          // Filter out `enum`s, because the `case`s of an enum are flagged as
+          // abstract enums for some reasons rather than as case classes
+          (arg.typeSymbol.flags.is(Flags.Abstract) && !arg.typeSymbol.flags.is(Flags.Enum)))){
+      None
+    } else {
+      val sym = Symbol.newVal(
+        Symbol.spliceOwner,
+        name,
+        tpe,
+        Flags.Implicit | Flags.Lazy,
+        Symbol.noSymbol
+      )
+
+      val macroCall = TypeApply(
+        Select(prefix.asTerm, prefix.asTerm.tpe.typeSymbol.methodMember(macroX).head),
+        List(TypeTree.of(using arg.asType))
+      )
+
+      val newDef = ValDef(sym, Some(macroCall))
+
+      Some((newDef, sym))
+    }
+  }
+
+  def getDefs(t: TypeRepr, defs: List[(ValDef, Symbol)]): List[(ValDef, Symbol)] = {
+    t match{
+      case AppliedType(prefix, args) =>
+        val defAndSymbol = handleType(args(0), "x" + defs.size, skipTrait = true)
+        getDefs(args(1), defAndSymbol.toList ::: defs)
+```
+
+### `com.lihaoyi:ujson_3:3.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/ujson_3/3.3.1/ujson_3-3.3.1-sources.jar
+
+#### `BaseByteRenderer.scala`
+
+> A specialized JSON renderer that can render Bytes (Chars or Bytes) directly
+> to a [[java.io.Writer]] or [[java.io.OutputStream]]
+>
+> Note that we use an internal `ByteBuilder` to buffer the output internally
+> before sending it to [[out]] in batches. This lets us benefit from the high
+> performance and minimal overhead of `ByteBuilder` in the fast path of
+> pushing characters, and avoid the synchronization/polymorphism overhead of
+> [[out]] on the fast path. Most [[out]]s would also have performance
+> benefits from receiving data in batches, rather than byte by byte.
+
+```scala
+class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
+                      (out: T,
+                       indent: Int = -1,
+                       escapeUnicode: Boolean = false) extends JsVisitor[T, T]
+```
+
+```scala
+def flushByteBuilder() = ...
+```
+
+```scala
+def flushBuffer() = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def visitJsonableObject(length: Int, index: Int) = ...
+```
+
+```scala
+def visitNull(index: Int) = ...
+```
+
+```scala
+def visitFalse(index: Int) = ...
+```
+
+```scala
+def visitTrue(index: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+def visitNonNullString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+final def renderIndent() = ...
+```
+
+```scala
+object BaseByteRenderer
+```
+
+#### `BaseCharRenderer.scala`
+
+> A specialized JSON renderer that can render Chars (Chars or Bytes) directly
+> to a [[java.io.Writer]] or [[java.io.OutputStream]]
+>
+> Note that we use an internal `CharBuilder` to buffer the output internally
+> before sending it to [[out]] in batches. This lets us benefit from the high
+> performance and minimal overhead of `CharBuilder` in the fast path of
+> pushing characters, and avoid the synchronization/polymorphism overhead of
+> [[out]] on the fast path. Most [[out]]s would also have performance
+> benefits from receiving data in batches, rather than char by char.
+
+```scala
+class BaseCharRenderer[T <: upickle.core.CharOps.Output]
+                      (out: T,
+                       indent: Int = -1,
+                       escapeUnicode: Boolean = false) extends JsVisitor[T, T]
+```
+
+```scala
+def flushCharBuilder() = ...
+```
+
+```scala
+def flushBuffer() = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def visitJsonableObject(length: Int, index: Int) = ...
+```
+
+```scala
+def visitNull(index: Int) = ...
+```
+
+```scala
+def visitFalse(index: Int) = ...
+```
+
+```scala
+def visitTrue(index: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+def visitNonNullString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+final def renderIndent() = ...
+```
+
+```scala
+object BaseCharRenderer
+```
+
+#### `ByteParser.scala`
+
+> A specialized JSON parse that can parse Bytes (Chars or Bytes), sending
+> method calls to the given [[upickle.core.Visitor]].
+>
+> Generally has a lot of tricks for performance: e.g. having duplicate
+> implementations for nested v.s. top-level parsing, using an `ByteBuilder`
+> to construct the `CharSequences` that `visitString` requires, etc.
+
+```scala
+abstract class ByteParser[J] extends upickle.core.BufferingByteParser
+```
+
+> A fast-path to check whether an index can be safely accessed, before calling
+> [[getByteUnsafe]]. Together, it is similar to calling [[getByteSafe]], except
+> this returns the new safeIndex which the caller can then use to call
+> [[getByteUnsafe]] multiple times before needing to call this again.
+
+```scala
+def requestUntilOrThrow(j: Int): Unit = ...
+```
+
+```scala
+def checkSafeIndex(j: Int): Int = ...
+```
+
+```scala
+override def getByteSafe(i: Int): Byte = ...
+```
+
+> Parse the JSON document into a single JSON value.
+>
+> The parser considers documents like '333', 'true', and '"foo"' to be
+> valid, as well as more traditional documents like [1,2,3,4,5]. However,
+> multiple top-level objects are not allowed.
+
+```scala
+final def parse(facade: Visitor[_, J]): J = ...
+```
+
+```scala
+def visitFloat64StringPartsWithWrapper(facade: Visitor[_, J],
+                                         decIndex: Int,
+                                         expIndex: Int,
+                                         i: Int,
+                                         j: Int) = ...
+```
+
+```scala
+def reject(j: Int): PartialFunction[Throwable, Nothing] = ...
+```
+
+```scala
+def dieWithFailureMessage(i: Int, state: Int) = ...
+```
+
+```scala
+def failIfNotData(state: Int, i: Int) = ...
+```
+
+```scala
+def tryCloseCollection(stackHead: ObjArrVisitor[_, J], stackTail: List[ObjArrVisitor[_, J]], i: Int) = ...
+```
+
+```scala
+def collectionEndFor(stackHead: ObjArrVisitor[_, _]) = ...
+```
+
+```scala
+def parseStringToOutputBuilder(i: Int, k: Int) = ...
+```
+
+```scala
+def visitString(i: Int, s: CharSequence, stackHead: ObjArrVisitor[_, J]) = ...
+```
+
+```scala
+def visitStringKey(i: Int, s: CharSequence, stackHead: ObjArrVisitor[_, J]) = ...
+```
+
+#### `CharParser.scala`
+
+> A specialized JSON parse that can parse Chars (Chars or Bytes), sending
+> method calls to the given [[upickle.core.Visitor]].
+>
+> Generally has a lot of tricks for performance: e.g. having duplicate
+> implementations for nested v.s. top-level parsing, using an `CharBuilder`
+> to construct the `CharSequences` that `visitString` requires, etc.
+
+```scala
+abstract class CharParser[J] extends upickle.core.BufferingCharParser
+```
+
+> A fast-path to check whether an index can be safely accessed, before calling
+> [[getCharUnsafe]]. Together, it is similar to calling [[getCharSafe]], except
+> this returns the new safeIndex which the caller can then use to call
+> [[getCharUnsafe]] multiple times before needing to call this again.
+
+```scala
+def requestUntilOrThrow(j: Int): Unit = ...
+```
+
+```scala
+def checkSafeIndex(j: Int): Int = ...
+```
+
+```scala
+override def getCharSafe(i: Int): Char = ...
+```
+
+> Parse the JSON document into a single JSON value.
+>
+> The parser considers documents like '333', 'true', and '"foo"' to be
+> valid, as well as more traditional documents like [1,2,3,4,5]. However,
+> multiple top-level objects are not allowed.
+
+```scala
+final def parse(facade: Visitor[_, J]): J = ...
+```
+
+```scala
+def visitFloat64StringPartsWithWrapper(facade: Visitor[_, J],
+                                         decIndex: Int,
+                                         expIndex: Int,
+                                         i: Int,
+                                         j: Int) = ...
+```
+
+```scala
+def reject(j: Int): PartialFunction[Throwable, Nothing] = ...
+```
+
+```scala
+def dieWithFailureMessage(i: Int, state: Int) = ...
+```
+
+```scala
+def failIfNotData(state: Int, i: Int) = ...
+```
+
+```scala
+def tryCloseCollection(stackHead: ObjArrVisitor[_, J], stackTail: List[ObjArrVisitor[_, J]], i: Int) = ...
+```
+
+```scala
+def collectionEndFor(stackHead: ObjArrVisitor[_, _]) = ...
+```
+
+```scala
+def parseStringToOutputBuilder(i: Int, k: Int) = ...
+```
+
+```scala
+def visitString(i: Int, s: CharSequence, stackHead: ObjArrVisitor[_, J]) = ...
+```
+
+```scala
+def visitStringKey(i: Int, s: CharSequence, stackHead: ObjArrVisitor[_, J]) = ...
+```
+
+#### `DoubleToDecimalByte.java`
+
+> This class exposes a method to render a {@code double} as a string.
+>
+> @author Raffaello Giulietti
+
+```java
+final public class DoubleToDecimalByte
+```
+
+```java
+static final int P = ...
+```
+
+```java
+static final int Q_MIN = ...
+```
+
+```java
+static final int Q_MAX = ...
+```
+
+```java
+static final int E_MIN = ...
+```
+
+```java
+static final int E_MAX = ...
+```
+
+```java
+static final long C_TINY = ...
+```
+
+```java
+static final int K_MIN = ...
+```
+
+```java
+static final int K_MAX = ...
+```
+
+```java
+static final int H = ...
+```
+
+```java
+public final int MAX_CHARS = ...
+```
+
+> Returns a string rendering of the {@code double} argument.
+>
+> <p>The characters of the result are all drawn from the ASCII set.
+> <ul>
+> <li> Any NaN, whether quiet or signaling, is rendered as
+> {@code "NaN"}, regardless of the sign bit.
+> <li> The infinities +∞ and -∞ are rendered as
+> {@code "Infinity"} and {@code "-Infinity"}, respectively.
+> <li> The positive and negative zeroes are rendered as
+> {@code "0.0"} and {@code "-0.0"}, respectively.
+> <li> A finite negative {@code v} is rendered as the sign
+> '{@code -}' followed by the rendering of the magnitude -{@code v}.
+> <li> A finite positive {@code v} is rendered in two stages:
+> <ul>
+> <li> <em>Selection of a decimal</em>: A well-defined
+> decimal <i>d</i><sub><code>v</code></sub> is selected
+> to represent {@code v}.
+> <li> <em>Formatting as a string</em>: The decimal
+> <i>d</i><sub><code>v</code></sub> is formatted as a string,
+> either in plain or in computerized scientific notation,
+> depending on its value.
+> </ul>
+> </ul>
+>
+> <p>A <em>decimal</em> is a number of the form
+> <i>d</i>×10<sup><i>i</i></sup>
+> for some (unique) integers <i>d</i> > 0 and <i>i</i> such that
+> <i>d</i> is not a multiple of 10.
+> These integers are the <em>significand</em> and
+> the <em>exponent</em>, respectively, of the decimal.
+> The <em>length</em> of the decimal is the (unique)
+> integer <i>n</i> meeting
+> 10<sup><i>n</i>-1</sup> ≤ <i>d</i> < 10<sup><i>n</i></sup>.
+>
+> <p>The decimal <i>d</i><sub><code>v</code></sub>
+> for a finite positive {@code v} is defined as follows:
+> <ul>
+> <li>Let <i>R</i> be the set of all decimals that round to {@code v}
+> according to the usual round-to-closest rule of
+> IEEE 754 floating-point arithmetic.
+> <li>Let <i>m</i> be the minimal length over all decimals in <i>R</i>.
+> <li>When <i>m</i> ≥ 2, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length <i>m</i>.
+> Otherwise, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length 1 or 2.
+> <li>Define <i>d</i><sub><code>v</code></sub> as
+> the decimal in <i>T</i> that is closest to {@code v}.
+> Or if there are two such decimals in <i>T</i>,
+> select the one with the even significand (there is exactly one).
+> </ul>
+>
+> <p>The (uniquely) selected decimal <i>d</i><sub><code>v</code></sub>
+> is then formatted.
+>
+> <p>Let <i>d</i>, <i>i</i> and <i>n</i> be the significand, exponent and
+> length of <i>d</i><sub><code>v</code></sub>, respectively.
+> Further, let <i>e</i> = <i>n</i> + <i>i</i> - 1 and let
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>
+> be the usual decimal expansion of the significand.
+> Note that <i>d</i><sub>1</sub> ≠ 0 ≠ <i>d</i><sub><i>n</i></sub>.
+> <ul>
+> <li>Case -3 ≤ <i>e</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <code>0.0</code>…<code>0</code><!--
+> --><i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>,
+> where there are exactly -(<i>n</i> + <i>i</i>) zeroes between
+> the decimal point and <i>d</i><sub>1</sub>.
+> For example, 123 × 10<sup>-4</sup> is formatted as
+> {@code 0.0123}.
+> <li>Case 0 ≤ <i>e</i> < 7:
+> <ul>
+> <li>Subcase <i>i</i> ≥ 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub><!--
+> --><code>0</code>…<code>0.0</code>,
+> where there are exactly <i>i</i> zeroes
+> between <i>d</i><sub><i>n</i></sub> and the decimal point.
+> For example, 123 × 10<sup>2</sup> is formatted as
+> {@code 12300.0}.
+> <li>Subcase <i>i</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i></sub>.<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i>+1</sub>…<!--
+> --><i>d</i><sub><i>n</i></sub>.
+> There are exactly -<i>i</i> digits to the right of
+> the decimal point.
+> For example, 123 × 10<sup>-1</sup> is formatted as
+> {@code 12.3}.
+> </ul>
+> <li>Case <i>e</i> < -3 or <i>e</i> ≥ 7:
+> computerized scientific notation is used to format
+> <i>d</i><sub><code>v</code></sub>.
+> Here <i>e</i> is formatted as by {@link Integer#toString(int)}.
+> <ul>
+> <li>Subcase <i>n</i> = 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.0E</code><i>e</i>.
+> For example, 1 × 10<sup>23</sup> is formatted as
+> {@code 1.0E23}.
+> <li>Subcase <i>n</i> > 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.</code><i>d</i><sub>2</sub><!--
+> -->…<i>d</i><sub><i>n</i></sub><code>E</code><i>e</i>.
+> For example, 123 × 10<sup>-21</sup> is formatted as
+> {@code 1.23E-19}.
+> </ul>
+> </ul>
+>
+> @param v the {@code double} to be rendered.
+> @return a string rendering of the argument.
+
+```java
+public static int toString(byte[] bytes, int index, double v)
+```
+
+#### `DoubleToDecimalChar.java`
+
+> This class exposes a method to render a {@code double} as a string.
+>
+> @author Raffaello Giulietti
+
+```java
+final public class DoubleToDecimalChar
+```
+
+```java
+static final int P = ...
+```
+
+```java
+static final int Q_MIN = ...
+```
+
+```java
+static final int Q_MAX = ...
+```
+
+```java
+static final int E_MIN = ...
+```
+
+```java
+static final int E_MAX = ...
+```
+
+```java
+static final long C_TINY = ...
+```
+
+```java
+static final int K_MIN = ...
+```
+
+```java
+static final int K_MAX = ...
+```
+
+```java
+static final int H = ...
+```
+
+```java
+public final int MAX_CHARS = ...
+```
+
+> Returns a string rendering of the {@code double} argument.
+>
+> <p>The characters of the result are all drawn from the ASCII set.
+> <ul>
+> <li> Any NaN, whether quiet or signaling, is rendered as
+> {@code "NaN"}, regardless of the sign bit.
+> <li> The infinities +∞ and -∞ are rendered as
+> {@code "Infinity"} and {@code "-Infinity"}, respectively.
+> <li> The positive and negative zeroes are rendered as
+> {@code "0.0"} and {@code "-0.0"}, respectively.
+> <li> A finite negative {@code v} is rendered as the sign
+> '{@code -}' followed by the rendering of the magnitude -{@code v}.
+> <li> A finite positive {@code v} is rendered in two stages:
+> <ul>
+> <li> <em>Selection of a decimal</em>: A well-defined
+> decimal <i>d</i><sub><code>v</code></sub> is selected
+> to represent {@code v}.
+> <li> <em>Formatting as a string</em>: The decimal
+> <i>d</i><sub><code>v</code></sub> is formatted as a string,
+> either in plain or in computerized scientific notation,
+> depending on its value.
+> </ul>
+> </ul>
+>
+> <p>A <em>decimal</em> is a number of the form
+> <i>d</i>×10<sup><i>i</i></sup>
+> for some (unique) integers <i>d</i> > 0 and <i>i</i> such that
+> <i>d</i> is not a multiple of 10.
+> These integers are the <em>significand</em> and
+> the <em>exponent</em>, respectively, of the decimal.
+> The <em>length</em> of the decimal is the (unique)
+> integer <i>n</i> meeting
+> 10<sup><i>n</i>-1</sup> ≤ <i>d</i> < 10<sup><i>n</i></sup>.
+>
+> <p>The decimal <i>d</i><sub><code>v</code></sub>
+> for a finite positive {@code v} is defined as follows:
+> <ul>
+> <li>Let <i>R</i> be the set of all decimals that round to {@code v}
+> according to the usual round-to-closest rule of
+> IEEE 754 floating-point arithmetic.
+> <li>Let <i>m</i> be the minimal length over all decimals in <i>R</i>.
+> <li>When <i>m</i> ≥ 2, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length <i>m</i>.
+> Otherwise, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length 1 or 2.
+> <li>Define <i>d</i><sub><code>v</code></sub> as
+> the decimal in <i>T</i> that is closest to {@code v}.
+> Or if there are two such decimals in <i>T</i>,
+> select the one with the even significand (there is exactly one).
+> </ul>
+>
+> <p>The (uniquely) selected decimal <i>d</i><sub><code>v</code></sub>
+> is then formatted.
+>
+> <p>Let <i>d</i>, <i>i</i> and <i>n</i> be the significand, exponent and
+> length of <i>d</i><sub><code>v</code></sub>, respectively.
+> Further, let <i>e</i> = <i>n</i> + <i>i</i> - 1 and let
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>
+> be the usual decimal expansion of the significand.
+> Note that <i>d</i><sub>1</sub> ≠ 0 ≠ <i>d</i><sub><i>n</i></sub>.
+> <ul>
+> <li>Case -3 ≤ <i>e</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <code>0.0</code>…<code>0</code><!--
+> --><i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>,
+> where there are exactly -(<i>n</i> + <i>i</i>) zeroes between
+> the decimal point and <i>d</i><sub>1</sub>.
+> For example, 123 × 10<sup>-4</sup> is formatted as
+> {@code 0.0123}.
+> <li>Case 0 ≤ <i>e</i> < 7:
+> <ul>
+> <li>Subcase <i>i</i> ≥ 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub><!--
+> --><code>0</code>…<code>0.0</code>,
+> where there are exactly <i>i</i> zeroes
+> between <i>d</i><sub><i>n</i></sub> and the decimal point.
+> For example, 123 × 10<sup>2</sup> is formatted as
+> {@code 12300.0}.
+> <li>Subcase <i>i</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i></sub>.<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i>+1</sub>…<!--
+> --><i>d</i><sub><i>n</i></sub>.
+> There are exactly -<i>i</i> digits to the right of
+> the decimal point.
+> For example, 123 × 10<sup>-1</sup> is formatted as
+> {@code 12.3}.
+> </ul>
+> <li>Case <i>e</i> < -3 or <i>e</i> ≥ 7:
+> computerized scientific notation is used to format
+> <i>d</i><sub><code>v</code></sub>.
+> Here <i>e</i> is formatted as by {@link Integer#toString(int)}.
+> <ul>
+> <li>Subcase <i>n</i> = 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.0E</code><i>e</i>.
+> For example, 1 × 10<sup>23</sup> is formatted as
+> {@code 1.0E23}.
+> <li>Subcase <i>n</i> > 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.</code><i>d</i><sub>2</sub><!--
+> -->…<i>d</i><sub><i>n</i></sub><code>E</code><i>e</i>.
+> For example, 123 × 10<sup>-21</sup> is formatted as
+> {@code 1.23E-19}.
+> </ul>
+> </ul>
+>
+> @param v the {@code double} to be rendered.
+> @return a string rendering of the argument.
+
+```java
+public static int toString(char[] bytes, int index, double v)
+```
+
+#### `FloatToDecimalByte.java`
+
+> This class exposes a method to render a {@code float} as a string.
+>
+> @author Raffaello Giulietti
+
+```java
+final public class FloatToDecimalByte
+```
+
+```java
+static final int P = ...
+```
+
+```java
+static final int Q_MIN = ...
+```
+
+```java
+static final int Q_MAX = ...
+```
+
+```java
+static final int E_MIN = ...
+```
+
+```java
+static final int E_MAX = ...
+```
+
+```java
+static final int C_TINY = ...
+```
+
+```java
+static final int K_MIN = ...
+```
+
+```java
+static final int K_MAX = ...
+```
+
+```java
+static final int H = ...
+```
+
+```java
+public final int MAX_CHARS = ...
+```
+
+> Returns a string rendering of the {@code float} argument.
+>
+> <p>The characters of the result are all drawn from the ASCII set.
+> <ul>
+> <li> Any NaN, whether quiet or signaling, is rendered as
+> {@code "NaN"}, regardless of the sign bit.
+> <li> The infinities +∞ and -∞ are rendered as
+> {@code "Infinity"} and {@code "-Infinity"}, respectively.
+> <li> The positive and negative zeroes are rendered as
+> {@code "0.0"} and {@code "-0.0"}, respectively.
+> <li> A finite negative {@code v} is rendered as the sign
+> '{@code -}' followed by the rendering of the magnitude -{@code v}.
+> <li> A finite positive {@code v} is rendered in two stages:
+> <ul>
+> <li> <em>Selection of a decimal</em>: A well-defined
+> decimal <i>d</i><sub><code>v</code></sub> is selected
+> to represent {@code v}.
+> <li> <em>Formatting as a string</em>: The decimal
+> <i>d</i><sub><code>v</code></sub> is formatted as a string,
+> either in plain or in computerized scientific notation,
+> depending on its value.
+> </ul>
+> </ul>
+>
+> <p>A <em>decimal</em> is a number of the form
+> <i>d</i>×10<sup><i>i</i></sup>
+> for some (unique) integers <i>d</i> > 0 and <i>i</i> such that
+> <i>d</i> is not a multiple of 10.
+> These integers are the <em>significand</em> and
+> the <em>exponent</em>, respectively, of the decimal.
+> The <em>length</em> of the decimal is the (unique)
+> integer <i>n</i> meeting
+> 10<sup><i>n</i>-1</sup> ≤ <i>d</i> < 10<sup><i>n</i></sup>.
+>
+> <p>The decimal <i>d</i><sub><code>v</code></sub>
+> for a finite positive {@code v} is defined as follows:
+> <ul>
+> <li>Let <i>R</i> be the set of all decimals that round to {@code v}
+> according to the usual round-to-closest rule of
+> IEEE 754 floating-point arithmetic.
+> <li>Let <i>m</i> be the minimal length over all decimals in <i>R</i>.
+> <li>When <i>m</i> ≥ 2, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length <i>m</i>.
+> Otherwise, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length 1 or 2.
+> <li>Define <i>d</i><sub><code>v</code></sub> as
+> the decimal in <i>T</i> that is closest to {@code v}.
+> Or if there are two such decimals in <i>T</i>,
+> select the one with the even significand (there is exactly one).
+> </ul>
+>
+> <p>The (uniquely) selected decimal <i>d</i><sub><code>v</code></sub>
+> is then formatted.
+>
+> <p>Let <i>d</i>, <i>i</i> and <i>n</i> be the significand, exponent and
+> length of <i>d</i><sub><code>v</code></sub>, respectively.
+> Further, let <i>e</i> = <i>n</i> + <i>i</i> - 1 and let
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>
+> be the usual decimal expansion of the significand.
+> Note that <i>d</i><sub>1</sub> ≠ 0 ≠ <i>d</i><sub><i>n</i></sub>.
+> <ul>
+> <li>Case -3 ≤ <i>e</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <code>0.0</code>…<code>0</code><!--
+> --><i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>,
+> where there are exactly -(<i>n</i> + <i>i</i>) zeroes between
+> the decimal point and <i>d</i><sub>1</sub>.
+> For example, 123 × 10<sup>-4</sup> is formatted as
+> {@code 0.0123}.
+> <li>Case 0 ≤ <i>e</i> < 7:
+> <ul>
+> <li>Subcase <i>i</i> ≥ 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub><!--
+> --><code>0</code>…<code>0.0</code>,
+> where there are exactly <i>i</i> zeroes
+> between <i>d</i><sub><i>n</i></sub> and the decimal point.
+> For example, 123 × 10<sup>2</sup> is formatted as
+> {@code 12300.0}.
+> <li>Subcase <i>i</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i></sub>.<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i>+1</sub>…<!--
+> --><i>d</i><sub><i>n</i></sub>.
+> There are exactly -<i>i</i> digits to the right of
+> the decimal point.
+> For example, 123 × 10<sup>-1</sup> is formatted as
+> {@code 12.3}.
+> </ul>
+> <li>Case <i>e</i> < -3 or <i>e</i> ≥ 7:
+> computerized scientific notation is used to format
+> <i>d</i><sub><code>v</code></sub>.
+> Here <i>e</i> is formatted as by {@link Integer#toString(int)}.
+> <ul>
+> <li>Subcase <i>n</i> = 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.0E</code><i>e</i>.
+> For example, 1 × 10<sup>23</sup> is formatted as
+> {@code 1.0E23}.
+> <li>Subcase <i>n</i> > 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.</code><i>d</i><sub>2</sub><!--
+> -->…<i>d</i><sub><i>n</i></sub><code>E</code><i>e</i>.
+> For example, 123 × 10<sup>-21</sup> is formatted as
+> {@code 1.23E-19}.
+> </ul>
+> </ul>
+>
+> @param  v the {@code float} to be rendered.
+> @return a string rendering of the argument.
+
+```java
+public static int toString(byte[] bytes, int offset, float v)
+```
+
+#### `FloatToDecimalChar.java`
+
+> This class exposes a method to render a {@code float} as a string.
+>
+> @author Raffaello Giulietti
+
+```java
+final public class FloatToDecimalChar
+```
+
+```java
+static final int P = ...
+```
+
+```java
+static final int Q_MIN = ...
+```
+
+```java
+static final int Q_MAX = ...
+```
+
+```java
+static final int E_MIN = ...
+```
+
+```java
+static final int E_MAX = ...
+```
+
+```java
+static final int C_TINY = ...
+```
+
+```java
+static final int K_MIN = ...
+```
+
+```java
+static final int K_MAX = ...
+```
+
+```java
+static final int H = ...
+```
+
+```java
+public final int MAX_CHARS = ...
+```
+
+> Returns a string rendering of the {@code float} argument.
+>
+> <p>The characters of the result are all drawn from the ASCII set.
+> <ul>
+> <li> Any NaN, whether quiet or signaling, is rendered as
+> {@code "NaN"}, regardless of the sign bit.
+> <li> The infinities +∞ and -∞ are rendered as
+> {@code "Infinity"} and {@code "-Infinity"}, respectively.
+> <li> The positive and negative zeroes are rendered as
+> {@code "0.0"} and {@code "-0.0"}, respectively.
+> <li> A finite negative {@code v} is rendered as the sign
+> '{@code -}' followed by the rendering of the magnitude -{@code v}.
+> <li> A finite positive {@code v} is rendered in two stages:
+> <ul>
+> <li> <em>Selection of a decimal</em>: A well-defined
+> decimal <i>d</i><sub><code>v</code></sub> is selected
+> to represent {@code v}.
+> <li> <em>Formatting as a string</em>: The decimal
+> <i>d</i><sub><code>v</code></sub> is formatted as a string,
+> either in plain or in computerized scientific notation,
+> depending on its value.
+> </ul>
+> </ul>
+>
+> <p>A <em>decimal</em> is a number of the form
+> <i>d</i>×10<sup><i>i</i></sup>
+> for some (unique) integers <i>d</i> > 0 and <i>i</i> such that
+> <i>d</i> is not a multiple of 10.
+> These integers are the <em>significand</em> and
+> the <em>exponent</em>, respectively, of the decimal.
+> The <em>length</em> of the decimal is the (unique)
+> integer <i>n</i> meeting
+> 10<sup><i>n</i>-1</sup> ≤ <i>d</i> < 10<sup><i>n</i></sup>.
+>
+> <p>The decimal <i>d</i><sub><code>v</code></sub>
+> for a finite positive {@code v} is defined as follows:
+> <ul>
+> <li>Let <i>R</i> be the set of all decimals that round to {@code v}
+> according to the usual round-to-closest rule of
+> IEEE 754 floating-point arithmetic.
+> <li>Let <i>m</i> be the minimal length over all decimals in <i>R</i>.
+> <li>When <i>m</i> ≥ 2, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length <i>m</i>.
+> Otherwise, let <i>T</i> be the set of all decimals
+> in <i>R</i> with length 1 or 2.
+> <li>Define <i>d</i><sub><code>v</code></sub> as
+> the decimal in <i>T</i> that is closest to {@code v}.
+> Or if there are two such decimals in <i>T</i>,
+> select the one with the even significand (there is exactly one).
+> </ul>
+>
+> <p>The (uniquely) selected decimal <i>d</i><sub><code>v</code></sub>
+> is then formatted.
+>
+> <p>Let <i>d</i>, <i>i</i> and <i>n</i> be the significand, exponent and
+> length of <i>d</i><sub><code>v</code></sub>, respectively.
+> Further, let <i>e</i> = <i>n</i> + <i>i</i> - 1 and let
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>
+> be the usual decimal expansion of the significand.
+> Note that <i>d</i><sub>1</sub> ≠ 0 ≠ <i>d</i><sub><i>n</i></sub>.
+> <ul>
+> <li>Case -3 ≤ <i>e</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <code>0.0</code>…<code>0</code><!--
+> --><i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub>,
+> where there are exactly -(<i>n</i> + <i>i</i>) zeroes between
+> the decimal point and <i>d</i><sub>1</sub>.
+> For example, 123 × 10<sup>-4</sup> is formatted as
+> {@code 0.0123}.
+> <li>Case 0 ≤ <i>e</i> < 7:
+> <ul>
+> <li>Subcase <i>i</i> ≥ 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<i>d</i><sub><i>n</i></sub><!--
+> --><code>0</code>…<code>0.0</code>,
+> where there are exactly <i>i</i> zeroes
+> between <i>d</i><sub><i>n</i></sub> and the decimal point.
+> For example, 123 × 10<sup>2</sup> is formatted as
+> {@code 12300.0}.
+> <li>Subcase <i>i</i> < 0:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub>…<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i></sub>.<!--
+> --><i>d</i><sub><i>n</i>+<i>i</i>+1</sub>…<!--
+> --><i>d</i><sub><i>n</i></sub>.
+> There are exactly -<i>i</i> digits to the right of
+> the decimal point.
+> For example, 123 × 10<sup>-1</sup> is formatted as
+> {@code 12.3}.
+> </ul>
+> <li>Case <i>e</i> < -3 or <i>e</i> ≥ 7:
+> computerized scientific notation is used to format
+> <i>d</i><sub><code>v</code></sub>.
+> Here <i>e</i> is formatted as by {@link Integer#toString(int)}.
+> <ul>
+> <li>Subcase <i>n</i> = 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.0E</code><i>e</i>.
+> For example, 1 × 10<sup>23</sup> is formatted as
+> {@code 1.0E23}.
+> <li>Subcase <i>n</i> > 1:
+> <i>d</i><sub><code>v</code></sub> is formatted as
+> <i>d</i><sub>1</sub><code>.</code><i>d</i><sub>2</sub><!--
+> -->…<i>d</i><sub><i>n</i></sub><code>E</code><i>e</i>.
+> For example, 123 × 10<sup>-21</sup> is formatted as
+> {@code 1.23E-19}.
+> </ul>
+> </ul>
+>
+> @param  v the {@code float} to be rendered.
+> @return a string rendering of the argument.
+
+```java
+public static int toString(char[] bytes, int offset, float v)
+```
+
+#### `ujson/AstTransformer.scala`
+
+```scala
+trait AstTransformer[I] extends ujson.Transformer[I] with JsVisitor[I, I]
+```
+
+```scala
+def apply(t: Readable): I = ...
+```
+
+```scala
+def transformArray[T](f: Visitor[_, T], items: Iterable[I]) = ...
+```
+
+```scala
+def transformObject[T](f: Visitor[_, T], items: Iterable[(String, I)]) = ...
+```
+
+```scala
+class AstObjVisitor[T](build: T => I)
+```
+
+```scala
+def subVisitor = ...
+```
+
+```scala
+def visitKey(index: Int) = ...
+```
+
+```scala
+def visitKeyValue(s: Any): Unit = ...
+```
+
+```scala
+def visitValue(v: I, index: Int): Unit = ...
+```
+
+```scala
+def visitEnd(index: Int) = ...
+```
+
+```scala
+class AstArrVisitor[T[_]](build: T[I] => I)
+```
+
+```scala
+def subVisitor = ...
+```
+
+```scala
+def visitValue(v: I, index: Int): Unit = ...
+```
+
+```scala
+def visitEnd(index: Int) = ...
+```
+
+#### `ujson/ByteArrayParser.scala`
+
+> Basic ByteBuffer parser.
+>
+> This assumes that the provided ByteBuffer is ready to be read. The
+> user is responsible for any necessary flipping/resetting of the
+> ByteBuffer before parsing.
+>
+> The parser makes absolute calls to the ByteBuffer, which will not
+> update its own mutable position fields.
+
+```scala
+final class ByteArrayParser[J](src: Array[Byte]) extends ByteParser[J]
+```
+
+```scala
+val srcLength = ...
+```
+
+```scala
+override def growBuffer(until: Int): Unit = ...
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int) = ...
+```
+
+```scala
+object ByteArrayParser extends Transformer[Array[Byte]]
+```
+
+```scala
+def transform[T](j: Array[Byte], f: Visitor[_, T]) = ...
+```
+
+#### `ujson/ByteBufferParser.scala`
+
+> Basic ByteBuffer parser.
+>
+> This assumes that the provided ByteBuffer is ready to be read. The
+> user is responsible for any necessary flipping/resetting of the
+> ByteBuffer before parsing.
+>
+> The parser makes absolute calls to the ByteBuffer, which will not
+> update its own mutable position fields.
+
+```scala
+final class ByteBufferParser[J](src: ByteBuffer) extends ByteParser[J]
+```
+
+```scala
+override def growBuffer(until: Int): Unit = ...
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int) = ...
+```
+
+```scala
+object ByteBufferParser extends Transformer[ByteBuffer]
+```
+
+```scala
+def transform[T](j: ByteBuffer, f: Visitor[_, T]) = ...
+```
+
+#### `ujson/CharSequenceParser.scala`
+
+```scala
+object CharSequenceParser extends Transformer[CharSequence]
+```
+
+```scala
+def transform[T](j: CharSequence, f: Visitor[_, T]) = ...
+```
+
+#### `ujson/Exceptions.scala`
+
+```scala
+sealed trait ParsingFailedException extends Exception
+```
+
+```scala
+case class ParseException(clue: String, index: Int)
+```
+
+```scala
+case class IncompleteParseException(msg: String)
+```
+
+#### `ujson/IndexedValue.scala`
+
+> A version of [[ujson.Value]] that keeps the index positions of the various AST
+> nodes it is constructing. Usually not necessary, but sometimes useful if you
+> want to work with an AST but still provide source-index error positions if
+> something goes wrong
+
+```scala
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "upickle after 3.1.4")
+sealed trait IndexedValue
+```
+
+```scala
+def index: Int
+```
+
+```scala
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "upickle after 3.1.4")
+object IndexedValue extends Transformer[IndexedValue]
+```
+
+```scala
+case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue
+```
+
+```scala
+case class Obj(index: Int, value0: (java.lang.CharSequence, IndexedValue)*) extends IndexedValue
+```
+
+```scala
+case class Arr(index: Int, value: IndexedValue*) extends IndexedValue
+```
+
+```scala
+case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends IndexedValue
+```
+
+```scala
+case class NumRaw(index: Int, d: Double) extends IndexedValue
+```
+
+```scala
+case class False(index: Int) extends IndexedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class True(index: Int) extends IndexedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class Null(index: Int) extends IndexedValue
+```
+
+```scala
+def value = ...
+```
+
+```scala
+def transform[T](j: IndexedValue, f: Visitor[_, T]): T = ...
+```
+
+```scala
+object Builder extends JsVisitor[IndexedValue, IndexedValue]
+```
+
+```scala
+def visitArray(length: Int, i: Int) = ...
+```
+
+```scala
+def visitJsonableObject(length: Int, i: Int) = ...
+```
+
+```scala
+def visitNull(i: Int) = ...
+```
+
+```scala
+def visitFalse(i: Int) = ...
+```
+
+```scala
+def visitTrue(i: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, i: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, i: Int) = ...
+```
+
+#### `ujson/InputStreamParser.scala`
+
+> Parser that reads in bytes from an InputStream, buffering them in memory
+> until a `reset` call discards them.
+>
+> Mostly the same as ByteArrayParser, except using an UberBuffer rather than
+> reading directly from an Array[Byte].
+>
+> Generally not meant to be used directly, but via [[ujson.Readable.fromReadable]]
+
+```scala
+final class InputStreamParser[J](val inputStream: java.io.InputStream,
+                                 val minBufferStartSize: Int = BufferingInputStreamParser.defaultMinBufferStartSize,
+                                 val maxBufferStartSize: Int = BufferingInputStreamParser.defaultMaxBufferStartSize)
+```
+
+```scala
+object InputStreamParser extends Transformer[java.io.InputStream]
+```
+
+```scala
+def transform[T](j: java.io.InputStream, f: Visitor[_, T]) = ...
+```
+
+#### `ujson/JsVisitor.scala`
+
+> A [[Visitor]] specialized to work with JSON types. Forwards the
+> not-JSON-related methods to their JSON equivalents.
+
+```scala
+trait JsVisitor[-T, +J] extends Visitor[T, J]
+```
+
+```scala
+def visitFloat64(d: Double, index: Int): J = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int): J = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int): J = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int): J = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int): J = ...
+```
+
+```scala
+def visitFloat64String(s: String, index: Int): J = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int): J = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int): J = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int): J = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int) = ...
+```
+
+```scala
+def visitJsonableObject(length: Int, index: Int): ObjVisitor[T, J]
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+#### `ujson/MathUtils.java`
+
+> This class exposes package private utilities for other classes.
+> Thus, all methods are assumed to be invoked with correct arguments,
+> so these are not checked at all.
+>
+> @author Raffaello Giulietti
+
+```java
+final class MathUtils
+```
+
+```java
+static final int K_MIN = ...
+```
+
+```java
+static final int K_MAX = ...
+```
+
+```java
+static final int H = ...
+```
+
+> Returns 10<sup>{@code e}</sup>.
+>
+> @param e The exponent which must meet
+> 0 ≤ {@code e} ≤ {@link #H}.
+> @return 10<sup>{@code e}</sup>.
+
+```java
+static long pow10(int e)
+```
+
+> Returns the unique integer <i>k</i> such that
+> 10<sup><i>k</i></sup> ≤ 2<sup>{@code e}</sup>
+> < 10<sup><i>k</i>+1</sup>.
+> <p>
+> The result is correct when |{@code e}| ≤ 5_456_721.
+> Otherwise the result is undefined.
+>
+> @param e The exponent of 2, which should meet
+> |{@code e}| ≤ 5_456_721 for safe results.
+> @return ⌊log<sub>10</sub>2<sup>{@code e}</sup>⌋.
+
+```java
+static int flog10pow2(int e)
+```
+
+> Returns the unique integer <i>k</i> such that
+> 10<sup><i>k</i></sup> ≤ 3/4 · 2<sup>{@code e}</sup>
+> < 10<sup><i>k</i>+1</sup>.
+> <p>
+> The result is correct when
+> -2_956_395 ≤ {@code e} ≤ 2_500_325.
+> Otherwise the result is undefined.
+>
+> @param e The exponent of 2, which should meet
+> -2_956_395 ≤ {@code e} ≤ 2_500_325 for safe results.
+> @return ⌊log<sub>10</sub>(3/4 ·
+> 2<sup>{@code e}</sup>)⌋.
+
+```java
+static int flog10threeQuartersPow2(int e)
+```
+
+> Returns the unique integer <i>k</i> such that
+> 2<sup><i>k</i></sup> ≤ 10<sup>{@code e}</sup>
+> < 2<sup><i>k</i>+1</sup>.
+> <p>
+> The result is correct when |{@code e}| ≤ 1_838_394.
+> Otherwise the result is undefined.
+>
+> @param e The exponent of 10, which should meet
+> |{@code e}| ≤ 1_838_394 for safe results.
+> @return ⌊log<sub>2</sub>10<sup>{@code e}</sup>⌋.
+
+```java
+static int flog2pow10(int e)
+```
+
+> Let 10<sup>-{@code k}</sup> = <i>β</i> 2<sup><i>r</i></sup>,
+> for the unique pair of integer <i>r</i> and real <i>β</i> meeting
+> 2<sup>125</sup> ≤ <i>β</i> < 2<sup>126</sup>.
+> Further, let <i>g</i> = ⌊<i>β</i>⌋ + 1.
+> Split <i>g</i> into the higher 63 bits <i>g</i><sub>1</sub> and
+> the lower 63 bits <i>g</i><sub>0</sub>. Thus,
+> <i>g</i><sub>1</sub> =
+> ⌊<i>g</i> 2<sup>-63</sup>⌋
+> and
+> <i>g</i><sub>0</sub> =
+> <i>g</i> - <i>g</i><sub>1</sub> 2<sup>63</sup>.
+> <p>
+> This method returns <i>g</i><sub>1</sub> while
+> {@link #g0(int)} returns <i>g</i><sub>0</sub>.
+> <p>
+> If needed, the exponent <i>r</i> can be computed as
+> <i>r</i> = {@code flog2pow10(-k)} - 125 (see {@link #flog2pow10(int)}).
+>
+> @param k The exponent of 10, which must meet
+> {@link #K_MIN} ≤ {@code e} ≤ {@link #K_MAX}.
+> @return <i>g</i><sub>1</sub> as described above.
+
+```java
+static long g1(int k)
+```
+
+> Returns <i>g</i><sub>0</sub> as described in
+> {@link #g1(int)}.
+>
+> @param k The exponent of 10, which must meet
+> {@link #K_MIN} ≤ {@code e} ≤ {@link #K_MAX}.
+> @return <i>g</i><sub>0</sub> as described in
+> {@link #g1(int)}.
+
+```java
+static long g0(int k)
+```
+
+```java
+static long multiplyHigh(long x, long y)
+```
+
+#### `ujson/Readable.scala`
+
+```scala
+trait Readable
+```
+
+```scala
+def transform[T](f: Visitor[_, T]): T
+```
+
+```scala
+object Readable extends ReadableLowPri with Transformer[Readable]
+```
+
+```scala
+def transform[T](j: ujson.Readable, f: upickle.core.Visitor[_, T]): T = ...
+```
+
+```scala
+case class fromTransformer[T](t: T, w: Transformer[T]) extends Readable
+```
+
+```scala
+def transform[T](f: Visitor[_, T]): T = ...
+```
+
+```scala
+implicit def fromString(s: String): fromTransformer[String] = ...
+```
+
+```scala
+implicit def fromCharSequence(s: CharSequence): fromTransformer[CharSequence] = ...
+```
+
+```scala
+implicit def fromPath(s: java.nio.file.Path): Readable = ...
+```
+
+```scala
+implicit def fromFile(s: java.io.File): Readable = ...
+```
+
+```scala
+implicit def fromByteBuffer(s: ByteBuffer): fromTransformer[ByteBuffer] = ...
+```
+
+```scala
+implicit def fromByteArray(s: Array[Byte]): fromTransformer[Array[Byte]] = ...
+```
+
+```scala
+trait ReadableLowPri
+```
+
+```scala
+implicit def fromReadable[T](s: T)(implicit conv: T => geny.Readable): Readable = ...
+```
+
+#### `ujson/Renderer.scala`
+
+```scala
+case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
+```
+
+```scala
+case class StringRenderer(indent: Int = -1,
+                          escapeUnicode: Boolean = false)
+```
+
+```scala
+case class Renderer(out: java.io.Writer,
+                    indent: Int = -1,
+                    escapeUnicode: Boolean = false)
+```
+
+#### `ujson/StringParser.scala`
+
+```scala
+object StringParser extends Transformer[String]
+```
+
+```scala
+def transform[T](j: String, f: Visitor[_, T]) = ...
+```
+
+#### `ujson/Transformer.scala`
+
+```scala
+trait Transformer[I] extends upickle.core.Transformer[I]
+```
+
+```scala
+def transformable[T](j: I) = ...
+```
+
+#### `ujson/Value.scala`
+
+```scala
+sealed trait Value extends Readable with geny.Writable
+```
+
+```scala
+override def httpContentType = ...
+```
+
+```scala
+def value: Any
+```
+
+> Returns the `String` value of this [[Value]], fails if it is not
+> a [[ujson.Str]]
+
+```scala
+def str = ...
+```
+
+> Returns an Optional `String` value of this [[Value]] in case this [[Value]] is a 'String'.
+
+```scala
+def strOpt = ...
+```
+
+> Returns the key/value map of this [[Value]], fails if it is not
+> a [[ujson.Obj]]
+
+```scala
+def obj = ...
+```
+
+> Returns an Optional key/value map of this [[Value]] in case this [[Value]] is a 'Obj'.
+
+```scala
+def objOpt = ...
+```
+
+> Returns the elements of this [[Value]], fails if it is not
+> a [[ujson.Arr]]
+
+```scala
+def arr = ...
+```
+
+> Returns The optional elements of this [[Value]] in case this [[Value]] is a 'Arr'.
+
+```scala
+def arrOpt = ...
+```
+
+> Returns the `Double` value of this [[Value]], fails if it is not
+> a [[ujson.Num]]
+
+```scala
+def num = ...
+```
+
+> Returns an Option[Double] in case this [[Value]] is a 'Num'.
+
+```scala
+def numOpt = ...
+```
+
+> Returns the `Boolean` value of this [[Value]], fails if it is not
+> a [[ujson.Bool]]
+
+```scala
+def bool = ...
+```
+
+> Returns an Optional `Boolean` value of this [[Value]] in case this [[Value]] is a 'Bool'.
+
+```scala
+def boolOpt = ...
+```
+
+> Returns true if the value of this [[Value]] is ujson.Null, false otherwise
+
+```scala
+def isNull = ...
+```
+
+```scala
+def apply(s: Value.Selector): Value = ...
+```
+
+```scala
+def update(s: Value.Selector, v: Value): Unit = ...
+```
+
+> Update a value in-place. Takes an `Int` or a `String`, through the
+> implicitly-constructe [[Value.Selector]] type.
+>
+> We cannot just overload `update` on `s: Int` and `s: String` because
+> of type inference problems in Scala 2.11.
+
+```scala
+def update(s: Value.Selector, f: Value => Value): Unit = ...
+```
+
+```scala
+def transform[T](f: Visitor[_, T]) = ...
+```
+
+```scala
+override def toString = ...
+```
+
+```scala
+def render(indent: Int = -1, escapeUnicode: Boolean = false) = ...
+```
+
+```scala
+def writeBytesTo(out: java.io.OutputStream, indent: Int = -1, escapeUnicode: Boolean = false): Unit = ...
+```
+
+```scala
+def writeBytesTo(out: java.io.OutputStream): Unit = ...
+```
+
+> A very small, very simple JSON AST that uPickle uses as part of its
+> serialization process. A common standard between the Jawn AST (which
+> we don't use so we don't pull in the bulk of Spire) and the Javascript
+> JSON AST.
+
+```scala
+object Value extends AstTransformer[Value]
+```
+
+```scala
+type Value = ...
+```
+
+```scala
+sealed trait Selector
+```
+
+```scala
+def apply(x: Value): Value
+```
+
+```scala
+def update(x: Value, y: Value): Unit
+```
+
+```scala
+object Selector
+```
+
+```scala
+implicit class IntSelector(i: Int) extends Selector
+```
+
+```scala
+def apply(x: Value): Value = ...
+```
+
+```scala
+def update(x: Value, y: Value) = ...
+```
+
+```scala
+implicit class StringSelector(i: String) extends Selector
+```
+
+```scala
+def apply(x: Value): Value = ...
+```
+
+```scala
+def update(x: Value, y: Value) = ...
+```
+
+```scala
+implicit def JsonableSeq[T](items: IterableOnce[T])
+```
+
+```scala
+implicit def JsonableDict[T](items: IterableOnce[(String, T)])
+```
+
+```scala
+implicit def JsonableBoolean(i: Boolean): Bool = ...
+```
+
+```scala
+implicit def JsonableByte(i: Byte): Num = ...
+```
+
+```scala
+implicit def JsonableShort(i: Short): Num = ...
+```
+
+```scala
+implicit def JsonableInt(i: Int): Num = ...
+```
+
+```scala
+implicit def JsonableLong(i: Long): Str = ...
+```
+
+```scala
+implicit def JsonableFloat(i: Float): Num = ...
+```
+
+```scala
+implicit def JsonableDouble(i: Double): Num = ...
+```
+
+```scala
+implicit def JsonableNull(i: Null): Null.type = ...
+```
+
+```scala
+implicit def JsonableString(s: CharSequence): Str = ...
+```
+
+```scala
+def transform[T](j: Value, f: Visitor[_, T]): T = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def visitJsonableObject(length: Int, index: Int) = ...
+```
+
+```scala
+def visitNull(index: Int) = ...
+```
+
+```scala
+def visitFalse(index: Int) = ...
+```
+
+```scala
+def visitTrue(index: Int) = ...
+```
+
+```scala
+override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int) = ...
+```
+
+> Thrown when uPickle tries to convert a JSON blob into a given data
+> structure but fails because part the blob is invalid
+>
+> @param data The section of the JSON blob that uPickle tried to convert.
+> This could be the entire blob, or it could be some subtree.
+> @param msg Human-readable text saying what went wrong
+
+```scala
+case class InvalidData(data: Value, msg: String)
+```
+
+```scala
+case class Str(value: String) extends Value
+```
+
+```scala
+case class Obj(value: LinkedHashMap[String, Value]) extends Value
+```
+
+```scala
+object Obj
+```
+
+```scala
+implicit def from(items: IterableOnce[(String, Value)]): Obj = ...
+```
+
+```scala
+def apply[V](item: (String, V),
+               items: (String, Value)*)(implicit conv: V => Value): Obj = ...
+```
+
+```scala
+def apply(): Obj = ...
+```
+
+```scala
+case class Arr(value: mutable.ArrayBuffer[Value]) extends Value
+```
+
+```scala
+object Arr
+```
+
+```scala
+implicit def from[T](items: IterableOnce[T])(implicit conv: T => Value): Arr = ...
+```
+
+```scala
+def apply(items: Value*): Arr = ...
+```
+
+```scala
+case class Num(value: Double) extends Value
+```
+
+```scala
+sealed abstract class Bool extends Value
+```
+
+```scala
+def value: Boolean
+```
+
+```scala
+object Bool
+```
+
+```scala
+def apply(value: Boolean): Bool = ...
+```
+
+```scala
+def unapply(bool: Bool): Some[Boolean] = ...
+```
+
+```scala
+case object False extends Bool
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case object True extends Bool
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case object Null extends Value
+```
+
+```scala
+def value = ...
+```
+
+#### `ujson/package.scala`
+
+```scala
+package object ujson
+```
+
+```scala
+def transform[T](t: Readable,
+                   v: upickle.core.Visitor[_, T],
+                   sortKeys: Boolean = false): T = ...
+```
+
+### `com.lihaoyi:upack_3:3.3.1`
+
+Source: https://repo1.maven.org/maven2/com/lihaoyi/upack_3/3.3.1/upack_3-3.3.1-sources.jar
+
+#### `upack/Msg.scala`
+
+> In-memory representation of the MessagePack data model
+>
+> test - https://msgpack.org/index.html
+>
+> Note that we do not model all the fine details of the MessagePack format
+> in this type; fixed and variable length strings/maps/arrays are all
+> modelled using the same [[Str]]/[[Obj]]/[[Arr]] types, and the various
+> sized integers are all collapsed into [[Int32]]/[[Int64]]/[[UInt64]]. The
+> appropriately sized versions are written out when the message is serialized
+> to bytes.
+
+```scala
+sealed trait Msg extends Readable with geny.Writable
+```
+
+```scala
+override def httpContentType = ...
+```
+
+```scala
+def transform[T](f: Visitor[_, T]) = ...
+```
+
+> Returns the `String` value of this [[Msg]], fails if it is not
+> a [[upack.Str]]
+
+```scala
+def binary = ...
+```
+
+> Returns the `String` value of this [[Msg]], fails if it is not
+> a [[upack.Str]]
+
+```scala
+def str = ...
+```
+
+> Returns the key/value map of this [[Msg]], fails if it is not
+> a [[upack.Obj]]
+
+```scala
+def obj = ...
+```
+
+> Returns the elements of this [[Msg]], fails if it is not
+> a [[upack.Arr]]
+
+```scala
+def arr = ...
+```
+
+> Returns the `Double` value of this [[Msg]], fails if it is not
+> a [[upack.Int32]], [[upack.Int64]] or [[upack.UInt64]]
+
+```scala
+def int32 = ...
+```
+
+> Returns the `Double` value of this [[Msg]], fails if it is not
+> a [[upack.Int32]], [[upack.Int64]] or [[upack.UInt64]]
+
+```scala
+def int64 = ...
+```
+
+> Returns the `Boolean` value of this [[Msg]], fails if it is not
+> a [[upack.Bool]]
+
+```scala
+def bool = ...
+```
+
+> Returns true if the value of this [[Msg]] is ujson.Null, false otherwise
+
+```scala
+def isNull = ...
+```
+
+```scala
+def writeBytesTo(out: java.io.OutputStream): Unit = ...
+```
+
+```scala
+case object Null extends Msg
+```
+
+```scala
+case object True extends Bool
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case object False extends Bool
+```
+
+```scala
+def value = ...
+```
+
+```scala
+case class Int32(value: Int) extends Msg
+```
+
+```scala
+case class Int64(value: Long) extends Msg
+```
+
+```scala
+case class UInt64(value: Long) extends Msg
+```
+
+```scala
+case class Float32(value: Float) extends Msg
+```
+
+```scala
+case class Float64(value: Double) extends Msg
+```
+
+```scala
+case class Str(value: String) extends Msg
+```
+
+```scala
+case class Binary(value: Array[Byte]) extends Msg
+```
+
+```scala
+case class Arr(value: mutable.ArrayBuffer[Msg]) extends Msg
+```
+
+```scala
+object Arr
+```
+
+```scala
+def apply(items: Msg*): Arr = ...
+```
+
+```scala
+case class Obj(value: LinkedHashMap[Msg, Msg]) extends Msg
+```
+
+```scala
+object Obj
+```
+
+```scala
+def apply(item: (Msg, Msg),
+            items: (Msg, Msg)*): Obj = ...
+```
+
+```scala
+def apply(): Obj = ...
+```
+
+```scala
+case class Ext(tag: Byte, data: Array[Byte]) extends Msg
+```
+
+```scala
+sealed abstract class Bool extends Msg
+```
+
+```scala
+def value: Boolean
+```
+
+```scala
+object Bool
+```
+
+```scala
+def apply(value: Boolean): Bool = ...
+```
+
+```scala
+def unapply(bool: Bool): Some[Boolean] = ...
+```
+
+```scala
+object Msg extends MsgVisitor[Msg, Msg]
+```
+
+> Thrown when uPickle tries to convert a JSON blob into a given data
+> structure but fails because part the blob is invalid
+>
+> @param data The section of the JSON blob that uPickle tried to convert.
+> This could be the entire blob, or it could be some subtree.
+> @param msg Human-readable text saying what went wrong
+
+```scala
+case class InvalidData(data: Msg, msg: String)
+```
+
+```scala
+sealed trait Selector
+```
+
+```scala
+def apply(x: Msg): Msg
+```
+
+```scala
+def update(x: Msg, y: Msg): Unit
+```
+
+```scala
+object Selector
+```
+
+```scala
+implicit class IntSelector(i: Int) extends Selector
+```
+
+```scala
+def apply(x: Msg): Msg = ...
+```
+
+```scala
+def update(x: Msg, y: Msg) = ...
+```
+
+```scala
+implicit class StringSelector(i: String) extends Selector
+```
+
+```scala
+def apply(x: Msg): Msg = ...
+```
+
+```scala
+def update(x: Msg, y: Msg) = ...
+```
+
+```scala
+implicit class MsgSelector(i: Msg) extends Selector
+```
+
+```scala
+def apply(x: Msg): Msg = ...
+```
+
+```scala
+def update(x: Msg, y: Msg) = ...
+```
+
+```scala
+def transform[T](j: Msg, f: Visitor[_, T]): T = ...
+```
+
+```scala
+def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+def visitNull(index: Int) = ...
+```
+
+```scala
+def visitFalse(index: Int) = ...
+```
+
+```scala
+def visitTrue(index: Int) = ...
+```
+
+```scala
+def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int) = ...
+```
+
+#### `upack/MsgPackKeys.scala`
+
+```scala
+object MsgPackKeys
+```
+
+```scala
+final val PositiveFixInt = ...
+```
+
+```scala
+final val FixMapMask = ...
+```
+
+```scala
+final val FixMap = ...
+```
+
+```scala
+final val FixArrMask = ...
+```
+
+```scala
+final val FixArray = ...
+```
+
+```scala
+final val FixStrMask = ...
+```
+
+```scala
+final val FixStr = ...
+```
+
+```scala
+final val Nil = ...
+```
+
+```scala
+final val False = ...
+```
+
+```scala
+final val True = ...
+```
+
+```scala
+final val Bin8 = ...
+```
+
+```scala
+final val Bin16 = ...
+```
+
+```scala
+final val Bin32 = ...
+```
+
+```scala
+final val Ext8 = ...
+```
+
+```scala
+final val Ext16 = ...
+```
+
+```scala
+final val Ext32 = ...
+```
+
+```scala
+final val Float32 = ...
+```
+
+```scala
+final val Float64 = ...
+```
+
+```scala
+final val UInt8 = ...
+```
+
+```scala
+final val UInt16 = ...
+```
+
+```scala
+final val UInt32 = ...
+```
+
+```scala
+final val UInt64 = ...
+```
+
+```scala
+final val Int8 = ...
+```
+
+```scala
+final val Int16 = ...
+```
+
+```scala
+final val Int32 = ...
+```
+
+```scala
+final val Int64 = ...
+```
+
+```scala
+final val FixExt1 = ...
+```
+
+```scala
+final val FixExt2 = ...
+```
+
+```scala
+final val FixExt4 = ...
+```
+
+```scala
+final val FixExt8 = ...
+```
+
+```scala
+final val FixExt16 = ...
+```
+
+```scala
+final val Str8 = ...
+```
+
+```scala
+final val Str16 = ...
+```
+
+```scala
+final val Str32 = ...
+```
+
+```scala
+final val Array16 = ...
+```
+
+```scala
+final val Array32 = ...
+```
+
+```scala
+final val Map16 = ...
+```
+
+```scala
+final val Map32 = ...
+```
+
+#### `upack/MsgPackReader.scala`
+
+```scala
+class MsgPackReader(input0: Array[Byte]) extends BaseMsgPackReader
+```
+
+```scala
+val srcLength = ...
+```
+
+```scala
+override def growBuffer(until: Int): Unit = ...
+```
+
+```scala
+def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int) = ...
+```
+
+```scala
+class InputStreamMsgPackReader(val inputStream: java.io.InputStream,
+                               val minBufferStartSize: Int = BufferingInputStreamParser.defaultMinBufferStartSize,
+                               val maxBufferStartSize: Int = BufferingInputStreamParser.defaultMaxBufferStartSize)
+```
+
+```scala
+abstract class BaseMsgPackReader extends upickle.core.BufferingByteParser
+```
+
+```scala
+def getIndex = ...
+```
+
+```scala
+def parse[T](visitor: Visitor[_, T]): T = ...
+```
+
+```scala
+def parseExt[T](n: Int, visitor: Visitor[_, T]) = ...
+```
+
+```scala
+def parseStr[T](n: Int, visitor: Visitor[_, T]) = ...
+```
+
+```scala
+def parseBin[T](n: Int, visitor: Visitor[_, T]) = ...
+```
+
+```scala
+def parseMap[T](n: Int, visitor: Visitor[_, T]) = ...
+```
+
+```scala
+def parseArray[T](n: Int, visitor: Visitor[_, T]) = ...
+```
+
+```scala
+def parseUInt8(i: Int) = ...
+```
+
+```scala
+def parseUInt16(i: Int) = ...
+```
+
+```scala
+def parseUInt32(i: Int) = ...
+```
+
+```scala
+def parseUInt64(i: Int) = ...
+```
+
+#### `upack/MsgPackWriter.scala`
+
+```scala
+class MsgPackWriter[T <: java.io.OutputStream](out: T = new ByteArrayOutputStream())
+```
+
+```scala
+def flushElemBuilder() = ...
+```
+
+```scala
+override def visitArray(length: Int, index: Int) = ...
+```
+
+```scala
+override def visitObject(length: Int, jsonableKeys: Boolean, index: Int) = ...
+```
+
+```scala
+override def visitNull(index: Int) = ...
+```
+
+```scala
+override def visitFalse(index: Int) = ...
+```
+
+```scala
+override def visitTrue(index: Int) = ...
+```
+
+```scala
+override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+```scala
+override def visitFloat64(d: Double, index: Int) = ...
+```
+
+```scala
+override def visitFloat32(d: Float, index: Int) = ...
+```
+
+```scala
+override def visitInt32(i: Int, index: Int) = ...
+```
+
+```scala
+override def visitInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitUInt64(i: Long, index: Int) = ...
+```
+
+```scala
+override def visitString(s: CharSequence, index: Int) = ...
+```
+
+```scala
+override def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def writeUInt8(arr: Array[Byte], length: Int, i: Int): Unit = ...
+```
+
+```scala
+def writeUInt16(arr: Array[Byte], length: Int, i: Int): Unit = ...
+```
+
+```scala
+def writeUInt32(arr: Array[Byte], length: Int, i: Int): Unit = ...
+```
+
+```scala
+def writeUInt64(arr: Array[Byte], length: Int, i: Long): Unit = ...
+```
+
+```scala
+def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = ...
+```
+
+```scala
+def visitChar(s: Char, index: Int) = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def writeUInt8(i: Int): Unit = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def writeUInt16(i: Int): Unit = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def writeUInt32(i: Int): Unit = ...
+```
+
+```scala
+  @deprecated("Not used, kept for binary compatibility")
+def writeUInt64(i: Long): Unit = ...
+```
+
+#### `upack/MsgVisitor.scala`
+
+> A [[Visitor]] specialized to work with msgpack types. Forwards the
+> not-msgpack-related methods to their msgpack equivalents.
+
+```scala
+trait MsgVisitor[-T, +J] extends Visitor[T, J]
+```
+
+```scala
+def visitFloat64String(s: String, index: Int) = ...
+```
+
+```scala
+def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = ...
+```
+
+#### `upack/Readable.scala`
+
+```scala
+trait Readable
+```
+
+```scala
+def transform[T](f: Visitor[_, T]): T
+```
+
+```scala
+object Readable extends ReadableLowPri
+```
+
+```scala
+implicit def fromByteArray(s: Array[Byte]): Readable = ...
+```
+
+```scala
+trait ReadableLowPri
+```
+
+```scala
+implicit def fromReadable[T](s: T)(implicit conv: T => geny.Readable): Readable = ...
+```
+
+#### `upack/package.scala`
+
+```scala
+package object upack
+```
+
+```scala
+def transform[T](t: Readable, v: upickle.core.Visitor[_, T]) = ...
+```
+
+> Read the given MessagePack input into a MessagePack struct
+
+```scala
+def read(s: Readable, trace: Boolean = false): Msg = ...
+```
+
+```scala
+def copy(t: Msg): Msg = ...
+```
+
+> Write the given MessagePack struct as a binary
+
+```scala
+def write(t: Msg): Array[Byte] = ...
+```
+
+> Write the given MessagePack struct as a binary to the given OutputStream
+
+```scala
+def writeTo(t: Msg, out: java.io.OutputStream): Unit = ...
+```
+
+```scala
+def writeToByteArray(t: Msg) = ...
+```
+
+> Parse the given MessagePack input, failing if it is invalid
+
+```scala
+def validate(s: Readable): Unit = ...
+```
+

--- a/mif/src/Logger.scala
+++ b/mif/src/Logger.scala
@@ -1,31 +1,59 @@
 package in.avimit.dev.mif
 
 import scala.io.AnsiColor._
+import scala.util.DynamicVariable
 
 class FatalException(message: String) extends Exception(message)
 
-object Logger {
+enum LogLevel(val priority: Int):
+  case Trace extends LogLevel(0)
+  case Info extends LogLevel(1)
+  case Warn extends LogLevel(2)
+  case Error extends LogLevel(3)
+  case Quiet extends LogLevel(4)
 
-  val level = sys.env.getOrElse("LOG_LEVEL", "INFO") match
-    case "TRACE" | "trace" => 0
-    case "INFO" | "info"   => 1
-    case "WARN" | "warn"   => 2
-    case "ERROR" | "error" => 3
-    case _                 => 4
+object LogLevel:
+  def fromString(value: String): LogLevel =
+    value.trim.toLowerCase match
+      case "trace"            => Trace
+      case "info"             => Info
+      case "warn" | "warning" => Warn
+      case "error"            => Error
+      case "quiet" | "off"    => Quiet
+      case _                  => Quiet
 
-  def trace(message: String) =
-    if level <= 0 then println(s"${BOLD}${BLUE}[TRACE]${RESET} ${message}")
+object Logger:
+  private val envLevel =
+    LogLevel.fromString(sys.env.getOrElse("LOG_LEVEL", "INFO"))
+  // Scoped, thread-local override used by tests and other temporary callers.
+  private val overrideLevel = DynamicVariable[Option[LogLevel]](None)
 
-  def info(message: String) =
-    if level <= 1 then println(s"${BOLD}${GREEN}[INFO]${RESET} ${message}")
+  def withLevel[T](level: LogLevel)(body: => T): T =
+    overrideLevel.withValue(Some(level))(body)
 
-  def warning(message: String) =
-    if level <= 2 then println(s"${BOLD}${YELLOW}[WARNING]${RESET} ${message}")
+  private def currentLevel: LogLevel =
+    overrideLevel.value.getOrElse(envLevel)
 
-  def error(message: String) =
-    if level <= 3 then println(s"${BOLD}${RED}[ERROR]${RESET} ${message}")
+  private def enabled(level: LogLevel): Boolean =
+    currentLevel.priority <= level.priority
 
-  def fatal(message: String) =
-    println(s"${BOLD}${RED}[FATAL]${RESET} ${message}")
+  def trace(message: String): Unit =
+    if enabled(LogLevel.Trace) then
+      println(s"${BOLD}${BLUE}[TRACE]${RESET} ${message}")
+
+  def info(message: String): Unit =
+    if enabled(LogLevel.Info) then
+      println(s"${BOLD}${GREEN}[INFO]${RESET} ${message}")
+
+  def warning(message: String): Unit =
+    if enabled(LogLevel.Warn) then
+      println(s"${BOLD}${YELLOW}[WARNING]${RESET} ${message}")
+
+  def error(message: String): Unit =
+    if enabled(LogLevel.Error) then
+      println(s"${BOLD}${RED}[ERROR]${RESET} ${message}")
+
+  def fatal(message: String): Nothing =
+    if enabled(LogLevel.Error) then
+      println(s"${BOLD}${RED}[FATAL]${RESET} ${message}")
     throw new FatalException(message)
-}

--- a/mif/src/MavenRepositoryStore.scala
+++ b/mif/src/MavenRepositoryStore.scala
@@ -1,0 +1,196 @@
+package in.avimit.dev.mif
+
+import scala.util.control.NonFatal
+import scalasql.*
+import scalasql.SqliteDialect.*
+import scalasql.core.SqlStr.SqlStringSyntax
+
+case class MavenRepositoryFile(
+    mavenPath: String,
+    sha256: String,
+    size: Long,
+    contentType: String,
+    upstreamUrl: Option[String]
+)
+
+case class CachedArtifact[T[_]](
+    mavenPath: T[String],
+    sha256: T[String],
+    size: T[Long],
+    contentType: T[String],
+    upstreamUrl: T[Option[String]],
+    firstSeenAtMillis: T[Long],
+    updatedAtMillis: T[Long]
+)
+object CachedArtifact extends Table[CachedArtifact]:
+  override def tableName = "cached_artifacts"
+
+object MavenRepositoryStore:
+  val MetadataDirectoryName = ".mif"
+  val DatabaseFileName = "repository.sqlite"
+
+  def databasePath(repoDir: os.Path): os.Path =
+    repoDir / MetadataDirectoryName / DatabaseFileName
+
+  def open(repoDir: os.Path): Either[String, MavenRepositoryStore] =
+    val dbPath = databasePath(repoDir)
+    try
+      os.makeDir.all(dbPath / os.up)
+      val dataSource = new org.sqlite.SQLiteDataSource()
+      dataSource.setUrl(s"jdbc:sqlite:${dbPath}")
+      val store = MavenRepositoryStore(
+        dbPath,
+        new scalasql.DbClient.DataSource(
+          dataSource,
+          config = new scalasql.Config {}
+        )
+      )
+
+      store.initialize().map(_ => store)
+    catch
+      case NonFatal(e) =>
+        Left(
+          s"Failed to open Maven repository database ${dbPath}: ${e.getMessage}"
+        )
+
+class MavenRepositoryStore private (
+    val dbPath: os.Path,
+    dbClient: scalasql.DbClient
+) extends AutoCloseable:
+  private val storeLock = new AnyRef
+
+  private def initialize(): Either[String, Unit] =
+    storeLock.synchronized:
+      try
+        dbClient.transaction: db =>
+          db.updateRaw("PRAGMA busy_timeout = 5000")
+          db.updateRaw(
+            """
+              |CREATE TABLE IF NOT EXISTS cached_artifacts (
+              |  maven_path TEXT PRIMARY KEY NOT NULL,
+              |  sha256 TEXT NOT NULL,
+              |  size INTEGER NOT NULL CHECK(size >= 0),
+              |  content_type TEXT NOT NULL,
+              |  upstream_url TEXT,
+              |  first_seen_at_millis INTEGER NOT NULL,
+              |  updated_at_millis INTEGER NOT NULL
+              |)
+              |""".stripMargin
+          )
+          ()
+        Right(())
+      catch
+        case NonFatal(e) =>
+          Left(
+            s"Failed to initialize Maven repository database ${dbPath}: ${e.getMessage}"
+          )
+
+  def record(file: MavenRepositoryFile): Either[String, Unit] =
+    storeLock.synchronized:
+      try
+        val now = System.currentTimeMillis()
+        dbClient.transaction: db =>
+          db.updateRaw("PRAGMA busy_timeout = 5000")
+          db.updateSql(sql"""
+            INSERT INTO cached_artifacts (
+              maven_path,
+              sha256,
+              size,
+              content_type,
+              upstream_url,
+              first_seen_at_millis,
+              updated_at_millis
+            )
+            VALUES (
+              ${file.mavenPath},
+              ${file.sha256},
+              ${file.size},
+              ${file.contentType},
+              ${file.upstreamUrl},
+              ${now},
+              ${now}
+            )
+            ON CONFLICT(maven_path) DO UPDATE SET
+              sha256 = excluded.sha256,
+              size = excluded.size,
+              content_type = excluded.content_type,
+              upstream_url = COALESCE(
+                excluded.upstream_url,
+                cached_artifacts.upstream_url
+              ),
+              updated_at_millis = excluded.updated_at_millis
+          """)
+          ()
+        Right(())
+      catch
+        case NonFatal(e) =>
+          Left(
+            s"Failed to update Maven repository database ${dbPath}: ${e.getMessage}"
+          )
+
+  def find(mavenPath: String): Either[String, Option[MavenRepositoryFile]] =
+    storeLock.synchronized:
+      try
+        val files = dbClient.transaction: db =>
+          db.updateRaw("PRAGMA busy_timeout = 5000")
+          db.run(
+            CachedArtifact.select
+              .filter(_.mavenPath === mavenPath)
+              .map(file =>
+                (
+                  file.mavenPath,
+                  file.sha256,
+                  file.size,
+                  file.contentType,
+                  file.upstreamUrl
+                )
+              )
+          )
+
+        Right(files.headOption.map(fromRepositoryFileTuple))
+      catch
+        case NonFatal(e) =>
+          Left(
+            s"Failed to read Maven repository database ${dbPath}: ${e.getMessage}"
+          )
+
+  def snapshot(): Either[String, Seq[MavenRepositoryFile]] =
+    storeLock.synchronized:
+      try
+        val files = dbClient.transaction: db =>
+          db.updateRaw("PRAGMA busy_timeout = 5000")
+          db.run(
+            CachedArtifact.select
+              .sortBy(_.mavenPath)
+              .asc
+              .map(file =>
+                (
+                  file.mavenPath,
+                  file.sha256,
+                  file.size,
+                  file.contentType,
+                  file.upstreamUrl
+                )
+              )
+          )
+
+        Right(files.map(fromRepositoryFileTuple))
+      catch
+        case NonFatal(e) =>
+          Left(
+            s"Failed to read Maven repository database ${dbPath}: ${e.getMessage}"
+          )
+
+  private def fromRepositoryFileTuple(
+      tuple: (String, String, Long, String, Option[String])
+  ): MavenRepositoryFile =
+    val (mavenPath, sha256, size, contentType, upstreamUrl) = tuple
+    MavenRepositoryFile(
+      mavenPath = mavenPath,
+      sha256 = sha256,
+      size = size,
+      contentType = contentType,
+      upstreamUrl = upstreamUrl
+    )
+
+  def close(): Unit = ()

--- a/mif/src/Mif.scala
+++ b/mif/src/Mif.scala
@@ -73,6 +73,52 @@ object MillIvyFetcher {
   }
 
   @main()
+  def relay(
+      @arg(name = "host", doc = "Host interface for the relay server")
+      host: String = "127.0.0.1",
+      @arg(short = 'p', name = "port", doc = "Port for the relay server")
+      port: Int = 8081,
+      @arg(
+        short = 'r',
+        name = "repo-dir",
+        doc = "Local Maven repository directory used to archive files"
+      )
+      repoDir: os.Path = os.pwd / ".mif" / "repository",
+      @arg(
+        short = 'u',
+        name = "upstream",
+        doc = "Maven-compatible upstream base URL"
+      )
+      upstream: String = MavenRelayServer.DefaultUpstream,
+      @arg(
+        name = "proxy",
+        doc =
+          "HTTP proxy URL for upstream requests, for example http://127.0.0.1:8080"
+      )
+      proxy: Option[String] = None,
+      @arg(
+        name = "connect-timeout-seconds",
+        doc = "Timeout for connecting to the upstream repository"
+      )
+      connectTimeoutSeconds: Int = 30,
+      @arg(
+        name = "request-timeout-seconds",
+        doc = "Timeout for each upstream repository request"
+      )
+      requestTimeoutSeconds: Int = 120
+  ): Unit = {
+    val config = MavenRelayConfig(
+      repoDir = repoDir,
+      upstreamBaseUrl = upstream,
+      proxyUrl = proxy,
+      connectTimeoutSeconds = connectTimeoutSeconds,
+      requestTimeoutSeconds = requestTimeoutSeconds
+    )
+
+    MavenRelayServer.run(host, port, config)
+  }
+
+  @main()
   def run(
       @arg(short = 'p', name = "project-dir", doc = "specify project directory")
       projectDir: Option[os.Path],

--- a/mif/src/Relay.scala
+++ b/mif/src/Relay.scala
@@ -1,0 +1,972 @@
+package in.avimit.dev.mif
+
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.security.MessageDigest
+
+import java.util.Base64
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import io.undertow.Undertow
+import io.undertow.server.HttpHandler
+import scala.util.Using
+import scala.util.control.NonFatal
+
+private def catchNonFatal[T](action: => T): Either[String, T] =
+  try Right(action)
+  catch case NonFatal(e) => Left(failureMessage(e))
+
+private def failureMessage(e: Throwable): String =
+  Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+
+private def safeGetFileSize(file: os.Path): Either[String, Long] =
+  catchNonFatal(os.size(file))
+
+object MavenPath:
+  private val invalidSegments = Set("", ".", "..")
+
+  def fromSegments(segments: Seq[String]): Either[String, String] =
+    if segments.isEmpty then Left("missing Maven repository path")
+    else
+      segments.find(isInvalidSegment) match
+        case Some(segment) => Left(s"invalid Maven path segment: ${segment}")
+        case None          => Right(segments.mkString("/"))
+
+  def encodeForUri(mavenPath: String): String =
+    mavenPath
+      .split('/')
+      .map(segment =>
+        URLEncoder
+          .encode(segment, StandardCharsets.UTF_8)
+          .replace("+", "%20")
+      )
+      .mkString("/")
+
+  private def isInvalidSegment(segment: String): Boolean =
+    invalidSegments.contains(segment) || segment.exists(ch =>
+      ch == '/' || ch == '\\' || Character.isISOControl(ch)
+    )
+
+object MavenUpstream:
+  def validate(upstream: String): Either[String, URI] =
+    parseUri(upstream, "upstream URL").flatMap(validateUri(upstream, _))
+
+  private def validateUri(upstream: String, uri: URI): Either[String, URI] =
+    val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT))
+    if !scheme.exists(s => s == "http" || s == "https") then
+      Left(s"upstream URL must use http or https: ${upstream}")
+    else if uri.getRawAuthority == null then
+      Left(s"upstream URL must include a host: ${upstream}")
+    else if uri.getRawUserInfo != null then
+      Left("upstream URL must not contain user info or credentials")
+    else if uri.getRawQuery != null || uri.getRawFragment != null then
+      Left(s"upstream URL must not contain query or fragment: ${upstream}")
+    else
+      val normalized = uri.toASCIIString
+      Right(
+        URI.create(
+          if normalized.endsWith("/") then normalized else s"${normalized}/"
+        )
+      )
+
+  private def parseUri(value: String, label: String): Either[String, URI] =
+    val trimmed = value.trim
+    if trimmed.isEmpty then Left(s"${label} is empty")
+    else
+      try Right(URI.create(trimmed))
+      catch
+        case e: IllegalArgumentException =>
+          Left(s"invalid ${label} ${value}: ${e.getMessage}")
+
+object MavenProxy:
+  def validate(proxyUrl: String): Either[String, URI] =
+    parseUri(proxyUrl, "proxy URL").flatMap(validateUri(proxyUrl, _))
+
+  private def validateUri(proxyUrl: String, uri: URI): Either[String, URI] =
+    val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT))
+    val path = Option(uri.getRawPath).getOrElse("")
+
+    if !scheme.contains("http") then
+      Left(s"proxy URL must use http: ${proxyUrl}")
+    else if uri.getRawAuthority == null || uri.getHost == null then
+      Left(s"proxy URL must include a host: ${proxyUrl}")
+    else if uri.getRawUserInfo != null then
+      Left("proxy URL must not contain user info or credentials")
+    else if uri.getPort <= 0 then
+      Left(s"proxy URL must include an explicit port: ${proxyUrl}")
+    else if path.nonEmpty && path != "/" then
+      Left(s"proxy URL must not contain a path: ${proxyUrl}")
+    else if uri.getRawQuery != null || uri.getRawFragment != null then
+      Left(s"proxy URL must not contain query or fragment: ${proxyUrl}")
+    else Right(uri)
+
+  private def parseUri(value: String, label: String): Either[String, URI] =
+    val trimmed = value.trim
+    if trimmed.isEmpty then Left(s"${label} is empty")
+    else
+      try Right(URI.create(trimmed))
+      catch
+        case e: IllegalArgumentException =>
+          Left(s"invalid ${label} ${value}: ${e.getMessage}")
+
+  def tuple(uri: URI): (String, Int) = uri.getHost -> uri.getPort
+
+object Sha256:
+  def sri(bytes: Array[Byte]): String =
+    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+    s"sha256-${Base64.getEncoder.encodeToString(digest)}"
+
+  def sriFile(file: os.Path): Either[Throwable, String] =
+    try
+      val digest = MessageDigest.getInstance("SHA-256")
+      Using.resource(os.read.inputStream(file)): input =>
+        val buffer = Array.ofDim[Byte](8192)
+        var count = input.read(buffer)
+        while count != -1 do
+          digest.update(buffer, 0, count)
+          count = input.read(buffer)
+
+      Right(s"sha256-${Base64.getEncoder.encodeToString(digest.digest())}")
+    catch case NonFatal(e) => Left(e)
+
+object AtomicFiles:
+
+  def moveIntoPlace(
+      tmp: os.Path,
+      target: os.Path
+  ): Either[Throwable, Unit] =
+    try
+      moveIntoPlaceUnsafe(tmp, target)
+      Right(())
+    catch case NonFatal(e) => Left(e)
+
+  private def moveIntoPlaceUnsafe(
+      tmp: os.Path,
+      target: os.Path
+  ): Unit =
+    try
+      os.move(
+        from = tmp,
+        to = target,
+        replaceExisting = true,
+        atomicMove = true
+      )
+    catch
+      case _: AtomicMoveNotSupportedException =>
+        os.move(from = tmp, to = target, replaceExisting = true)
+
+case class MavenRelayConfig(
+    repoDir: os.Path,
+    upstreamBaseUrl: String,
+    proxyUrl: Option[String] = None,
+    connectTimeoutSeconds: Int,
+    requestTimeoutSeconds: Int
+)
+
+sealed trait RelayBody
+
+object RelayBody:
+  case object Empty extends RelayBody
+  final case class Bytes(bytes: Array[Byte]) extends RelayBody
+  final case class File(path: os.Path) extends RelayBody
+
+case class RelayResponse(
+    statusCode: Int,
+    body: RelayBody,
+    headers: Seq[(String, String)]
+)
+
+private case class UpstreamResponse(
+    statusCode: Int,
+    headers: Map[String, Seq[String]]
+)
+
+object MavenRelayService:
+  def fromConfig(config: MavenRelayConfig): Either[String, MavenRelayService] =
+    for
+      connectTimeout <- timeoutMillis("connect", config.connectTimeoutSeconds)
+      requestTimeout <- timeoutMillis("request", config.requestTimeoutSeconds)
+      upstreamBase <- MavenUpstream.validate(config.upstreamBaseUrl)
+      proxy <- validateProxy(config.proxyUrl)
+      repositoryStore <- MavenRepositoryStore.open(config.repoDir)
+    yield new MavenRelayService(
+      config,
+      upstreamBase,
+      proxy,
+      connectTimeout,
+      requestTimeout,
+      repositoryStore
+    )
+
+  private def validateProxy(
+      proxyUrl: Option[String]
+  ): Either[String, Option[URI]] =
+    proxyUrl match
+      case Some(value) => MavenProxy.validate(value).map(Some(_))
+      case None        => Right(None)
+
+  private def timeoutMillis(label: String, seconds: Int): Either[String, Int] =
+    val millis = seconds.toLong * 1000L
+    if seconds <= 0 then Left(s"${label} timeout must be greater than zero")
+    else if millis > Int.MaxValue then Left(s"${label} timeout is too large")
+    else Right(millis.toInt)
+
+class MavenRelayService private (
+    config: MavenRelayConfig,
+    upstreamBase: URI,
+    proxy: Option[URI],
+    connectTimeoutMillis: Int,
+    requestTimeoutMillis: Int,
+    repositoryStore: MavenRepositoryStore
+) extends AutoCloseable:
+  // Each value is a plain JVM object used only as a monitor for one Maven path.
+  // AnyRef is the common supertype of reference values that support synchronized.
+  private val pathLocks = ConcurrentHashMap[String, AnyRef]()
+  private val upstreamSession = requests.Session(
+    headers = Map(
+      "User-Agent" -> s"mif/${MillIvyFetcher.VERSION}",
+      "Accept" -> "*/*"
+    ),
+    proxy = proxy.map(MavenProxy.tuple).orNull,
+    readTimeout = requestTimeoutMillis,
+    connectTimeout = connectTimeoutMillis,
+    autoDecompress = false,
+    check = false
+  )
+
+  def upstreamBaseUrl: String = upstreamBase.toString
+  def proxyUrl: Option[String] = proxy.map(_.toString)
+  def repositoryDatabasePath: os.Path = repositoryStore.dbPath
+
+  def closeEither(): Either[String, Unit] =
+    val failures = Seq(
+      "upstream HTTP session" -> catchNonFatal(upstreamSession.close()),
+      "repository database" -> catchNonFatal(repositoryStore.close())
+    ).collect:
+      case (resourceLabel, Left(reason)) => s"${resourceLabel}: ${reason}"
+
+    if failures.isEmpty then Right(())
+    else
+      Left(s"Failed to close Maven relay service: ${failures.mkString("; ")}")
+
+  def close(): Unit =
+    closeEither().left.foreach(Logger.warning)
+
+  def handle(method: String, segments: Seq[String]): RelayResponse =
+    MavenPath.fromSegments(segments) match
+      case Left(reason) => textResponse(400, reason)
+      case Right(mavenPath) =>
+        method.toUpperCase(Locale.ROOT) match
+          case "GET"  => handleGetReq(mavenPath)
+          case "HEAD" => handleHeadReq(mavenPath)
+          case method =>
+            throw new AssertionError(
+              s"unreachable: Cask routed unsupported method ${method} to relay handler"
+            )
+
+  private def handleGetReq(mavenPath: String): RelayResponse =
+    pathLock(mavenPath).synchronized:
+      val file = localFile(mavenPath)
+      if os.exists(file) && os.isFile(file) then cachedGet(mavenPath, file)
+      else fetchAndCacheGet(mavenPath, file)
+
+  // A local file alone is not a trusted cache hit. The repository database is
+  // the source of truth, so cached responses must have a DB record and the file
+  // on disk must still match the recorded size and SHA-256. Untrusted files are
+  // deleted and treated as cache misses.
+  private def cachedGet(mavenPath: String, file: os.Path): RelayResponse =
+    repositoryStore.find(mavenPath) match
+      case Left(reason) =>
+        repositoryDatabaseFailure(
+          phase = "read repository database",
+          mavenPath = mavenPath,
+          reason = reason
+        )
+      case Right(None) =>
+        deleteLocalArtifact(
+          mavenPath,
+          file,
+          reason = "Local artifact not recorded"
+        ) match
+          case Left(response) => response
+          case Right(_)       => fetchAndCacheGet(mavenPath, file)
+      case Right(Some(recordedFile)) =>
+        cachedArtifactMatches(mavenPath, file, recordedFile) match
+          case Left(response) => response
+          case Right(false) =>
+            deleteLocalArtifact(
+              mavenPath,
+              file,
+              reason = "Cached artifact does not match repository database"
+            ) match
+              case Left(response) => response
+              case Right(_)       => fetchAndCacheGet(mavenPath, file)
+          case Right(true) =>
+            RelayResponse(
+              statusCode = 200,
+              body = RelayBody.File(file),
+              headers = headersFor(
+                mavenPath,
+                size = Some(recordedFile.size),
+                upstreamHeaders =
+                  Seq("Content-Type" -> recordedFile.contentType)
+              )
+            )
+
+  private def cachedArtifactMatches(
+      mavenPath: String,
+      file: os.Path,
+      recordedFile: MavenRepositoryFile
+  ): Either[RelayResponse, Boolean] =
+    val artifactInfo =
+      for
+        size <- safeGetFileSize(file).left.map: reason =>
+          raiseInternalServerErr(
+            phase = "read cached artifact size",
+            mavenPath = mavenPath,
+            reason = reason
+          )
+        sha256 <- Sha256
+          .sriFile(file)
+          .left
+          .map: cause =>
+            raiseInternalServerErr(
+              phase = "hash cached artifact",
+              mavenPath = mavenPath,
+              reason = failureMessage(cause)
+            )
+      yield (size, sha256)
+
+    artifactInfo.map: (size, sha256) =>
+      size == recordedFile.size && sha256 == recordedFile.sha256
+
+  private def fetchAndCacheGet(
+      mavenPath: String,
+      file: os.Path
+  ): RelayResponse =
+    val parent = file / os.up
+    catchNonFatal(os.makeDir.all(parent)) match
+      case Left(reason) =>
+        raiseInternalServerErr(
+          phase = "create artifact directory",
+          mavenPath = mavenPath,
+          reason = reason
+        )
+      case Right(_) =>
+        withTempArtifactFile(parent, file): tmp =>
+          fetchUpstreamToFile(mavenPath, tmp) match
+            case Left(response) => response
+            case Right(upstreamResponse) =>
+              upstreamGetResponse(mavenPath, file, tmp, upstreamResponse)
+
+  private def withTempArtifactFile(
+      parent: os.Path,
+      file: os.Path
+  )(buildResponse: os.Path => RelayResponse): RelayResponse =
+    val tmp = os.temp(
+      dir = parent,
+      prefix = s".${file.last}.",
+      suffix = ".tmp",
+      deleteOnExit = false
+    )
+    try buildResponse(tmp)
+    finally if os.exists(tmp) then os.remove(tmp)
+
+  private def upstreamGetResponse(
+      mavenPath: String,
+      file: os.Path,
+      tmp: os.Path,
+      upstreamResponse: UpstreamResponse
+  ): RelayResponse =
+    val upstreamHeaders = safeUpstreamHeaders(upstreamResponse)
+
+    if upstreamResponse.statusCode == 200 then
+      cacheSuccessfulGet(mavenPath, file, tmp, upstreamHeaders)
+    else
+      forwardUncachedUpstreamGet(
+        mavenPath,
+        tmp,
+        upstreamResponse.statusCode,
+        upstreamHeaders
+      )
+
+  private def cacheSuccessfulGet(
+      mavenPath: String,
+      file: os.Path,
+      tmp: os.Path,
+      upstreamHeaders: Seq[(String, String)]
+  ): RelayResponse =
+    val artifactInfo =
+      for
+        size <- safeGetFileSize(tmp).left.map: reason =>
+          raiseInternalServerErr(
+            phase = "read downloaded artifact size",
+            mavenPath = mavenPath,
+            reason = reason
+          )
+        sha256 <- Sha256
+          .sriFile(tmp)
+          .left
+          .map: cause =>
+            raiseInternalServerErr(
+              phase = "hash downloaded artifact",
+              mavenPath = mavenPath,
+              reason = failureMessage(cause)
+            )
+        _ <- AtomicFiles
+          .moveIntoPlace(tmp, file)
+          .left
+          .map: cause =>
+            raiseInternalServerErr(
+              phase = "persist artifact",
+              mavenPath = mavenPath,
+              reason = failureMessage(cause)
+            )
+      yield (size, sha256)
+
+    artifactInfo match
+      case Left(response) => response
+      case Right((size, sha256)) =>
+        val contentType = contentTypeFromHeaders(upstreamHeaders, mavenPath)
+        record(
+          mavenPath,
+          sha256,
+          size,
+          contentType,
+          upstreamUrl = Some(upstreamUrl(mavenPath))
+        ) match
+          case Left(reason) =>
+            repositoryDatabaseFailure(
+              phase = "update repository database",
+              mavenPath = mavenPath,
+              reason = reason
+            )
+          case Right(_) =>
+            Logger.info(s"Archived ${mavenPath}")
+            RelayResponse(
+              statusCode = 200,
+              body = RelayBody.File(file),
+              headers = headersFor(
+                mavenPath,
+                size = Some(size),
+                upstreamHeaders = upstreamHeaders
+              )
+            )
+
+  private def forwardUncachedUpstreamGet(
+      mavenPath: String,
+      tmp: os.Path,
+      status: Int,
+      upstreamHeaders: Seq[(String, String)]
+  ): RelayResponse =
+    if status >= 400 then
+      Logger.warning(s"Upstream returned ${status} for ${mavenPath}")
+
+    val bytesResult =
+      catchNonFatal(os.read.bytes(tmp)).left.map: reason =>
+        raiseInternalServerErr(
+          phase = "read uncached upstream response",
+          mavenPath = mavenPath,
+          reason = reason
+        )
+
+    bytesResult match
+      case Left(response) => response
+      case Right(bytes) =>
+        RelayResponse(
+          statusCode = status,
+          body = RelayBody.Bytes(bytes),
+          headers = headersFor(
+            mavenPath,
+            size = Some(bytes.length.toLong),
+            upstreamHeaders = upstreamHeaders
+          )
+        )
+
+  private def handleHeadReq(mavenPath: String): RelayResponse =
+    pathLock(mavenPath).synchronized:
+      val file = localFile(mavenPath)
+      if os.exists(file) && os.isFile(file) then cachedHead(mavenPath, file)
+      else fetchUpstreamHeadResponse(mavenPath)
+
+  private def cachedHead(mavenPath: String, file: os.Path): RelayResponse =
+    repositoryStore.find(mavenPath) match
+      case Left(reason) =>
+        repositoryDatabaseFailure(
+          phase = "read repository database",
+          mavenPath = mavenPath,
+          reason = reason
+        )
+      case Right(None) =>
+        deleteLocalArtifact(
+          mavenPath,
+          file,
+          reason = "Local artifact not recorded"
+        ) match
+          case Left(response) => response
+          case Right(_)       => fetchUpstreamHeadResponse(mavenPath)
+      case Right(Some(recordedFile)) =>
+        cachedArtifactMatches(mavenPath, file, recordedFile) match
+          case Left(response) => response
+          case Right(false) =>
+            deleteLocalArtifact(
+              mavenPath,
+              file,
+              reason = "Cached artifact does not match repository database"
+            ) match
+              case Left(response) => response
+              case Right(_)       => fetchUpstreamHeadResponse(mavenPath)
+          case Right(true) =>
+            RelayResponse(
+              statusCode = 200,
+              body = RelayBody.Empty,
+              headers = headersFor(
+                mavenPath,
+                size = Some(recordedFile.size),
+                upstreamHeaders =
+                  Seq("Content-Type" -> recordedFile.contentType)
+              )
+            )
+
+  private def fetchUpstreamHeadResponse(mavenPath: String): RelayResponse =
+    fetchUpstreamHead(mavenPath) match
+      case Left(response) => response
+      case Right(upstreamResponse) =>
+        RelayResponse(
+          statusCode = upstreamResponse.statusCode,
+          body = RelayBody.Empty,
+          headers = headersFor(
+            mavenPath,
+            size = upstreamContentLength(upstreamResponse),
+            upstreamHeaders = safeUpstreamHeaders(upstreamResponse)
+          )
+        )
+
+  private def handleUpstreamFailure[T](
+      mavenPath: String
+  ): PartialFunction[Throwable, Either[RelayResponse, T]] =
+    case e: InterruptedException =>
+      Thread.currentThread().interrupt()
+      Left(upstreamFailure(mavenPath, e))
+    case NonFatal(e) =>
+      Left(upstreamFailure(mavenPath, e))
+
+  private def repositoryDatabaseFailure(
+      phase: String,
+      mavenPath: String,
+      reason: String
+  ): RelayResponse =
+    raiseInternalServerErr(
+      phase = phase,
+      mavenPath = mavenPath,
+      reason = reason
+    )
+
+  private def deleteLocalArtifact(
+      mavenPath: String,
+      file: os.Path,
+      reason: String
+  ): Either[RelayResponse, Unit] =
+    Logger.warning(s"${reason}, deleting: ${mavenPath}")
+    for _ <- catchNonFatal(os.remove(file)).left.map: reason =>
+        raiseInternalServerErr(
+          phase = "delete local artifact",
+          mavenPath = mavenPath,
+          reason = reason
+        )
+    yield ()
+
+  private def raiseInternalServerErr(
+      phase: String,
+      mavenPath: String,
+      reason: String
+  ): RelayResponse =
+    Logger.error(
+      s"Local relay failure while ${phase} for ${mavenPath}: ${reason}"
+    )
+    textResponse(500, "internal server error\n")
+
+  private def upstreamFailure(mavenPath: String, e: Throwable): RelayResponse =
+    upstreamFailure(
+      mavenPath,
+      Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+    )
+
+  private def upstreamFailure(
+      mavenPath: String,
+      reason: String
+  ): RelayResponse =
+    Logger.error(s"Upstream request failed for ${mavenPath}: ${reason}")
+    textResponse(502, s"upstream request failed for ${mavenPath}\n")
+
+  private def fetchUpstreamToFile(
+      mavenPath: String,
+      tmp: os.Path
+  ): Either[RelayResponse, UpstreamResponse] =
+    try
+      var upstreamResponse: Option[UpstreamResponse] = None
+      val readable = upstreamSession.get.stream(
+        url = upstreamUrl(mavenPath),
+        check = false,
+        onHeadersReceived =
+          headers => upstreamResponse = Some(toUpstreamResponse(headers))
+      )
+      Using.resource(os.write.outputStream(tmp)): output =>
+        readable.writeBytesTo(output)
+        ()
+
+      upstreamResponse.toRight:
+        upstreamFailure(
+          mavenPath,
+          "upstream response did not include headers"
+        )
+    catch handleUpstreamFailure(mavenPath)
+
+  private def fetchUpstreamHead(
+      mavenPath: String
+  ): Either[RelayResponse, UpstreamResponse] =
+    try
+      Right(
+        toUpstreamResponse(
+          upstreamSession.head(
+            url = upstreamUrl(mavenPath),
+            check = false
+          )
+        )
+      )
+    catch handleUpstreamFailure(mavenPath)
+
+  private def toUpstreamResponse(
+      response: requests.StreamHeaders
+  ): UpstreamResponse =
+    UpstreamResponse(
+      statusCode = response.statusCode,
+      headers = response.headers
+    )
+
+  private def toUpstreamResponse(
+      response: requests.Response
+  ): UpstreamResponse =
+    UpstreamResponse(
+      statusCode = response.statusCode,
+      headers = response.headers
+    )
+
+  private def upstreamUrl(mavenPath: String): String =
+    upstreamBase.resolve(MavenPath.encodeForUri(mavenPath)).toString
+
+  private def localFile(mavenPath: String): os.Path =
+    config.repoDir / os.RelPath(mavenPath)
+
+  private def pathLock(mavenPath: String): AnyRef =
+    val newLock = new AnyRef
+    val existing = pathLocks.putIfAbsent(mavenPath, newLock)
+    if existing == null then newLock else existing
+
+  private def record(
+      mavenPath: String,
+      sha256: String,
+      size: Long,
+      contentType: String,
+      upstreamUrl: Option[String]
+  ): Either[String, Unit] =
+    repositoryStore.record(
+      MavenRepositoryFile(
+        mavenPath = mavenPath,
+        sha256 = sha256,
+        size = size,
+        contentType = contentType,
+        upstreamUrl = upstreamUrl
+      )
+    )
+
+  private val forwardedResponseHeaders = Set(
+    "accept-ranges",
+    "cache-control",
+    "content-disposition",
+    "content-encoding",
+    "content-language",
+    "content-type",
+    "etag",
+    "expires",
+    "last-modified",
+    "retry-after",
+    "www-authenticate"
+  )
+
+  private def safeUpstreamHeaders(
+      response: UpstreamResponse
+  ): Seq[(String, String)] =
+    response.headers.toSeq.flatMap:
+      case (name, values) =>
+        val lowerName = name.toLowerCase(Locale.ROOT)
+        if forwardedResponseHeaders.contains(lowerName) then
+          values.map(value => name -> value)
+        else Nil
+
+  private def headersFor(
+      mavenPath: String,
+      size: Option[Long],
+      upstreamHeaders: Seq[(String, String)] = Nil
+  ): Seq[(String, String)] =
+    val withoutContentLength = upstreamHeaders.filterNot:
+      case (name, _) => name.equalsIgnoreCase("Content-Length")
+    val hasContentType = withoutContentLength.exists:
+      case (name, _) => name.equalsIgnoreCase("Content-Type")
+    val withContentType =
+      if hasContentType then withoutContentLength
+      else ("Content-Type" -> contentTypeFor(mavenPath)) +: withoutContentLength
+
+    withContentType ++ size.map(value => "Content-Length" -> value.toString)
+
+  private def contentTypeFromHeaders(
+      headers: Seq[(String, String)],
+      mavenPath: String
+  ): String =
+    headers
+      .collectFirst:
+        case (name, value) if name.equalsIgnoreCase("Content-Type") => value
+      .getOrElse(contentTypeFor(mavenPath))
+
+  private def contentTypeFor(mavenPath: String): String =
+    if mavenPath.endsWith(".pom") || mavenPath.endsWith(".xml") then
+      "application/xml"
+    else if mavenPath.endsWith(".jar") then "application/java-archive"
+    else if Seq(".sha1", ".md5", ".sha256", ".sha512", ".asc")
+        .exists(mavenPath.endsWith)
+    then "text/plain"
+    else "application/octet-stream"
+
+  private def upstreamContentLength(
+      response: UpstreamResponse
+  ): Option[Long] =
+    response.headers
+      .get("content-length")
+      .flatMap(_.headOption)
+      .flatMap(_.toLongOption)
+
+  private def textResponse(statusCode: Int, message: String): RelayResponse =
+    RelayResponse(
+      statusCode = statusCode,
+      body = RelayBody.Bytes(message.getBytes(StandardCharsets.UTF_8)),
+      headers = Seq("Content-Type" -> "text/plain; charset=utf-8")
+    )
+
+case class MavenRelayRoutes(service: MavenRelayService)(implicit
+    cc: castor.Context,
+    log: cask.Logger
+) extends cask.Routes:
+  @cask.route("/", methods = Seq("get", "head"))
+  def relay(
+      segments: cask.RemainingPathSegments,
+      request: cask.Request
+  ) =
+    val method = request.exchange.getRequestMethod.toString
+    val response =
+      if segments.value.isEmpty then rootResponse(method)
+      else service.handle(method, segments.value)
+
+    cask.Response(
+      toCaskData(response.body),
+      statusCode = response.statusCode,
+      headers = response.headers
+    )
+
+  private def toCaskData(body: RelayBody): cask.Response.Data =
+    body match
+      case RelayBody.Empty        => ()
+      case RelayBody.Bytes(bytes) => bytes
+      case RelayBody.File(path)   => FileData(path)
+
+  private final case class FileData(path: os.Path) extends cask.Response.Data:
+    def write(out: java.io.OutputStream): Unit =
+      val input = os.read.inputStream(path)
+      try
+        input.transferTo(out)
+        ()
+      finally input.close()
+
+    def headers: Seq[(String, String)] = Nil
+
+  private def rootResponse(method: String): RelayResponse =
+    val messageBytes =
+      "mif Maven relay is running\n".getBytes(StandardCharsets.UTF_8)
+    val headers = Seq(
+      "Content-Type" -> "text/plain; charset=utf-8",
+      "Content-Length" -> messageBytes.length.toString
+    )
+
+    method.toUpperCase(Locale.ROOT) match
+      case "GET" =>
+        RelayResponse(
+          statusCode = 200,
+          body = RelayBody.Bytes(messageBytes),
+          headers = headers
+        )
+      case "HEAD" =>
+        RelayResponse(
+          statusCode = 200,
+          body = RelayBody.Empty,
+          headers = headers
+        )
+      case method =>
+        throw new AssertionError(
+          s"unreachable: Cask routed unsupported method ${method} to root"
+        )
+
+  initialize()
+
+object RelayHttpServer:
+  def start(
+      host: String,
+      port: Int,
+      handler: HttpHandler
+  ): Either[String, Undertow] =
+    build(host, port, handler).flatMap(startServer(host, port, _))
+
+  private def build(
+      host: String,
+      port: Int,
+      handler: HttpHandler
+  ): Either[String, Undertow] =
+    try
+      // This mirrors the useful setup from Cask's `main` without giving up
+      // lifecycle control. Cask silences noisy JBoss/Undertow startup logging
+      // before building the server, then starts Undertow and registers its own
+      // shutdown hook. The relay does those steps itself so startup can return
+      // `Either` and tests can close the returned handle deterministically.
+      cask.main.Main.silenceJboss()
+      Right(
+        Undertow.builder
+          .addHttpListener(port, host)
+          .setHandler(handler)
+          .build
+      )
+    catch
+      case NonFatal(e) =>
+        Left(
+          s"Failed to build Maven relay HTTP server at http://${host}:${port}/: ${failureMessage(e)}"
+        )
+
+  private def startServer(
+      host: String,
+      port: Int,
+      server: Undertow
+  ): Either[String, Undertow] =
+    try
+      server.start()
+      Right(server)
+    catch
+      case NonFatal(e) =>
+        stop(server).left.foreach(Logger.warning)
+        Left(
+          s"Failed to start Maven relay HTTP server at http://${host}:${port}/: ${failureMessage(e)}"
+        )
+
+  def stop(server: Undertow): Either[String, Unit] =
+    try
+      server.stop()
+      Right(())
+    catch
+      case NonFatal(e) =>
+        Left(s"Failed to stop Maven relay HTTP server: ${failureMessage(e)}")
+
+object RuntimeHooks:
+  def addShutdownHook(close: () => Unit): Either[String, Unit] =
+    try
+      Runtime.getRuntime.addShutdownHook(new Thread(() => close()))
+      Right(())
+    catch
+      case NonFatal(e) =>
+        Left(s"Failed to install relay shutdown hook: ${failureMessage(e)}")
+
+class MavenRelayApp(
+    hostName: String,
+    portNumber: Int,
+    service: MavenRelayService
+) extends cask.Main:
+  override def host: String = hostName
+  override def port: Int = portNumber
+  override def debugMode: Boolean = false
+
+  override def handleMethodNotAllowed(req: cask.Request): cask.Response.Raw =
+    cask.Response(
+      "Error 405: Method Not Allowed",
+      statusCode = 405,
+      headers = Seq("Allow" -> "GET, HEAD")
+    )
+
+  override val allRoutes = Seq(MavenRelayRoutes(service)(actorContext, log))
+
+  def start(): Either[String, MavenRelayHandle] =
+    RelayHttpServer
+      .start(host, port, defaultHandler)
+      .map: server =>
+        MavenRelayHandle(
+          baseUrl = s"http://${host}:${port}/",
+          server = server,
+          service = service,
+          shutdownApp = () => executionContext.shutdown()
+        )
+
+class MavenRelayHandle(
+    val baseUrl: String,
+    server: Undertow,
+    service: MavenRelayService,
+    shutdownApp: () => Unit
+) extends AutoCloseable:
+  def closeEither(): Either[String, Unit] =
+    val failures = Seq(
+      "HTTP server" -> RelayHttpServer.stop(server),
+      "relay service" -> service.closeEither(),
+      "Cask execution context" -> catchNonFatal(shutdownApp())
+    ).collect:
+      case (resourceLabel, Left(reason)) => s"${resourceLabel}: ${reason}"
+
+    if failures.isEmpty then Right(())
+    else Left(s"Failed to close Maven relay handle: ${failures.mkString("; ")}")
+
+  def close(): Unit =
+    closeEither().left.foreach(Logger.warning)
+
+object MavenRelayServer:
+  val DefaultUpstream = "https://repo1.maven.org/maven2"
+
+  def start(
+      host: String,
+      port: Int,
+      config: MavenRelayConfig
+  ): Either[String, MavenRelayHandle] =
+    MavenRelayService
+      .fromConfig(config)
+      .flatMap: service =>
+        MavenRelayApp(host, port, service).start() match
+          case Right(handle) =>
+            Logger.info(s"Starting Maven relay at ${handle.baseUrl}")
+            Logger.info(s"Upstream: ${service.upstreamBaseUrl}")
+            service.proxyUrl
+              .foreach(proxyUrl => Logger.info(s"Upstream proxy: ${proxyUrl}"))
+            Logger.info(s"Archive repository: ${config.repoDir}")
+            Logger.info(
+              s"Repository database: ${service.repositoryDatabasePath}"
+            )
+            Right(handle)
+          case Left(reason) =>
+            service.close()
+            Left(reason)
+
+  def run(
+      host: String,
+      port: Int,
+      config: MavenRelayConfig
+  ): Unit =
+    val handle = start(host, port, config) match
+      case Left(reason)  => Logger.fatal(reason)
+      case Right(handle) => handle
+
+    RuntimeHooks
+      .addShutdownHook(() => handle.close())
+      .left
+      .foreach(Logger.warning)

--- a/mif/test/src/LoggerTests.scala
+++ b/mif/test/src/LoggerTests.scala
@@ -5,10 +5,12 @@ import utest._
 object LoggerTests extends TestSuite {
   val tests = Tests {
     test("fatal throws FatalException") {
-      val ex = intercept[FatalException] {
-        Logger.fatal("test error")
+      Logger.withLevel(LogLevel.Quiet) {
+        val ex = intercept[FatalException] {
+          Logger.fatal("test error")
+        }
+        assert(ex.getMessage == "test error")
       }
-      assert(ex.getMessage == "test error")
     }
   }
 }

--- a/mif/test/src/ProcessRunnerTests.scala
+++ b/mif/test/src/ProcessRunnerTests.scala
@@ -11,8 +11,11 @@ object ProcessRunnerTests extends TestSuite {
     }
 
     test("run throws FatalException on command failure") {
-      intercept[FatalException] {
-        ProcessRunner.run(Seq("false"))
+      Logger.withLevel(LogLevel.Quiet) {
+        intercept[FatalException] {
+          ProcessRunner.run(Seq("false"))
+        }
+        ()
       }
     }
   }

--- a/mif/test/src/RelayTests.scala
+++ b/mif/test/src/RelayTests.scala
@@ -1,0 +1,390 @@
+package in.avimit.dev.mif
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import utest._
+
+object RelayTests extends TestSuite:
+  private val sampleSegments = Seq(
+    "com",
+    "example",
+    "foo",
+    "1.0.0",
+    "foo-1.0.0.pom"
+  )
+  private val sampleMavenPath = "com/example/foo/1.0.0/foo-1.0.0.pom"
+
+  private def withLocalUpstream[T](
+      mavenPath: String,
+      content: Array[Byte]
+  )(runTest: String => T): T =
+    val server = ServerSocket(0)
+    val running = AtomicBoolean(true)
+    val thread =
+      Thread(() => serveRequests(server, running, mavenPath, content))
+    thread.setDaemon(true)
+    thread.start()
+
+    try runTest(s"http://127.0.0.1:${server.getLocalPort}/")
+    finally
+      running.set(false)
+      server.close()
+      thread.join(1000)
+
+  private def serveRequests(
+      server: ServerSocket,
+      running: AtomicBoolean,
+      mavenPath: String,
+      content: Array[Byte]
+  ): Unit =
+    while running.get do
+      try handleRequest(server.accept(), mavenPath, content)
+      catch case _: SocketException if !running.get => ()
+
+  private def handleRequest(
+      socket: Socket,
+      mavenPath: String,
+      content: Array[Byte]
+  ): Unit =
+    try
+      val input = BufferedReader(
+        InputStreamReader(socket.getInputStream, StandardCharsets.ISO_8859_1)
+      )
+      val requestLine = input.readLine()
+      var headerLine = input.readLine()
+      while headerLine != null && headerLine.nonEmpty do
+        headerLine = input.readLine()
+
+      val parts = Option(requestLine).getOrElse("GET / HTTP/1.1").split(" ")
+      val method = parts.lift(0).getOrElse("GET")
+      val path = parts.lift(1).getOrElse("/")
+      val found = path == s"/${mavenPath}"
+      val body =
+        if found then content else "missing".getBytes(StandardCharsets.UTF_8)
+      val status = if found then "200 OK" else "404 Not Found"
+      val output = socket.getOutputStream
+
+      writeAscii(output, s"HTTP/1.1 ${status}\r\n")
+      writeAscii(output, "Content-Type: application/xml\r\n")
+      writeAscii(output, s"Content-Length: ${body.length}\r\n")
+      writeAscii(output, "Connection: close\r\n")
+      writeAscii(output, "\r\n")
+      if method != "HEAD" then output.write(body)
+      output.flush()
+    finally socket.close()
+
+  private def writeAscii(output: java.io.OutputStream, text: String): Unit =
+    output.write(text.getBytes(StandardCharsets.ISO_8859_1))
+
+  private def newService(config: MavenRelayConfig): MavenRelayService =
+    MavenRelayService.fromConfig(config) match
+      case Right(service) => service
+      case Left(reason)   => throw new java.lang.AssertionError(reason)
+
+  private def openStore(repoDir: os.Path): MavenRepositoryStore =
+    MavenRepositoryStore.open(repoDir) match
+      case Right(store) => store
+      case Left(reason) => throw new java.lang.AssertionError(reason)
+
+  private def repositorySnapshot(repoDir: os.Path): Seq[MavenRepositoryFile] =
+    val store = openStore(repoDir)
+    try
+      store.snapshot() match
+        case Right(files) => files
+        case Left(reason) => throw new java.lang.AssertionError(reason)
+    finally store.close()
+
+  private def freePort(): Int =
+    val socket = ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+
+  private def headerValues(
+      response: requests.Response,
+      name: String
+  ): Seq[String] =
+    response.headers.toSeq
+      .collect:
+        case (headerName, values) if headerName.equalsIgnoreCase(name) =>
+          values
+      .flatten
+
+  private def relayBodyBytes(body: RelayBody): Array[Byte] =
+    body match
+      case RelayBody.Empty        => Array.emptyByteArray
+      case RelayBody.Bytes(bytes) => bytes
+      case RelayBody.File(path)   => os.read.bytes(path)
+
+  val tests = Tests {
+    test("MavenPath accepts repository-relative Maven paths") {
+      assert(MavenPath.fromSegments(sampleSegments) == Right(sampleMavenPath))
+    }
+
+    test("MavenPath rejects unsafe path segments") {
+      assert(MavenPath.fromSegments(Seq.empty).isLeft)
+      assert(MavenPath.fromSegments(Seq("com", "..", "foo.pom")).isLeft)
+      assert(MavenPath.fromSegments(Seq("com/example", "foo.pom")).isLeft)
+      assert(MavenPath.fromSegments(Seq("com", "", "foo.pom")).isLeft)
+      assert(MavenPath.fromSegments(Seq("com", "foo\nbar.pom")).isLeft)
+    }
+
+    test("upstream validation rejects unsafe or ambiguous base URLs") {
+      assert(
+        MavenUpstream
+          .validate("https://repo1.maven.org/maven2")
+          .map(_.toString) == Right("https://repo1.maven.org/maven2/")
+      )
+      assert(MavenUpstream.validate("file:///tmp/repository").isLeft)
+      assert(
+        MavenUpstream
+          .validate("https://user:password@example.com/maven2")
+          .isLeft
+      )
+      assert(
+        MavenUpstream.validate("https://example.com/maven2?token=secret").isLeft
+      )
+    }
+
+    test("proxy validation accepts only explicit HTTP proxy URLs") {
+      assert(
+        MavenProxy
+          .validate("http://127.0.0.1:8080")
+          .map(_.toString) == Right("http://127.0.0.1:8080")
+      )
+      assert(MavenProxy.validate("https://127.0.0.1:8080").isLeft)
+      assert(MavenProxy.validate("http://user:password@127.0.0.1:8080").isLeft)
+      assert(MavenProxy.validate("http://127.0.0.1").isLeft)
+      assert(MavenProxy.validate("http://127.0.0.1:8080/proxy").isLeft)
+    }
+
+    test("repository store records files") {
+      val tempDir = os.temp.dir(prefix = "mif-repository-store-test_")
+      val repoDir = tempDir / "repository"
+      val store1 = openStore(repoDir)
+      val store2 = openStore(repoDir)
+
+      try
+        val fileA = MavenRepositoryFile(
+          mavenPath = "com/example/a/1.0.0/a-1.0.0.pom",
+          sha256 = "sha256-a",
+          size = 1,
+          contentType = "application/xml",
+          upstreamUrl = Some("https://repo.example/a")
+        )
+        val fileB = MavenRepositoryFile(
+          mavenPath = "com/example/b/1.0.0/b-1.0.0.pom",
+          sha256 = "sha256-b",
+          size = 2,
+          contentType = "application/xml",
+          upstreamUrl = Some("https://repo.example/b")
+        )
+
+        assert(store1.record(fileA) == Right(()))
+        assert(store2.record(fileB) == Right(()))
+        assert(store1.find(fileA.mavenPath) == Right(Some(fileA)))
+        assert(
+          store1.find("com/example/missing/1.0.0/missing.pom") == Right(None)
+        )
+      finally
+        store1.close()
+        store2.close()
+
+      val files = repositorySnapshot(repoDir)
+      assert(
+        files.map(_.mavenPath) == Seq(
+          "com/example/a/1.0.0/a-1.0.0.pom",
+          "com/example/b/1.0.0/b-1.0.0.pom"
+        )
+      )
+
+      assert(files.forall(_.sha256.startsWith("sha256-")))
+      assert(
+        files.map(_.upstreamUrl) == Seq(
+          Some("https://repo.example/a"),
+          Some("https://repo.example/b")
+        )
+      )
+    }
+
+    test("route decorator rejects unsupported artifact methods") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+        val config = MavenRelayConfig(
+          repoDir = tempDir / "repository",
+          upstreamBaseUrl = MavenRelayServer.DefaultUpstream,
+          connectTimeoutSeconds = 1,
+          requestTimeoutSeconds = 1
+        )
+        val handle =
+          MavenRelayServer.start("127.0.0.1", freePort(), config) match
+            case Right(handle) => handle
+            case Left(reason)  => throw new java.lang.AssertionError(reason)
+
+        try
+          val response = requests.post(
+            s"${handle.baseUrl}${sampleMavenPath}",
+            check = false
+          )
+          assert(response.statusCode == 405)
+          assert(headerValues(response, "Allow") == Seq("GET, HEAD"))
+        finally handle.close()
+      }
+    }
+
+    test("GET ignores untracked local artifact and fetches upstream") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val localContent = "<project>local-only</project>"
+          .getBytes(StandardCharsets.UTF_8)
+        val upstreamContent = "<project>upstream</project>"
+          .getBytes(StandardCharsets.UTF_8)
+
+        withLocalUpstream(sampleMavenPath, upstreamContent) { upstreamBaseUrl =>
+          val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+          val repoDir = tempDir / "repository"
+          val artifact = repoDir / os.RelPath(sampleMavenPath)
+
+          os.makeDir.all(artifact / os.up)
+          os.write(artifact, localContent)
+
+          val service = newService(
+            MavenRelayConfig(
+              repoDir = repoDir,
+              upstreamBaseUrl = upstreamBaseUrl,
+              connectTimeoutSeconds = 1,
+              requestTimeoutSeconds = 1
+            )
+          )
+
+          try
+            val response = service.handle("GET", sampleSegments)
+            assert(response.statusCode == 200)
+            assert(relayBodyBytes(response.body).sameElements(upstreamContent))
+            assert(os.read.bytes(artifact).sameElements(upstreamContent))
+
+            val files = repositorySnapshot(repoDir)
+            assert(files.size == 1)
+            assert(files.head.mavenPath == sampleMavenPath)
+            assert(files.head.sha256.startsWith("sha256-"))
+            assert(files.head.size == upstreamContent.length.toLong)
+            assert(files.head.contentType == "application/xml")
+            assert(
+              files.head.upstreamUrl == Some(
+                s"${upstreamBaseUrl}${sampleMavenPath}"
+              )
+            )
+          finally service.close()
+        }
+      }
+    }
+
+    test("GET fetches missing artifact from upstream and records it") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val content =
+          "<project>upstream</project>".getBytes(StandardCharsets.UTF_8)
+        withLocalUpstream(sampleMavenPath, content) { upstreamBaseUrl =>
+          val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+          val repoDir = tempDir / "repository"
+          val service = newService(
+            MavenRelayConfig(
+              repoDir = repoDir,
+              upstreamBaseUrl = upstreamBaseUrl,
+              connectTimeoutSeconds = 1,
+              requestTimeoutSeconds = 1
+            )
+          )
+
+          try
+            val upstreamHead = service.handle("HEAD", sampleSegments)
+            assert(upstreamHead.statusCode == 200)
+            assert(upstreamHead.body == RelayBody.Empty)
+            assert(
+              upstreamHead.headers.contains(
+                "Content-Length" -> content.length.toString
+              )
+            )
+
+            val response = service.handle("GET", sampleSegments)
+            assert(response.statusCode == 200)
+            assert(relayBodyBytes(response.body).sameElements(content))
+            assert(
+              os.read
+                .bytes(repoDir / os.RelPath(sampleMavenPath))
+                .sameElements(content)
+            )
+
+            val files = repositorySnapshot(repoDir)
+            assert(files.size == 1)
+            assert(files.head.mavenPath == sampleMavenPath)
+            assert(files.head.size == content.length.toLong)
+            assert(
+              files.head.upstreamUrl == Some(
+                s"${upstreamBaseUrl}${sampleMavenPath}"
+              )
+            )
+
+            val cachedHead = service.handle("HEAD", sampleSegments)
+            assert(cachedHead.statusCode == 200)
+            assert(cachedHead.body == RelayBody.Empty)
+            assert(
+              cachedHead.headers.contains(
+                "Content-Length" -> content.length.toString
+              )
+            )
+          finally service.close()
+        }
+      }
+    }
+
+    test("GET and HEAD delete cached artifacts that differ from the database") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val content = "<project>upstream</project>"
+          .getBytes(StandardCharsets.UTF_8)
+        val corruptedContent = "<project>corrupted</project>"
+          .getBytes(StandardCharsets.UTF_8)
+
+        withLocalUpstream(sampleMavenPath, content) { upstreamBaseUrl =>
+          val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+          val repoDir = tempDir / "repository"
+          val artifact = repoDir / os.RelPath(sampleMavenPath)
+          val service = newService(
+            MavenRelayConfig(
+              repoDir = repoDir,
+              upstreamBaseUrl = upstreamBaseUrl,
+              connectTimeoutSeconds = 1,
+              requestTimeoutSeconds = 1
+            )
+          )
+
+          try
+            val initialResponse = service.handle("GET", sampleSegments)
+            assert(initialResponse.statusCode == 200)
+            assert(relayBodyBytes(initialResponse.body).sameElements(content))
+
+            os.write.over(artifact, corruptedContent)
+
+            val repairedGet = service.handle("GET", sampleSegments)
+            assert(repairedGet.statusCode == 200)
+            assert(relayBodyBytes(repairedGet.body).sameElements(content))
+            assert(os.read.bytes(artifact).sameElements(content))
+
+            os.write.over(artifact, corruptedContent)
+
+            val repairedHead = service.handle("HEAD", sampleSegments)
+            assert(repairedHead.statusCode == 200)
+            assert(repairedHead.body == RelayBody.Empty)
+            assert(
+              repairedHead.headers.contains(
+                "Content-Length" -> content.length.toString
+              )
+            )
+            assert(!os.exists(artifact))
+          finally service.close()
+        }
+      }
+    }
+  }

--- a/mif/test/src/ValidationTests.scala
+++ b/mif/test/src/ValidationTests.scala
@@ -5,14 +5,20 @@ import utest._
 object ValidationTests extends TestSuite {
   val tests = Tests {
     test("sanitize rejects newline in arguments") {
-      intercept[FatalException] {
-        ProcessRunner.run(Seq("echo", "hello\nworld"))
+      Logger.withLevel(LogLevel.Quiet) {
+        intercept[FatalException] {
+          ProcessRunner.run(Seq("echo", "hello\nworld"))
+        }
+        ()
       }
     }
 
     test("sanitize rejects null byte in arguments") {
-      intercept[FatalException] {
-        ProcessRunner.run(Seq("echo", "hello\u0000world"))
+      Logger.withLevel(LogLevel.Quiet) {
+        intercept[FatalException] {
+          ProcessRunner.run(Seq("echo", "hello\u0000world"))
+        }
+        ()
       }
     }
 

--- a/readme.md
+++ b/readme.md
@@ -38,18 +38,104 @@ mill -i mif.run codegen --cache "$cacheDir" -o lock.nix
 mill -i mif.run run -o lock.nix
 ```
 
+## Maven Relay Snapshot
+
+`mif relay` starts a local Maven-compatible HTTP relay. Build tools can use it
+as a Maven mirror. The relay serves files from a project-level local Maven
+repository when they already exist, otherwise it fetches them from the upstream
+repository and stores them in standard Maven layout.
+
+The relay does **not** write the Nix-facing JSON lock directly. It only maintains
+an internal SQLite database under the repository root:
+
+```text
+.mif/repository/.mif/repository.sqlite
+```
+
+That database is a relay implementation detail. The lock/export workflow will be
+built as a separate layer on top of this repository state.
+
+This is the first step of the Maven repository based redesign. It is intended
+to replace the old Coursier-cache scanning flow over time, but the old commands
+are still present for now.
+
+Run the relay manually:
+
+```bash
+mill -i mif.run relay \
+  --port 8081 \
+  --repo-dir .mif/repository
+```
+
+By default, the relay listens on `127.0.0.1:8081` and fetches missing files from
+Maven Central:
+
+```text
+https://repo1.maven.org/maven2
+```
+
+Point the build tool's Maven mirror to the relay:
+
+```text
+http://127.0.0.1:8081/
+```
+
+For Mill/Coursier, create a mirror file equivalent to:
+
+```properties
+central.from=https://repo1.maven.org/maven2
+central.to=http://127.0.0.1:8081
+```
+
+The relay stores downloaded files under `.mif/repository` using standard Maven
+repository paths such as:
+
+```text
+.mif/repository/com/example/foo/1.0.0/foo-1.0.0.pom
+.mif/repository/com/example/foo/1.0.0/foo-1.0.0.jar
+```
+
+
+
+The upstream can be replaced with another Maven-compatible endpoint. This is
+useful for testing relay chaining:
+
+```bash
+mill -i mif.run relay \
+  --port 8082 \
+  --repo-dir .mif/repository \
+  --upstream http://127.0.0.1:8081
+```
+
+If upstream requests must go through an HTTP proxy, pass an explicit proxy URL:
+
+```bash
+mill -i mif.run relay \
+  --proxy http://127.0.0.1:8080
+```
+
+Current limitations:
+
+* The lock/export layer is intentionally not implemented in this relay snapshot.
+* Maven Central is the only default upstream.
+* Private repository authentication and proxy authentication are not supported yet.
+* Cached Maven files are treated as archived content. Mutable metadata such as
+  `maven-metadata.xml` and SNAPSHOT metadata has no TTL yet; delete the cached
+  file or use a fresh repository directory if you need to refresh it.
+* The relay only observes files requested by the build tool. Lazy Mill targets
+  that are never evaluated will not be discovered by this layer.
+
 ## Implementation Details
 
-Mill doesn't provide a straightforward CLI interface to get the Ivy dependencies
-tree. The only way to know all the necessary build-time dependencies is to run
-`mill __.prepareOffline`. Given that Mill uses the Coursier library to download
-JAR packages, we can gather dependency information by searching the Coursier cache
-directory.
+Mill doesn't provide a straightforward CLI interface to get the full dependency
+tree. The old implementation works around this by running Mill targets and then
+scanning the Coursier cache directory. This is fragile because the cache layout is
+not the real distribution format and because Mill evaluates dependencies lazily.
 
-This project provides the executable `mif`. It will recursively search all `.pom`
-files in the Coursier cache, extract necessary information like project name,
-version, etc., and convert that information to Maven Central download URLs. Then
-it converts those URLs to Nix `fetchurl` expressions.
+The new relay direction records Maven repository requests directly. Build tools
+already understand Maven repositories and mirrors, so `mif` can archive the files
+that were actually requested and later materialize a project-level Maven
+repository from the JSON lock.
 
 ## Recommended Workflow
 


### PR DESCRIPTION
Part of the staged refactor work. Supersedes #44 by targeting the `refactor` integration branch instead of `master`.

## Summary

This PR adds the first Maven relay implementation for `mif`, focused on standard Maven repository layout, usability, and local cache integrity.

It adds:

- a new `mif relay` command
- a Maven-compatible local relay backed by Cask routes and an explicitly managed Undertow server lifecycle
- artifact storage in standard Maven repository paths under the configured repository directory
- an internal SQLite repository database at `<repo-dir>/.mif/repository.sqlite`, implemented with ScalaSql
- upstream fetching through `requests-scala`, with optional HTTP proxy support
- safe Maven path validation and GET/HEAD-only routing
- generic client-facing local failure responses, with detailed local failure diagnostics kept in logs
- relay tests covering path validation, upstream fetch, DB recording, cache integrity, and unsupported HTTP methods
- `docs/coding-guideline.md` plus dependency API reference docs used during this implementation

## Current relay design

The relay is intentionally decoupled from package lock generation.

The relay does **not** create or update `mif.lock.json`. Its persistent state is the internal SQLite repository database. A future `mif archive` workflow should wrap relay execution, run the build tool, then export the relay database into a canonical JSON lock outside the relay server.

The repository database is the source of truth for local cache state:

- a local file alone is not trusted as a cache hit
- a cache hit must have a database record
- cached files are validated against the recorded size and SHA-256 before serving
- dangling local files are warned about, deleted, and treated as cache misses
- corrupted local files are warned about, deleted, and treated as cache misses
- `GET` can refetch after cleanup; `HEAD` falls back to upstream metadata after cleanup

To migrate an existing Maven repository into relay-managed state, the intended flow is to point the relay upstream at that repository and fetch through the relay, rather than backfilling metadata from arbitrary files already present on disk.

## Notes / follow-ups

- Private Maven repository authentication is not implemented in this snapshot.
- The SQLite database is internal relay state, not a stable public schema yet.
- Canonical JSON lock export remains future work and should live outside the relay server.
- Mutable Maven metadata / SNAPSHOT policy may need more explicit design before production use.

## Validation

- `mill mif.reformat`
- `git --no-pager diff --check`
- `mill mif.test`
