### PR TITLE
Implement the mif archive command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ result
 .bloop/
 chisel/
 .direnv/
+.mif/

--- a/flake.nix
+++ b/flake.nix
@@ -69,10 +69,15 @@
             };
 
             devShells.default = pkgs.mkShell {
-              nativeBuildInputs = with pkgs; [
-                millVersions.mill_1_1_2
-                metals
-              ];
+              nativeBuildInputs =
+                with pkgs;
+                [
+                  millVersions.mill_1_1_2
+                  metals
+                ]
+                # `mif archive` sandboxes build commands with bubblewrap;
+                # bubblewrap is Linux-only.
+                ++ lib.optionals stdenv.hostPlatform.isLinux [ bubblewrap ];
             };
 
             treefmt = {

--- a/mif/src/Archive.scala
+++ b/mif/src/Archive.scala
@@ -1,0 +1,238 @@
+package in.avimit.dev.mif
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.control.NonFatal
+
+case class ArchiveParams(
+    projectDir: os.Path,
+    repoDir: os.Path,
+    lockPath: os.Path,
+    upstream: String,
+    proxyUrl: Option[String],
+    host: String,
+    port: Int,
+    sandboxMode: SandboxMode,
+    keepWorkdir: Boolean,
+    fresh: Boolean,
+    connectTimeoutSeconds: Int,
+    requestTimeoutSeconds: Int,
+    command: Seq[String]
+)
+
+case class LockUpdateSummary(
+    totalFiles: Int,
+    newFiles: Int,
+    runs: Int
+)
+
+object ArchiveRunner:
+  private def errorMessage(e: Throwable): String =
+    Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+
+  def run(params: ArchiveParams): Either[String, LockUpdateSummary] =
+    for
+      tool <- BuildTools.detect(params.command)
+      _ = tool
+        .preflightWarnings(params.projectDir, params.command)
+        .foreach(Logger.warning)
+      strategy <- SandboxStrategy.resolve(params.sandboxMode)
+      _ = strategy.warnings.foreach(Logger.warning)
+      accessed <- runBuildThroughRelay(params, strategy)
+      _ =
+        if accessed.isEmpty then
+          Logger.warning(
+            "no Maven files were requested through the relay; did the build resolve anything?"
+          )
+      summary <- updateLock(
+        lockPath = params.lockPath,
+        runFiles = accessed,
+        upstream = params.upstream,
+        run = LockRun.fromCommand(params.command),
+        fresh = params.fresh
+      )
+    yield summary
+
+  private def runBuildThroughRelay(
+      params: ArchiveParams,
+      strategy: SandboxStrategy
+  ): Either[String, Seq[MavenRepositoryFile]] =
+    withSandboxHome(params.keepWorkdir) { sandboxHome =>
+      for
+        accessed <- withRelay(params) { handle =>
+          runBuildWithRelay(params, strategy, sandboxHome, handle)
+        }
+        files <- lookupFiles(params.repoDir, accessed)
+      yield files
+    }
+
+  private def runBuildWithRelay(
+      params: ArchiveParams,
+      strategy: SandboxStrategy,
+      sandboxHome: os.Path,
+      handle: MavenRelayHandle
+  ): Either[String, Seq[String]] =
+    for
+      mirror <- CoursierMirror.properties(
+        params.upstream,
+        handle.baseUrl
+      )
+      _ <- writeMirrorFile(SandboxEnv.mirrorFile(sandboxHome), mirror)
+      (env, envWarnings) = SandboxEnv.build(strategy, sys.env, sandboxHome)
+      _ = envWarnings.foreach(Logger.warning)
+      exitCode <- executeBuild(params, strategy, sandboxHome, env)
+      _ <-
+        if exitCode == 0 then Right(())
+        else
+          Left(
+            s"build command exited with code ${exitCode}; lock not updated"
+          )
+    yield handle.accessedPaths
+
+  private def withSandboxHome[T](keep: Boolean)(
+      body: os.Path => Either[String, T]
+  ): Either[String, T] =
+    createSandboxHome().flatMap { sandboxHome =>
+      try body(sandboxHome)
+      finally cleanupSandboxHome(sandboxHome, keep)
+    }
+
+  private def withRelay[T](params: ArchiveParams)(
+      body: MavenRelayHandle => Either[String, T]
+  ): Either[String, T] =
+    val config = MavenRelayConfig(
+      repoDir = params.repoDir,
+      upstreamBaseUrl = params.upstream,
+      proxyUrl = params.proxyUrl,
+      connectTimeoutSeconds = params.connectTimeoutSeconds,
+      requestTimeoutSeconds = params.requestTimeoutSeconds
+    )
+    MavenRelayServer.start(params.host, params.port, config).flatMap { handle =>
+      val closed = AtomicBoolean(false)
+      def closeOnce(): Unit =
+        if closed.compareAndSet(false, true) then handle.close()
+      // The hook guards Ctrl-C during the build; close is idempotent so
+      // the normal path can also close eagerly.
+      RuntimeHooks
+        .addShutdownHook(() => closeOnce())
+        .left
+        .foreach(Logger.warning)
+      try body(handle)
+      finally closeOnce()
+    }
+
+  private def executeBuild(
+      params: ArchiveParams,
+      strategy: SandboxStrategy,
+      sandboxHome: os.Path,
+      env: Map[String, String]
+  ): Either[String, Int] =
+    strategy match
+      case SandboxStrategy.Bwrap =>
+        val spec = BubblewrapSandbox.Spec(
+          projectDir = params.projectDir,
+          sandboxHome = sandboxHome,
+          env = env,
+          command = params.command
+        )
+        // bwrap itself runs with the parent environment so the binary
+        // resolves through PATH; --clearenv wipes it for the child, which
+        // only sees the --setenv allowlist.
+        ProcessRunner.runStreaming(
+          BubblewrapSandbox.argv(spec),
+          cwd = params.projectDir
+        )
+      case SandboxStrategy.CleanEnvOnly(_) =>
+        ProcessRunner.runStreaming(
+          params.command,
+          cwd = params.projectDir,
+          env = env,
+          propagateEnv = false
+        )
+
+  private[mif] def lookupFiles(
+      repoDir: os.Path,
+      paths: Seq[String]
+  ): Either[String, Seq[MavenRepositoryFile]] =
+    withRepositoryStore(repoDir) { store =>
+      paths.foldLeft[Either[String, Vector[MavenRepositoryFile]]](
+        Right(Vector.empty)
+      ) { (acc, path) =>
+        for
+          files <- acc
+          found <- store.find(path)
+          file <- found.toRight(
+            s"artifact ${path} was served by the relay but is missing from the repository database ${store.dbPath}"
+          )
+        yield files :+ file
+      }
+    }
+
+  private def withRepositoryStore[T](repoDir: os.Path)(
+      body: MavenRepositoryStore => Either[String, T]
+  ): Either[String, T] =
+    MavenRepositoryStore.open(repoDir).flatMap { store =>
+      try body(store)
+      finally store.close()
+    }
+
+  private def createSandboxHome(): Either[String, os.Path] =
+    try
+      val home =
+        os.temp.dir(prefix = "mif-archive-home-", deleteOnExit = false)
+      os.makeDir.all(SandboxEnv.mirrorFile(home) / os.up)
+      os.makeDir.all(SandboxEnv.coursierCache(home))
+      os.makeDir.all(home / ".local" / "share")
+      os.makeDir.all(SandboxEnv.ivyHome(home))
+      os.makeDir.all(SandboxEnv.mavenLocalRepository(home))
+      Right(home)
+    catch
+      case NonFatal(e) =>
+        Left(s"failed to create sandbox home: ${errorMessage(e)}")
+
+  private def writeMirrorFile(
+      file: os.Path,
+      content: String
+  ): Either[String, Unit] =
+    try
+      os.makeDir.all(file / os.up)
+      os.write.over(file, content)
+      Logger.trace(s"coursier mirror file at ${file}:\n${content}")
+      Right(())
+    catch
+      case NonFatal(e) =>
+        Left(
+          s"failed to write coursier mirror file ${file}: ${errorMessage(e)}"
+        )
+
+  private def cleanupSandboxHome(home: os.Path, keep: Boolean): Unit =
+    if keep then Logger.info(s"Keeping sandbox home ${home}")
+    else
+      try os.remove.all(home)
+      catch
+        case NonFatal(e) =>
+          Logger.warning(
+            s"failed to delete sandbox home ${home}: ${errorMessage(e)}"
+          )
+
+  /** Merges the files of one archive run into the lock on disk. Unit testable
+    * without a relay or sandbox.
+    */
+  def updateLock(
+      lockPath: os.Path,
+      runFiles: Seq[MavenRepositoryFile],
+      upstream: String,
+      run: LockRun,
+      fresh: Boolean
+  ): Either[String, LockUpdateSummary] =
+    for
+      repository <- Lock.repositoryFor(upstream)
+      existing <- if fresh then Right(None) else Lock.read(lockPath)
+      base = existing.getOrElse(Lock.empty)
+      merged <- Lock.merge(base, repository, runFiles, run)
+      _ <- Lock.write(lockPath, merged)
+    yield LockUpdateSummary(
+      totalFiles = merged.files.size,
+      newFiles = merged.files.size - base.files.size,
+      runs = merged.runs.size
+    )

--- a/mif/src/BuildTool.scala
+++ b/mif/src/BuildTool.scala
@@ -1,0 +1,92 @@
+package in.avimit.dev.mif
+
+/** Build-tool specific behavior for `mif archive`. Implementations only advise;
+  * they never block a run.
+  */
+trait BuildToolSupport:
+  def name: String
+  def preflightWarnings(projectDir: os.Path, command: Seq[String]): Seq[String]
+
+object MillSupport extends BuildToolSupport:
+  def name = "mill"
+
+  private val daemonlessFlags =
+    Set("--no-daemon", "--no-server", "-i", "--interactive")
+
+  def preflightWarnings(
+      projectDir: os.Path,
+      command: Seq[String]
+  ): Seq[String] =
+    val flagWarning =
+      if command.exists(daemonlessFlags.contains) then None
+      else
+        Some(
+          "mill reuses a background daemon by default; pass `-i` or " +
+            "`--no-daemon` after `--` so the archived run cannot reuse " +
+            "daemon state from outside the sandbox"
+        )
+
+    val daemonDirs = Seq(
+      projectDir / "out" / "mill-daemon",
+      projectDir / "out" / "mill-server"
+    )
+    val daemonWarning =
+      if daemonDirs.exists(os.exists) then
+        Some(
+          s"a mill daemon from a previous run may be reachable through ${projectDir / "out"}; " +
+            "run `mill shutdown` in the project first so dependency downloads " +
+            "cannot bypass the archive relay"
+        )
+      else None
+
+    Seq(flagWarning, daemonWarning).flatten
+
+object BuildTools:
+  val supported: Map[String, BuildToolSupport] = Map("mill" -> MillSupport)
+
+  /** Detects the build tool from the executable name, tolerating relative and
+    * absolute invocations like `./mill` or `/nix/store/.../bin/mill`.
+    */
+  def detect(command: Seq[String]): Either[String, BuildToolSupport] =
+    command.headOption match
+      case None =>
+        Left(
+          "missing build command; usage: mif archive [flags] -- mill -i __.prepareOffline"
+        )
+      case Some(executable) =>
+        val name = executable.split('/').last
+        supported
+          .get(name)
+          .toRight(
+            s"unsupported build tool '${name}'; supported tools: ${supported.keys.toSeq.sorted.mkString(", ")}"
+          )
+
+object CoursierMirror:
+  /** Well-known base URLs that all serve Maven Central. Both are mirrored so
+    * resolution cannot escape the relay through the alternate alias.
+    */
+  val CentralAliases: Seq[String] = Seq(
+    "https://repo1.maven.org/maven2",
+    "https://repo.maven.apache.org/maven2"
+  )
+
+  /** Renders a coursier mirror.properties that redirects the upstream (and its
+    * aliases, for Maven Central) to the local relay.
+    */
+  def properties(
+      upstream: String,
+      relayBaseUrl: String
+  ): Either[String, String] =
+    MavenUpstream
+      .validate(upstream)
+      .map: uri =>
+        val normalized = uri.toString.stripSuffix("/")
+        val froms =
+          if CentralAliases.contains(normalized) then CentralAliases
+          else Seq(normalized)
+        val to = relayBaseUrl.stripSuffix("/")
+        froms.zipWithIndex
+          .map((from, index) =>
+            s"mif${index}.from=${from}\nmif${index}.to=${to}\n"
+          )
+          .mkString

--- a/mif/src/Lock.scala
+++ b/mif/src/Lock.scala
@@ -1,0 +1,348 @@
+package in.avimit.dev.mif
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Locale
+import scala.util.control.NonFatal
+
+import upickle.default.ReadWriter
+
+case class LockRepository(
+    id: String,
+    @upickle.implicits.key("type") repoType: String,
+    url: String
+) derives ReadWriter
+
+case class LockRun(
+    id: String,
+    command: Vector[String]
+) derives ReadWriter
+
+object LockRun:
+  /** Stable identifier for a build command: the same argv always maps to the
+    * same id, so locks written on different machines merge cleanly and
+    * re-archiving an already recorded command is a no-op. Archive commands are
+    * normalized before a run is constructed so newline-containing arguments do
+    * not reach this newline-joined encoding.
+    */
+  def idFor(command: Seq[String]): String =
+    val digest = MessageDigest
+      .getInstance("SHA-256")
+      .digest(command.mkString("\n").getBytes(StandardCharsets.UTF_8))
+    digest.take(6).map(byte => f"${byte & 0xff}%02x").mkString
+
+  def fromCommand(command: Seq[String]): LockRun =
+    LockRun(id = idFor(command), command = command.toVector)
+
+case class LockedFile(
+    repository: String,
+    mavenPath: String,
+    sha256: String,
+    size: Long,
+    runs: Vector[String]
+) derives ReadWriter
+
+case class MifLock(
+    version: Int,
+    kind: String,
+    repositories: Vector[LockRepository],
+    runs: Vector[LockRun],
+    files: Vector[LockedFile]
+) derives ReadWriter
+
+object Lock:
+  val Version = 1
+  val Kind = "mif-maven-lock"
+  val DefaultFileName = "mif.lock.json"
+
+  private val sriPattern = "^sha256-[A-Za-z0-9+/]{43}=$".r
+  private val runIdPattern = "^[0-9a-f]{12}$".r
+
+  def empty: MifLock =
+    MifLock(
+      version = Version,
+      kind = Kind,
+      repositories = Vector.empty,
+      runs = Vector.empty,
+      files = Vector.empty
+    )
+
+  private def errorMessage(e: Throwable): String =
+    Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+
+  /** Repository entry describing the upstream an archive run recorded from.
+    * Maven Central aliases share the well-known "central" id so locks stay
+    * comparable across mirrors of the same repository.
+    */
+  def repositoryFor(upstream: String): Either[String, LockRepository] =
+    MavenUpstream
+      .validate(upstream)
+      .map: uri =>
+        val normalized = uri.toString.stripSuffix("/")
+        val id =
+          if CoursierMirror.CentralAliases.contains(normalized) then "central"
+          else slugFor(uri)
+        LockRepository(id = id, repoType = "maven", url = normalized)
+
+  private def slugFor(uri: java.net.URI): String =
+    val host = Option(uri.getHost).getOrElse("repository")
+    val slug = host
+      .toLowerCase(Locale.ROOT)
+      .map(ch => if ch.isLetterOrDigit then ch else '-')
+      .dropWhile(_ == '-')
+      .reverse
+      .dropWhile(_ == '-')
+      .reverse
+    if slug.isEmpty then "repository" else slug
+
+  def parse(text: String): Either[String, MifLock] =
+    decode(text).flatMap(validate)
+
+  private def decode(text: String): Either[String, MifLock] =
+    try Right(upickle.default.read[MifLock](text))
+    catch case NonFatal(e) => Left(s"invalid lock JSON: ${errorMessage(e)}")
+
+  private def validate(lock: MifLock): Either[String, MifLock] =
+    for
+      _ <- validateHeader(lock)
+      _ <- validateRepositories(lock.repositories)
+      _ <- validateRuns(lock.runs)
+      _ <- validateFiles(lock)
+    yield lock
+
+  private def validateHeader(lock: MifLock): Either[String, Unit] =
+    if lock.version != Version then
+      Left(
+        s"unsupported lock version ${lock.version}; this mif understands version ${Version}, upgrade mif or regenerate the lock"
+      )
+    else if lock.kind != Kind then
+      Left(s"unsupported lock kind '${lock.kind}'; expected '${Kind}'")
+    else Right(())
+
+  private def validateRepositories(
+      repositories: Vector[LockRepository]
+  ): Either[String, Unit] =
+    val duplicate =
+      repositories.groupBy(_.id).collectFirst {
+        case (id, entries) if entries.size > 1 => id
+      }
+    val invalid = repositories.collectFirst {
+      case repo if repo.id.isEmpty =>
+        "repository entry with an empty id"
+      case repo if repo.repoType != "maven" =>
+        s"repository ${repo.id} has unsupported type '${repo.repoType}'"
+      case repo if MavenUpstream.validate(repo.url).isLeft =>
+        s"repository ${repo.id} has invalid url '${repo.url}'"
+    }
+    duplicate match
+      case Some(id) => Left(s"duplicate repository id '${id}'")
+      case None     => invalid.toLeft(())
+
+  private def validateRuns(runs: Vector[LockRun]): Either[String, Unit] =
+    val duplicate =
+      runs.groupBy(_.id).collectFirst {
+        case (id, entries) if entries.size > 1 => id
+      }
+    val invalid = runs.collectFirst {
+      case run if runIdPattern.findFirstIn(run.id).isEmpty =>
+        s"run id '${run.id}' is not a 12 character hex identifier"
+      case run if run.command.isEmpty =>
+        s"run ${run.id} has an empty command"
+    }
+    duplicate match
+      case Some(id) => Left(s"duplicate run id '${id}'")
+      case None     => invalid.toLeft(())
+
+  private def validateFiles(lock: MifLock): Either[String, Unit] =
+    val repositoryIds = lock.repositories.map(_.id).toSet
+    val runIds = lock.runs.map(_.id).toSet
+    val duplicate =
+      lock.files.groupBy(_.mavenPath).collectFirst {
+        case (path, entries) if entries.size > 1 => path
+      }
+    val invalid = lock.files.collectFirst {
+      case file
+          if MavenPath.fromSegments(file.mavenPath.split('/').toSeq).isLeft =>
+        s"file entry has invalid maven path '${file.mavenPath}'"
+      case file if sriPattern.findFirstIn(file.sha256).isEmpty =>
+        s"file ${file.mavenPath} has invalid sha256 '${file.sha256}'; expected SRI sha256-<base64>"
+      case file if file.size < 0 =>
+        s"file ${file.mavenPath} has negative size ${file.size}"
+      case file if !repositoryIds.contains(file.repository) =>
+        s"file ${file.mavenPath} references unknown repository '${file.repository}'"
+      case file if file.runs.isEmpty =>
+        s"file ${file.mavenPath} is not referenced by any run"
+      case file if !file.runs.forall(runIds.contains) =>
+        s"file ${file.mavenPath} references unknown run ids ${file.runs.filterNot(runIds.contains).mkString(", ")}"
+    }
+    duplicate match
+      case Some(path) => Left(s"duplicate lock entry for maven path '${path}'")
+      case None       => invalid.toLeft(())
+
+  /** Deterministic form: entry order never depends on sqlite collation or
+    * insertion order, so appends produce minimal diffs.
+    */
+  private def canonicalize(lock: MifLock): MifLock =
+    lock.copy(
+      repositories = lock.repositories.sortBy(_.id),
+      runs = lock.runs.sortBy(_.command.mkString("\n")),
+      files = lock.files
+        .map(file => file.copy(runs = file.runs.distinct.sorted))
+        .sortBy(_.mavenPath)
+    )
+
+  def render(lock: MifLock): String =
+    upickle.default.write(canonicalize(lock), indent = 2) + "\n"
+
+  def read(file: os.Path): Either[String, Option[MifLock]] =
+    if !os.exists(file) then Right(None)
+    else
+      val text =
+        try Right(os.read(file))
+        catch
+          case NonFatal(e) =>
+            Left(s"failed to read lock file ${file}: ${errorMessage(e)}")
+      text
+        .flatMap(parse)
+        .map(Some(_))
+        .left
+        .map(reason => s"${file}: ${reason}")
+
+  def write(file: os.Path, lock: MifLock): Either[String, Unit] =
+    val rendered = render(lock)
+    createTempFile(file).flatMap { tmp =>
+      try writeAndMove(tmp, file, rendered)
+      finally bestEffortDelete(tmp)
+    }
+
+  private def createTempFile(file: os.Path): Either[String, os.Path] =
+    try
+      os.makeDir.all(file / os.up)
+      Right(
+        os.temp(
+          dir = file / os.up,
+          prefix = s".${file.last}.",
+          suffix = ".tmp",
+          deleteOnExit = false
+        )
+      )
+    catch
+      case NonFatal(e) =>
+        Left(s"failed to write lock file ${file}: ${errorMessage(e)}")
+
+  private def writeAndMove(
+      tmp: os.Path,
+      file: os.Path,
+      rendered: String
+  ): Either[String, Unit] =
+    try
+      os.write.over(tmp, rendered)
+      AtomicFiles
+        .moveIntoPlace(tmp, file)
+        .left
+        .map(cause => s"failed to write lock file ${file}: ${cause}")
+    catch
+      case NonFatal(e) =>
+        Left(s"failed to write lock file ${file}: ${errorMessage(e)}")
+
+  private def bestEffortDelete(path: os.Path): Unit =
+    try if os.exists(path) then os.remove(path)
+    catch case NonFatal(_) => ()
+
+  /** Unions one archive run into an existing lock.
+    *
+    * `runFiles` is the set of files the relay actually served for this run, not
+    * a whole repository snapshot: a shared repo-dir can therefore never leak
+    * unrelated artifacts into the lock. A path already present must match by
+    * content; every mismatch is reported and the lock is left untouched.
+    */
+  def merge(
+      existing: MifLock,
+      upstream: LockRepository,
+      runFiles: Seq[MavenRepositoryFile],
+      run: LockRun
+  ): Either[String, MifLock] =
+    val (repositories, repositoryId) =
+      assignRepository(existing.repositories, upstream)
+    val byPath = existing.files.map(file => file.mavenPath -> file).toMap
+
+    val conflicts = runFiles.filter: observed =>
+      byPath
+        .get(observed.mavenPath)
+        .exists(locked =>
+          locked.sha256 != observed.sha256 || locked.size != observed.size
+        )
+
+    if conflicts.nonEmpty then Left(conflictMessage(conflicts, byPath))
+    else
+      val mergedFiles = runFiles.foldLeft(byPath): (acc, observed) =>
+        acc.get(observed.mavenPath) match
+          case Some(locked) =>
+            acc.updated(
+              observed.mavenPath,
+              locked.copy(runs = (locked.runs :+ run.id).distinct.sorted)
+            )
+          case None =>
+            acc.updated(
+              observed.mavenPath,
+              LockedFile(
+                repository = repositoryId,
+                mavenPath = observed.mavenPath,
+                sha256 = observed.sha256,
+                size = observed.size,
+                runs = Vector(run.id)
+              )
+            )
+
+      val runs =
+        if existing.runs.exists(_.id == run.id) then existing.runs
+        else existing.runs :+ run
+
+      Right(
+        canonicalize(
+          MifLock(
+            version = Version,
+            kind = Kind,
+            repositories = repositories,
+            runs = runs,
+            files = mergedFiles.values.toVector
+          )
+        )
+      )
+
+  private def assignRepository(
+      existing: Vector[LockRepository],
+      upstream: LockRepository
+  ): (Vector[LockRepository], String) =
+    existing.find(_.url == upstream.url) match
+      case Some(repository) => (existing, repository.id)
+      case None =>
+        val takenIds = existing.map(_.id).toSet
+        val id =
+          if !takenIds.contains(upstream.id) then upstream.id
+          else
+            // The candidate stream is infinite, so a free id always exists.
+            LazyList
+              .from(2)
+              .map(n => s"${upstream.id}-${n}")
+              .find(!takenIds.contains(_))
+              .get
+        (existing :+ upstream.copy(id = id), id)
+
+  private def conflictMessage(
+      conflicts: Seq[MavenRepositoryFile],
+      byPath: Map[String, LockedFile]
+  ): String =
+    val details = conflicts
+      .sortBy(_.mavenPath)
+      .map { observed =>
+        val locked = byPath(observed.mavenPath)
+        s"  ${observed.mavenPath}\n" +
+          s"    locked:   ${locked.sha256} (${locked.size} bytes)\n" +
+          s"    observed: ${observed.sha256} (${observed.size} bytes)"
+      }
+      .mkString("\n")
+    s"artifact content changed upstream for ${conflicts.size} path(s):\n" +
+      s"${details}\n" +
+      "Refusing to update the lock. Investigate the upstream mutation, or " +
+      "re-archive with --fresh into a clean --repo-dir if the change is expected."

--- a/mif/src/Mif.scala
+++ b/mif/src/Mif.scala
@@ -1,6 +1,6 @@
 package in.avimit.dev.mif
 
-import mainargs.{main, ParserForMethods, arg, TokensReader, Flag}
+import mainargs.{main, ParserForMethods, arg, TokensReader, Flag, Leftover}
 
 object MillIvyFetcher {
   val VERSION = "0.3.0"
@@ -8,6 +8,25 @@ object MillIvyFetcher {
   implicit object PathRead extends TokensReader.Simple[os.Path]:
     def shortName = "path"
     def read(strs: Seq[String]) = Right(os.Path(strs.head, os.pwd))
+
+  implicit object SandboxModeRead extends TokensReader.Simple[SandboxMode]:
+    def shortName = "sandbox-mode"
+    def read(strs: Seq[String]) = SandboxMode.parse(strs.head)
+
+  // Exceptions thrown inside a command are caught by mainargs and rendered
+  // with a stack trace; exiting directly keeps expected failures clean.
+  private def archiveFail(reason: String): Nothing =
+    Logger.error(reason)
+    sys.exit(1)
+
+  private[mif] def archiveCommandArgs(command: Leftover[String]): Seq[String] =
+    val args = command.value match
+      case Seq("--", args*) => args
+      case args             => args
+    args.filterNot(hasInvalidCommandChar)
+
+  private def hasInvalidCommandChar(arg: String): Boolean =
+    arg.exists(ch => ch == '\n' || ch == 0.toChar)
 
   @main
   def version(): Unit = {
@@ -116,6 +135,103 @@ object MillIvyFetcher {
     )
 
     MavenRelayServer.run(host, port, config)
+  }
+
+  @main()
+  def archive(
+      @arg(short = 'p', name = "project-dir", doc = "specify project directory")
+      projectDir: Option[os.Path],
+      @arg(
+        name = "lock",
+        doc =
+          "JSON lock file to create or append, default <project-dir>/mif.lock.json"
+      )
+      lock: Option[os.Path],
+      @arg(
+        short = 'r',
+        name = "repo-dir",
+        doc =
+          "Local Maven repository directory used to archive files, default <project-dir>/.mif/repository"
+      )
+      repoDir: Option[os.Path],
+      @arg(name = "host", doc = "Host interface for the archive relay")
+      host: String = "127.0.0.1",
+      @arg(
+        name = "port",
+        doc = "Port for the archive relay, 0 picks a free port"
+      )
+      port: Int = 0,
+      @arg(
+        short = 'u',
+        name = "upstream",
+        doc = "Maven-compatible upstream base URL"
+      )
+      upstream: String = MavenRelayServer.DefaultUpstream,
+      @arg(
+        name = "proxy",
+        doc =
+          "HTTP proxy URL for upstream requests, for example http://127.0.0.1:8080"
+      )
+      proxy: Option[String] = None,
+      @arg(
+        name = "sandbox",
+        doc = "Sandbox mode for the build command: bwrap or none"
+      )
+      sandbox: SandboxMode = SandboxMode.Bwrap,
+      @arg(
+        name = "fresh",
+        doc = "rebuild the lock from this run only instead of appending"
+      )
+      fresh: Flag = Flag(false),
+      @arg(
+        name = "keep-workdir",
+        doc = "keep the temporary sandbox home, default delete on exit"
+      )
+      keepWorkdir: Flag = Flag(false),
+      @arg(
+        name = "connect-timeout-seconds",
+        doc = "Timeout for connecting to the upstream repository"
+      )
+      connectTimeoutSeconds: Int = 30,
+      @arg(
+        name = "request-timeout-seconds",
+        doc = "Timeout for each upstream repository request"
+      )
+      requestTimeoutSeconds: Int = 120,
+      command: Leftover[String]
+  ): Unit = {
+    val projectDirPath = projectDir.getOrElse(os.pwd)
+    if !os.exists(projectDirPath) || !os.isDir(projectDirPath) then
+      archiveFail(
+        s"Project directory does not exist or is not a directory: ${projectDirPath}"
+      )
+
+    val commandArgs = archiveCommandArgs(command)
+
+    val lockPath = lock.getOrElse(projectDirPath / Lock.DefaultFileName)
+    val params = ArchiveParams(
+      projectDir = projectDirPath,
+      repoDir = repoDir.getOrElse(projectDirPath / ".mif" / "repository"),
+      lockPath = lockPath,
+      upstream = upstream,
+      proxyUrl = proxy,
+      host = host,
+      port = port,
+      sandboxMode = sandbox,
+      keepWorkdir = keepWorkdir.value,
+      fresh = fresh.value,
+      connectTimeoutSeconds = connectTimeoutSeconds,
+      requestTimeoutSeconds = requestTimeoutSeconds,
+      command = commandArgs
+    )
+
+    ArchiveRunner.run(params) match
+      case Left(reason) => archiveFail(reason)
+      case Right(summary) =>
+        Logger.info(
+          s"Lock ${lockPath} now tracks ${summary.totalFiles} files " +
+            s"(${summary.newFiles} new) from ${summary.runs} command(s)"
+        )
   }
 
   @main()

--- a/mif/src/ProcessRunner.scala
+++ b/mif/src/ProcessRunner.scala
@@ -1,5 +1,7 @@
 package in.avimit.dev.mif
 
+import scala.util.control.NonFatal
+
 case class ProcessResult(exitCode: Int, out: String, err: String)
 
 object ProcessRunner {
@@ -7,6 +9,46 @@ object ProcessRunner {
     if arg.contains('\n') || arg.contains('\u0000') then
       Logger.fatal(s"Invalid argument contains newline or null byte: ${arg}")
   }
+
+  private def invalidArg(cmd: Seq[String]): Option[String] =
+    cmd.find(arg => arg.exists(ch => ch == '\n' || ch == 0.toChar))
+
+  /** Runs a command with stdio inherited from the current terminal so its
+    * output streams live. Expected failures are values: a finished command
+    * returns its exit code, a command that cannot start returns Left.
+    * `propagateEnv = false` gives the child only the entries in `env`.
+    */
+  def runStreaming(
+      cmd: Seq[String],
+      cwd: os.Path,
+      env: Map[String, String] = Map.empty,
+      propagateEnv: Boolean = true
+  ): Either[String, Int] =
+    invalidArg(cmd) match {
+      case Some(bad) =>
+        Left(s"Invalid argument contains newline or null byte: ${bad}")
+      case None =>
+        try {
+          val result = os
+            .proc(cmd)
+            .call(
+              cwd = cwd,
+              env = env,
+              stdin = os.Inherit,
+              stdout = os.Inherit,
+              stderr = os.Inherit,
+              check = false,
+              propagateEnv = propagateEnv
+            )
+          Right(result.exitCode)
+        } catch {
+          case NonFatal(e) =>
+            val command = cmd.headOption.getOrElse("<empty command>")
+            val reason =
+              Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+            Left(s"Failed to start ${command}: ${reason}")
+        }
+    }
 
   def run(
       cmd: Seq[String],

--- a/mif/src/Relay.scala
+++ b/mif/src/Relay.scala
@@ -123,6 +123,11 @@ object MavenProxy:
   def tuple(uri: URI): (String, Int) = uri.getHost -> uri.getPort
 
 object Sha256:
+  def sri(bytes: Array[Byte]): String =
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.update(bytes)
+    s"sha256-${Base64.getEncoder.encodeToString(digest.digest())}"
+
   def sriFile(file: os.Path): Either[String, String] =
     catchNonFatal:
       val digest = MessageDigest.getInstance("SHA-256")
@@ -245,6 +250,10 @@ class MavenRelayService private (
   // and re-hashing the whole artifact under the lock. An external change moves the
   // file's mtime or size and forces a fresh SHA-256 verification.
   private val verifiedStamps = ConcurrentHashMap[String, VerifiedStamp]()
+  // Maven paths served with a 200 GET during this service's lifetime, whether
+  // from the local repository or freshly fetched. HEAD probes and upstream
+  // failures are not dependencies, so they are never tracked here.
+  private val accessedGetPaths = ConcurrentHashMap.newKeySet[String]()
   private val upstreamSession = requests.Session(
     headers = Map(
       "User-Agent" -> s"mif/${MillIvyFetcher.VERSION}",
@@ -264,6 +273,10 @@ class MavenRelayService private (
   def upstreamBaseUrl: String = upstreamBase.toString
   def proxyUrl: Option[String] = proxy.map(_.toString)
   def repositoryDatabasePath: os.Path = repositoryStore.dbPath
+
+  def accessedPaths: Seq[String] =
+    import scala.jdk.CollectionConverters.*
+    accessedGetPaths.asScala.toSeq.sorted
 
   def closeEither(): Either[String, Unit] =
     closeResources("Maven relay service")(
@@ -288,6 +301,7 @@ class MavenRelayService private (
       trustedCacheRecord(mavenPath, file) match
         case Left(response) => response
         case Right(Some(record)) =>
+          accessedGetPaths.add(mavenPath)
           cachedArtifactResponse(RelayBody.File(file), mavenPath, record)
         case Right(None) => fetchAndCacheGet(mavenPath, file)
 
@@ -519,6 +533,7 @@ class MavenRelayService private (
             // Record the just-written file's stamp so its first cache hit does
             // not re-hash bytes we just verified.
             currentStamp(file).foreach(verifiedStamps.put(mavenPath, _))
+            accessedGetPaths.add(mavenPath)
             RelayResponse(
               statusCode = 200,
               body = RelayBody.File(file),
@@ -881,6 +896,18 @@ object RelayHttpServer:
       case NonFatal(e) =>
         Left(s"Failed to stop Maven relay HTTP server: ${failureMessage(e)}")
 
+  // Undertow only knows the real port after binding, which matters when the
+  // relay is started on port 0 to pick a free ephemeral port.
+  def boundPort(server: Undertow): Either[String, Int] =
+    import scala.jdk.CollectionConverters.*
+    catchNonFatal(
+      server.getListenerInfo.asScala.headOption
+        .map(_.getAddress)
+        .collect { case address: java.net.InetSocketAddress =>
+          address.getPort
+        }
+    ).flatMap(_.toRight("Maven relay did not report a bound TCP port"))
+
 object RuntimeHooks:
   def addShutdownHook(close: () => Unit): Either[String, Unit] =
     try
@@ -911,20 +938,34 @@ class MavenRelayApp(
   def start(): Either[String, MavenRelayHandle] =
     RelayHttpServer
       .start(host, port, defaultHandler)
-      .map: server =>
-        MavenRelayHandle(
-          baseUrl = s"http://${host}:${port}/",
-          server = server,
-          service = service,
-          shutdownApp = () => executionContext.shutdown()
-        )
+      .flatMap: server =>
+        RelayHttpServer.boundPort(server) match
+          case Left(reason) =>
+            RelayHttpServer.stop(server).left.foreach(Logger.warning)
+            catchNonFatal(executionContext.shutdown()).left
+              .foreach(Logger.warning)
+            Left(reason)
+          case Right(actualPort) =>
+            Right(
+              MavenRelayHandle(
+                baseUrl = s"http://${host}:${actualPort}/",
+                boundPort = actualPort,
+                server = server,
+                service = service,
+                shutdownApp = () => executionContext.shutdown()
+              )
+            )
 
 class MavenRelayHandle(
     val baseUrl: String,
+    val boundPort: Int,
     server: Undertow,
     service: MavenRelayService,
     shutdownApp: () => Unit
 ) extends AutoCloseable:
+  // Maven paths served with a 200 GET so far. Read this before close().
+  def accessedPaths: Seq[String] = service.accessedPaths
+
   def closeEither(): Either[String, Unit] =
     closeResources("Maven relay handle")(
       "HTTP server" -> RelayHttpServer.stop(server),

--- a/mif/src/Sandbox.scala
+++ b/mif/src/Sandbox.scala
@@ -1,0 +1,306 @@
+package in.avimit.dev.mif
+
+import java.util.Locale
+
+import scala.util.control.NonFatal
+
+enum SandboxMode:
+  case Bwrap, Disabled
+
+object SandboxMode:
+  def parse(value: String): Either[String, SandboxMode] =
+    value.trim.toLowerCase match
+      case "bwrap" => Right(Bwrap)
+      case "none"  => Right(Disabled)
+      case other =>
+        Left(
+          s"invalid sandbox mode '${other}'; valid values: bwrap, none"
+        )
+
+/** How the build command will be isolated. Warnings are surfaced to the user
+  * before the build runs.
+  */
+enum SandboxStrategy(val warnings: Seq[String]):
+  case Bwrap extends SandboxStrategy(Seq.empty)
+  case CleanEnvOnly(reasons: Seq[String]) extends SandboxStrategy(reasons)
+
+object SandboxStrategy:
+  private val cleanEnvWarning =
+    "running without filesystem isolation; host caches or configuration may leak into the archived lock"
+
+  def resolve(mode: SandboxMode): Either[String, SandboxStrategy] =
+    resolve(
+      mode,
+      isLinux = sys.props
+        .getOrElse("os.name", "")
+        .toLowerCase(Locale.ROOT)
+        .contains("linux"),
+      probe = () => BubblewrapSandbox.probe(sys.env)
+    )
+
+  /** Pure decision matrix; the bubblewrap probe is injected for testability.
+    * Linux is strict: an unusable bwrap is an error rather than a silent
+    * downgrade, because a degraded run can record an incomplete lock.
+    */
+  private[mif] def resolve(
+      mode: SandboxMode,
+      isLinux: Boolean,
+      probe: () => Either[String, Unit]
+  ): Either[String, SandboxStrategy] =
+    mode match
+      case SandboxMode.Disabled =>
+        Right(CleanEnvOnly(Seq(cleanEnvWarning)))
+      case SandboxMode.Bwrap if !isLinux =>
+        Left(
+          "--sandbox bwrap requires Linux; bubblewrap has no support for this platform. Use --sandbox none to run without filesystem isolation."
+        )
+      case SandboxMode.Bwrap =>
+        probe() match
+          case Right(()) => Right(Bwrap)
+          case Left(reason) =>
+            Left(
+              s"bubblewrap sandbox is unavailable: ${reason}. " +
+                "Install bubblewrap (provided by the dev shell) or pass " +
+                "--sandbox none to run without filesystem isolation."
+            )
+
+object SandboxEnv:
+  private val bwrapPassthroughKeys = Seq(
+    "JAVA_HOME",
+    "SSL_CERT_FILE",
+    "NIX_SSL_CERT_FILE"
+  )
+
+  private val cleanEnvPassthroughKeys = Seq(
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "JAVA_HOME",
+    "SSL_CERT_FILE",
+    "NIX_SSL_CERT_FILE"
+  )
+
+  private val ignoredKeys = Seq(
+    "JAVA_TOOL_OPTIONS",
+    "JAVA_OPTS",
+    "COURSIER_CACHE",
+    "COURSIER_CONFIG_DIR",
+    "COURSIER_MIRRORS",
+    "COURSIER_REPOSITORIES",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME"
+  )
+
+  def mirrorFile(sandboxHome: os.Path): os.Path =
+    sandboxHome / ".config" / "coursier" / "mirror.properties"
+
+  def coursierCache(sandboxHome: os.Path): os.Path =
+    sandboxHome / ".cache" / "coursier"
+
+  def ivyHome(sandboxHome: os.Path): os.Path =
+    sandboxHome / ".ivy2"
+
+  def mavenLocalRepository(sandboxHome: os.Path): os.Path =
+    sandboxHome / ".m2" / "repository"
+
+  def build(
+      strategy: SandboxStrategy,
+      parentEnv: Map[String, String],
+      sandboxHome: os.Path
+  ): (Map[String, String], Seq[String]) =
+    strategy match
+      case SandboxStrategy.Bwrap => buildBwrap(parentEnv, sandboxHome)
+      case SandboxStrategy.CleanEnvOnly(_) =>
+        buildCleanEnv(parentEnv, sandboxHome)
+
+  /** Minimal environment for the bwrap child. Coursier uses its default config
+    * and cache locations under `user.home`, which JAVA_TOOL_OPTIONS points at
+    * the clean sandbox home.
+    */
+  private[mif] def buildBwrap(
+      parentEnv: Map[String, String],
+      sandboxHome: os.Path
+  ): (Map[String, String], Seq[String]) =
+    val ignored = ignoredKeys.filter(parentEnv.contains)
+    val warnings = ignored.map(key =>
+      s"environment variable ${key} is set but ignored inside the archive sandbox"
+    )
+
+    val pathEntry = parentEnv.get("PATH").map("PATH" -> _).toMap
+    val passthrough = bwrapPassthroughKeys
+      .flatMap(key => parentEnv.get(key).map(key -> _))
+      .toMap
+
+    val env = passthrough ++ pathEntry ++ Map(
+      "HOME" -> bwrapHome.toString,
+      "JAVA_TOOL_OPTIONS" -> javaToolOptions(bwrapHome)
+    )
+
+    (env, warnings)
+
+  /** Explicit unsafe fallback mode. This still has to redirect Coursier through
+    * environment variables because no filesystem sandbox is present.
+    */
+  private[mif] def buildCleanEnv(
+      parentEnv: Map[String, String],
+      sandboxHome: os.Path
+  ): (Map[String, String], Seq[String]) =
+    val ignored = ignoredKeys.filter(parentEnv.contains)
+    val warnings = ignored.map(key =>
+      s"environment variable ${key} is set but ignored inside the archive sandbox"
+    )
+
+    val pathEntry = parentEnv.get("PATH").map("PATH" -> _).toMap
+    val passthrough = cleanEnvPassthroughKeys
+      .flatMap(key => parentEnv.get(key).map(key -> _))
+      .toMap
+
+    val env = passthrough ++ pathEntry ++ Map(
+      "HOME" -> sandboxHome.toString,
+      "XDG_CACHE_HOME" -> (sandboxHome / ".cache").toString,
+      "XDG_CONFIG_HOME" -> (sandboxHome / ".config").toString,
+      "XDG_DATA_HOME" -> (sandboxHome / ".local" / "share").toString,
+      "COURSIER_CACHE" -> coursierCache(sandboxHome).toString,
+      "COURSIER_MIRRORS" -> mirrorFile(sandboxHome).toString,
+      "JAVA_TOOL_OPTIONS" -> javaToolOptions(sandboxHome)
+    )
+
+    (env, warnings)
+
+  /** JVM options every spawned JVM picks up. `-Duser.home` matters because the
+    * JVM derives user.home from /etc/passwd, not $HOME.
+    */
+  def javaToolOptions(sandboxHome: os.Path): String =
+    Seq(s"-Duser.home=${sandboxHome}").map(quoteIfNeeded).mkString(" ")
+
+  private def quoteIfNeeded(option: String): String =
+    if option.exists(_.isWhitespace) then s"\"${option}\"" else option
+
+  val bwrapHome: os.Path = os.Path("/mif")
+
+  val bwrapWorkDir: os.Path = os.Path("/workdir")
+
+object BubblewrapSandbox:
+  case class Spec(
+      projectDir: os.Path,
+      sandboxHome: os.Path,
+      env: Map[String, String],
+      command: Seq[String]
+  )
+
+  /** The bwrap invocation starts from an empty tmpfs root. The project is
+    * mounted at /workdir and mif's generated home/cache/config tree is mounted
+    * at /mif. Host toolchain roots are exposed read-only so commands from the
+    * inherited PATH still work for normal system and Nix dev-shell binaries,
+    * without exposing the whole host filesystem.
+    *
+    * The network namespace stays shared so the child reaches the relay on
+    * 127.0.0.1. `--unshare-pid` makes bwrap PID 1 of the sandbox: any daemon
+    * the build forks dies when the build command exits.
+    */
+  def argv(spec: Spec): Seq[String] =
+    val mounts = Seq(
+      "--die-with-parent",
+      "--unshare-pid",
+      "--tmpfs",
+      "/"
+    ) ++ readOnlyToolchainMounts ++ Seq(
+      "--dev",
+      "/dev",
+      "--proc",
+      "/proc",
+      "--dir",
+      "/tmp",
+      "--bind",
+      spec.projectDir.toString,
+      SandboxEnv.bwrapWorkDir.toString,
+      "--bind",
+      spec.sandboxHome.toString,
+      SandboxEnv.bwrapHome.toString,
+      "--chdir",
+      SandboxEnv.bwrapWorkDir.toString,
+      "--clearenv"
+    )
+
+    val envArgs = spec.env.toSeq.sortBy(_._1).flatMap { (key, value) =>
+      Seq("--setenv", key, value)
+    }
+
+    Seq("bwrap") ++ mounts ++ envArgs ++ Seq("--") ++ spec.command
+
+  private val readOnlyToolchainMounts: Seq[String] =
+    Seq(
+      dir("/bin"),
+      bindTry("/bin"),
+      dir("/lib"),
+      bindTry("/lib"),
+      dir("/lib64"),
+      bindTry("/lib64"),
+      dir("/usr"),
+      bindTry("/usr"),
+      dir("/nix"),
+      bindTry("/nix/store"),
+      dir("/run"),
+      dir("/run/current-system"),
+      bindTry("/run/current-system/sw"),
+      dir("/etc"),
+      bindTry("/etc/ssl"),
+      bindTry("/etc/pki")
+    ).flatten
+
+  private def dir(path: String): Seq[String] =
+    Seq("--dir", path)
+
+  private def bindTry(path: String): Seq[String] =
+    Seq("--ro-bind-try", path, path)
+
+  /** Runs a trivial command through the same argv shape the real build uses.
+    * Catches a missing bwrap binary as well as blocked user or PID namespaces
+    * (for example under restrictive container seccomp profiles).
+    */
+  def probe(parentEnv: Map[String, String]): Either[String, Unit] =
+    createProbeDir().flatMap { probeDir =>
+      try runProbe(probeDir, parentEnv)
+      finally bestEffortDelete(probeDir)
+    }
+
+  private def createProbeDir(): Either[String, os.Path] =
+    try Right(os.temp.dir(prefix = "mif-bwrap-probe-"))
+    catch case NonFatal(e) => Left(errorMessage(e))
+
+  private def runProbe(
+      probeDir: os.Path,
+      parentEnv: Map[String, String]
+  ): Either[String, Unit] =
+    try
+      val spec = Spec(
+        projectDir = probeDir,
+        sandboxHome = probeDir,
+        env = Map("PATH" -> parentEnv.getOrElse("PATH", "/usr/bin:/bin")),
+        command = Seq("/bin/sh", "-c", "true")
+      )
+      val result = os
+        .proc(argv(spec))
+        .call(
+          cwd = os.pwd,
+          check = false,
+          stdout = os.Pipe,
+          stderr = os.Pipe
+        )
+      if result.exitCode == 0 then Right(())
+      else
+        val stderr = result.err.trim()
+        Left(
+          if stderr.nonEmpty then stderr
+          else s"bwrap probe exited with code ${result.exitCode}"
+        )
+    catch case NonFatal(e) => Left(errorMessage(e))
+
+  private def bestEffortDelete(path: os.Path): Unit =
+    try os.remove.all(path)
+    catch case NonFatal(_) => ()
+
+  private def errorMessage(e: Throwable): String =
+    Option(e.getMessage).getOrElse(e.getClass.getSimpleName)

--- a/mif/test/src/ArchiveTests.scala
+++ b/mif/test/src/ArchiveTests.scala
@@ -1,0 +1,194 @@
+package in.avimit.dev.mif
+
+import utest._
+
+object ArchiveTests extends TestSuite:
+  private val upstream = MavenRelayServer.DefaultUpstream
+  private val prepareRun =
+    LockRun.fromCommand(Seq("mill", "-i", "__.prepareOffline"))
+  private val assemblyRun =
+    LockRun.fromCommand(Seq("mill", "-i", "foo.assembly"))
+
+  private def repoFile(path: String, size: Long = 42): MavenRepositoryFile =
+    MavenRepositoryFile(
+      mavenPath = path,
+      sha256 = Sha256.sri(path.getBytes("UTF-8")),
+      size = size,
+      contentType = "application/octet-stream",
+      upstreamUrl = None
+    )
+
+  private def unwrap[T](result: Either[String, T]): T =
+    result match
+      case Right(value) => value
+      case Left(reason) => throw new java.lang.AssertionError(reason)
+
+  val tests = Tests {
+    test("updateLock creates a lock from one run") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+      val files = Seq(
+        repoFile("com/example/a/1.0.0/a-1.0.0.pom"),
+        repoFile("com/example/a/1.0.0/a-1.0.0.jar")
+      )
+
+      val summary = unwrap(
+        ArchiveRunner.updateLock(
+          lockPath = lockPath,
+          runFiles = files,
+          upstream = upstream,
+          run = prepareRun,
+          fresh = false
+        )
+      )
+      assert(summary == LockUpdateSummary(2, 2, 1))
+
+      val lock = unwrap(Lock.read(lockPath)).get
+      assert(lock.repositories.map(_.id) == Vector("central"))
+      assert(lock.runs == Vector(prepareRun))
+      assert(lock.files.forall(_.runs == Vector(prepareRun.id)))
+    }
+
+    test("updateLock appends a second command into the same lock") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+      val shared = repoFile("com/example/shared/1.0.0/shared-1.0.0.jar")
+
+      val first = unwrap(
+        ArchiveRunner.updateLock(
+          lockPath,
+          Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"), shared),
+          upstream,
+          prepareRun,
+          fresh = false
+        )
+      )
+      assert(first == LockUpdateSummary(2, 2, 1))
+
+      val second = unwrap(
+        ArchiveRunner.updateLock(
+          lockPath,
+          Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom"), shared),
+          upstream,
+          assemblyRun,
+          fresh = false
+        )
+      )
+      assert(second == LockUpdateSummary(3, 1, 2))
+
+      val lock = unwrap(Lock.read(lockPath)).get
+      val byPath = lock.files.map(file => file.mavenPath -> file).toMap
+      assert(
+        byPath(shared.mavenPath).runs ==
+          Vector(prepareRun.id, assemblyRun.id).sorted
+      )
+    }
+
+    test("updateLock records the run even when it adds no new files") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+      val files = Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"))
+
+      unwrap(
+        ArchiveRunner.updateLock(lockPath, files, upstream, prepareRun, false)
+      )
+      val summary = unwrap(
+        ArchiveRunner.updateLock(lockPath, files, upstream, assemblyRun, false)
+      )
+      assert(summary == LockUpdateSummary(1, 0, 2))
+
+      val lock = unwrap(Lock.read(lockPath)).get
+      assert(
+        lock.runs.map(_.id).sorted == Vector(prepareRun, assemblyRun)
+          .map(_.id)
+          .sorted
+      )
+      assert(
+        lock.files.head.runs == Vector(prepareRun.id, assemblyRun.id).sorted
+      )
+    }
+
+    test("updateLock refuses conflicts and leaves the lock byte-identical") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+      val file = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+
+      unwrap(
+        ArchiveRunner.updateLock(
+          lockPath,
+          Seq(file),
+          upstream,
+          prepareRun,
+          false
+        )
+      )
+      val before = os.read(lockPath)
+
+      val mutated = file.copy(sha256 = Sha256.sri("other".getBytes("UTF-8")))
+      val result = ArchiveRunner.updateLock(
+        lockPath,
+        Seq(mutated),
+        upstream,
+        assemblyRun,
+        fresh = false
+      )
+      assert(result.left.exists(_.contains("artifact content changed")))
+      assert(os.read(lockPath) == before)
+    }
+
+    test("updateLock with fresh rebuilds the lock from this run only") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+
+      unwrap(
+        ArchiveRunner.updateLock(
+          lockPath,
+          Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
+          upstream,
+          prepareRun,
+          fresh = false
+        )
+      )
+      val summary = unwrap(
+        ArchiveRunner.updateLock(
+          lockPath,
+          Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom")),
+          upstream,
+          assemblyRun,
+          fresh = true
+        )
+      )
+      assert(summary == LockUpdateSummary(1, 1, 1))
+
+      val lock = unwrap(Lock.read(lockPath)).get
+      assert(
+        lock.files.map(_.mavenPath) == Vector("com/example/b/1.0.0/b-1.0.0.pom")
+      )
+      assert(lock.runs == Vector(assemblyRun))
+    }
+
+    test("lookupFiles resolves accessed paths through the repository store") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val repoDir = tempDir / "repository"
+      val recorded = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+
+      val store = MavenRepositoryStore.open(repoDir) match
+        case Right(store) => store
+        case Left(reason) => throw new java.lang.AssertionError(reason)
+      try assert(store.record(recorded) == Right(()))
+      finally store.close()
+
+      assert(
+        ArchiveRunner.lookupFiles(repoDir, Seq(recorded.mavenPath)) ==
+          Right(Vector(recorded))
+      )
+
+      val missing = ArchiveRunner.lookupFiles(
+        repoDir,
+        Seq(recorded.mavenPath, "com/example/gone/1.0.0/gone-1.0.0.pom")
+      )
+      assert(
+        missing.left.exists(_.contains("missing from the repository database"))
+      )
+    }
+  }

--- a/mif/test/src/CliTests.scala
+++ b/mif/test/src/CliTests.scala
@@ -1,11 +1,49 @@
 package in.avimit.dev.mif
 
+import mainargs.{Leftover, ParserForMethods, main}
 import utest._
 
 object CliTests extends TestSuite {
+  object ParserFixture:
+    @main
+    def archive(command: Leftover[String]): Seq[String] = command.value
+
+    @main
+    def version(): String = "test"
+
   val tests = Tests {
     test("version command outputs version") {
       assert(MillIvyFetcher.VERSION == "0.3.0")
+    }
+
+    test("archive command accepts build command as leftover arguments") {
+      val result = ParserForMethods(ParserFixture).runEither(
+        Seq("archive", "--", "mill", "run", "--", "--app-flag")
+      )
+
+      assert(result == Right(Seq("--", "mill", "run", "--", "--app-flag")))
+      assert(
+        MillIvyFetcher.archiveCommandArgs(
+          Leftover("--", "mill", "run", "--", "--app-flag")
+        ) == Seq("mill", "run", "--", "--app-flag")
+      )
+      assert(
+        MillIvyFetcher.archiveCommandArgs(
+          Leftover("--", "mill", "bad\narg", "__.compile", "bad\u0000arg")
+        ) == Seq("mill", "__.compile")
+      )
+      assert(
+        MillIvyFetcher
+          .archiveCommandArgs(
+            Leftover("--", "bad\narg", "bad\u0000arg")
+          )
+          .isEmpty
+      )
+      assert(
+        ParserForMethods(ParserFixture).runEither(Seq("archive")) == Right(
+          Seq()
+        )
+      )
     }
   }
 }

--- a/mif/test/src/LockTests.scala
+++ b/mif/test/src/LockTests.scala
@@ -1,0 +1,331 @@
+package in.avimit.dev.mif
+
+import utest._
+
+object LockTests extends TestSuite:
+  private val central =
+    Lock.repositoryFor(MavenRelayServer.DefaultUpstream) match
+      case Right(repository) => repository
+      case Left(reason)      => throw new java.lang.AssertionError(reason)
+
+  private val prepareRun =
+    LockRun.fromCommand(Seq("mill", "-i", "__.prepareOffline"))
+  private val assemblyRun =
+    LockRun.fromCommand(Seq("mill", "-i", "foo.assembly"))
+
+  private def repoFile(path: String, size: Long = 42): MavenRepositoryFile =
+    MavenRepositoryFile(
+      mavenPath = path,
+      sha256 = Sha256.sri(path.getBytes("UTF-8")),
+      size = size,
+      contentType = "application/octet-stream",
+      upstreamUrl = None
+    )
+
+  private def unwrap[T](result: Either[String, T]): T =
+    result match
+      case Right(value) => value
+      case Left(reason) => throw new java.lang.AssertionError(reason)
+
+  val tests = Tests {
+    test("run ids are stable across machines and dedupe identical commands") {
+      assert(prepareRun.id == "8f34a28c1e61")
+      assert(assemblyRun.id == "ef8e57c5498e")
+      assert(
+        LockRun.idFor(Seq("mill", "-i", "__.prepareOffline")) == prepareRun.id
+      )
+      assert(LockRun.idFor(Seq("mill -i __.prepareOffline")) != prepareRun.id)
+    }
+
+    test("repositoryFor maps central aliases to the well-known id") {
+      assert(central.id == "central")
+      assert(central.repoType == "maven")
+      assert(central.url == "https://repo1.maven.org/maven2")
+      assert(
+        Lock.repositoryFor("https://repo.maven.apache.org/maven2/") ==
+          Right(
+            LockRepository(
+              "central",
+              "maven",
+              "https://repo.maven.apache.org/maven2"
+            )
+          )
+      )
+      assert(
+        Lock.repositoryFor("https://nexus.example.com/maven2") ==
+          Right(
+            LockRepository(
+              "nexus-example-com",
+              "maven",
+              "https://nexus.example.com/maven2"
+            )
+          )
+      )
+      assert(Lock.repositoryFor("file:///tmp/repo").isLeft)
+    }
+
+    test("render produces the golden document") {
+      val jar = repoFile("com/example/foo/1.0.0/foo-1.0.0.jar", size = 49512)
+      val pom = repoFile("com/example/foo/1.0.0/foo-1.0.0.pom", size = 1207)
+      val lock =
+        unwrap(Lock.merge(Lock.empty, central, Seq(jar, pom), prepareRun))
+
+      val golden =
+        s"""{
+           |  "version": 1,
+           |  "kind": "mif-maven-lock",
+           |  "repositories": [
+           |    {
+           |      "id": "central",
+           |      "type": "maven",
+           |      "url": "https://repo1.maven.org/maven2"
+           |    }
+           |  ],
+           |  "runs": [
+           |    {
+           |      "id": "8f34a28c1e61",
+           |      "command": [
+           |        "mill",
+           |        "-i",
+           |        "__.prepareOffline"
+           |      ]
+           |    }
+           |  ],
+           |  "files": [
+           |    {
+           |      "repository": "central",
+           |      "mavenPath": "com/example/foo/1.0.0/foo-1.0.0.jar",
+           |      "sha256": "${jar.sha256}",
+           |      "size": 49512,
+           |      "runs": [
+           |        "8f34a28c1e61"
+           |      ]
+           |    },
+           |    {
+           |      "repository": "central",
+           |      "mavenPath": "com/example/foo/1.0.0/foo-1.0.0.pom",
+           |      "sha256": "${pom.sha256}",
+           |      "size": 1207,
+           |      "runs": [
+           |        "8f34a28c1e61"
+           |      ]
+           |    }
+           |  ]
+           |}
+           |""".stripMargin
+
+      val rendered = Lock.render(lock)
+      assert(rendered == golden)
+    }
+
+    test("render is deterministic under input reordering") {
+      val fileA = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+      val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
+      val forward =
+        unwrap(Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareRun))
+      val backward =
+        unwrap(Lock.merge(Lock.empty, central, Seq(fileB, fileA), prepareRun))
+      assert(Lock.render(forward) == Lock.render(backward))
+    }
+
+    test("parse render round-trip preserves hostile command strings") {
+      val command = Seq(
+        "mill",
+        "-D",
+        "prop=with \"quotes\" and \\backslashes\\",
+        "arg with spaces",
+        "#not-a-comment",
+        "unicode-テスト",
+        ""
+      )
+      val run = LockRun.fromCommand(command)
+      val lock = unwrap(
+        Lock.merge(
+          Lock.empty,
+          central,
+          Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
+          run
+        )
+      )
+      val reparsed = unwrap(Lock.parse(Lock.render(lock)))
+      assert(reparsed == lock)
+      assert(reparsed.runs.head.command == command.toVector)
+    }
+
+    test("parse rejects malformed JSON and schema violations") {
+      val base = unwrap(
+        Lock.merge(
+          Lock.empty,
+          central,
+          Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
+          prepareRun
+        )
+      )
+
+      assert(Lock.parse("not json").isLeft)
+      assert(Lock.parse("""{"version":1}""").isLeft)
+
+      def renderWith(change: MifLock => MifLock): String =
+        Lock.render(change(base))
+
+      val badVersion = Lock.parse(renderWith(_.copy(version = 2)))
+      assert(badVersion.left.exists(_.contains("unsupported lock version")))
+
+      val badKind = Lock.parse(renderWith(_.copy(kind = "other-lock")))
+      assert(badKind.left.exists(_.contains("unsupported lock kind")))
+
+      val badSha = Lock.parse(
+        renderWith(lock =>
+          lock.copy(files = lock.files.map(_.copy(sha256 = "abc123")))
+        )
+      )
+      assert(badSha.left.exists(_.contains("invalid sha256")))
+
+      val badPath = Lock.parse(
+        renderWith(lock =>
+          lock.copy(files = lock.files.map(_.copy(mavenPath = "com/../a.pom")))
+        )
+      )
+      assert(badPath.left.exists(_.contains("invalid maven path")))
+
+      val badRepository = Lock.parse(
+        renderWith(lock =>
+          lock.copy(files = lock.files.map(_.copy(repository = "missing")))
+        )
+      )
+      assert(badRepository.left.exists(_.contains("unknown repository")))
+
+      val badRunRef = Lock.parse(
+        renderWith(lock =>
+          lock.copy(files =
+            lock.files.map(_.copy(runs = Vector("000000000000")))
+          )
+        )
+      )
+      assert(badRunRef.left.exists(_.contains("unknown run ids")))
+
+      val duplicatePath = Lock.parse(
+        renderWith(lock => lock.copy(files = lock.files ++ lock.files))
+      )
+      assert(duplicatePath.left.exists(_.contains("duplicate lock entry")))
+
+      val duplicateRun = Lock.parse(
+        renderWith(lock => lock.copy(runs = lock.runs ++ lock.runs))
+      )
+      assert(duplicateRun.left.exists(_.contains("duplicate run id")))
+    }
+
+    test("read returns None for a missing lock file") {
+      val tempDir = os.temp.dir(prefix = "mif-lock-test_")
+      assert(Lock.read(tempDir / "mif.lock.json") == Right(None))
+    }
+
+    test("write is atomic and round-trips through read") {
+      val tempDir = os.temp.dir(prefix = "mif-lock-test_")
+      val lockPath = tempDir / "nested" / "mif.lock.json"
+      val lock = unwrap(
+        Lock.merge(
+          Lock.empty,
+          central,
+          Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
+          prepareRun
+        )
+      )
+
+      assert(Lock.write(lockPath, lock) == Right(()))
+      assert(Lock.read(lockPath) == Right(Some(lock)))
+
+      val updated = unwrap(
+        Lock.merge(
+          lock,
+          central,
+          Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom")),
+          assemblyRun
+        )
+      )
+      assert(Lock.write(lockPath, updated) == Right(()))
+      assert(Lock.read(lockPath) == Right(Some(updated)))
+
+      val residue = os.list(lockPath / os.up).filter(_.last.endsWith(".tmp"))
+      assert(residue.isEmpty)
+    }
+
+    test("merge appends while preserving files absent from the run") {
+      // Fresh-clone scenario: the lock already tracks A and B from a
+      // teammate's run; a local run only exercises B and C.
+      val fileA = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+      val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
+      val fileC = repoFile("com/example/c/1.0.0/c-1.0.0.pom")
+
+      val first =
+        unwrap(Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareRun))
+      val second =
+        unwrap(Lock.merge(first, central, Seq(fileB, fileC), assemblyRun))
+
+      assert(
+        second.files.map(_.mavenPath) == Vector(
+          fileA.mavenPath,
+          fileB.mavenPath,
+          fileC.mavenPath
+        )
+      )
+      assert(second.runs.map(_.id) == Vector(prepareRun.id, assemblyRun.id))
+
+      val byPath = second.files.map(file => file.mavenPath -> file).toMap
+      assert(byPath(fileA.mavenPath).runs == Vector(prepareRun.id))
+      assert(
+        byPath(fileB.mavenPath).runs ==
+          Vector(prepareRun.id, assemblyRun.id).sorted
+      )
+      assert(byPath(fileC.mavenPath).runs == Vector(assemblyRun.id))
+    }
+
+    test("merge of the same run twice is a no-op") {
+      val files = Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"))
+      val once = unwrap(Lock.merge(Lock.empty, central, files, prepareRun))
+      val twice = unwrap(Lock.merge(once, central, files, prepareRun))
+      assert(Lock.render(once) == Lock.render(twice))
+    }
+
+    test("merge reports every content conflict and keeps the lock untouched") {
+      val fileA = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+      val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
+      val existing =
+        unwrap(Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareRun))
+
+      val mutatedA = fileA.copy(sha256 = Sha256.sri("other".getBytes("UTF-8")))
+      val mutatedB = fileB.copy(size = fileB.size + 1)
+
+      val result =
+        Lock.merge(existing, central, Seq(mutatedA, mutatedB), assemblyRun)
+      result match
+        case Right(_) => assert(false)
+        case Left(reason) =>
+          assert(reason.contains("2 path(s)"))
+          assert(reason.contains(fileA.mavenPath))
+          assert(reason.contains(fileB.mavenPath))
+          assert(reason.contains("--fresh"))
+    }
+
+    test("merge reuses repository ids by url and suffixes collisions") {
+      val mirror =
+        LockRepository("central", "maven", "https://mirror.example.com/maven2")
+      val fileA = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+      val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
+
+      val first =
+        unwrap(Lock.merge(Lock.empty, central, Seq(fileA), prepareRun))
+      // Same url: entry reused, no duplicate repository.
+      val reused =
+        unwrap(Lock.merge(first, central, Seq(fileB), assemblyRun))
+      assert(reused.repositories == first.repositories)
+
+      // Different url wanting the same id: suffixed instead of clobbered.
+      val suffixed = unwrap(Lock.merge(first, mirror, Seq(fileB), assemblyRun))
+      assert(
+        suffixed.repositories.map(_.id) == Vector("central", "central-2")
+      )
+      val byPath = suffixed.files.map(file => file.mavenPath -> file).toMap
+      assert(byPath(fileB.mavenPath).repository == "central-2")
+    }
+  }

--- a/mif/test/src/ProcessRunnerTests.scala
+++ b/mif/test/src/ProcessRunnerTests.scala
@@ -18,5 +18,57 @@ object ProcessRunnerTests extends TestSuite {
         ()
       }
     }
+
+    test("runStreaming returns the exit code as a value") {
+      assert(ProcessRunner.runStreaming(Seq("true"), cwd = os.pwd) == Right(0))
+      assert(
+        ProcessRunner.runStreaming(
+          Seq("sh", "-c", "exit 3"),
+          cwd = os.pwd
+        ) == Right(3)
+      )
+    }
+
+    test("runStreaming returns Left when the command cannot start") {
+      val result = ProcessRunner.runStreaming(
+        Seq("mif-no-such-binary-for-tests"),
+        cwd = os.pwd
+      )
+      assert(result.isLeft)
+    }
+
+    test("runStreaming rejects arguments with newline or null byte") {
+      val result = ProcessRunner.runStreaming(
+        Seq("echo", "bad\narg"),
+        cwd = os.pwd
+      )
+      assert(result.isLeft)
+    }
+
+    test("runStreaming with propagateEnv=false gives the child only env") {
+      // Probe with HOME rather than PATH: shells substitute a default PATH
+      // when it is unset, but they never invent a HOME.
+      val scrubbedHome = ProcessRunner.runStreaming(
+        Seq("/bin/sh", "-c", "test -z \"$HOME\""),
+        cwd = os.pwd,
+        env = Map.empty,
+        propagateEnv = false
+      )
+      assert(scrubbedHome == Right(0))
+
+      val markerVisible = ProcessRunner.runStreaming(
+        Seq("/bin/sh", "-c", "test \"$MIF_TEST_MARKER\" = yes"),
+        cwd = os.pwd,
+        env = Map("MIF_TEST_MARKER" -> "yes"),
+        propagateEnv = false
+      )
+      assert(markerVisible == Right(0))
+
+      val inheritedPath = ProcessRunner.runStreaming(
+        Seq("/bin/sh", "-c", "test -n \"$PATH\""),
+        cwd = os.pwd
+      )
+      assert(inheritedPath == Right(0))
+    }
   }
 }

--- a/mif/test/src/RelayTests.scala
+++ b/mif/test/src/RelayTests.scala
@@ -417,6 +417,86 @@ object RelayTests extends TestSuite:
       }
     }
 
+    test("relay started on port 0 reports the actually bound port") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+        val config = MavenRelayConfig(
+          repoDir = tempDir / "repository",
+          upstreamBaseUrl = MavenRelayServer.DefaultUpstream,
+          connectTimeoutSeconds = 1,
+          requestTimeoutSeconds = 1
+        )
+        val handle = MavenRelayServer.start("127.0.0.1", 0, config) match
+          case Right(handle) => handle
+          case Left(reason)  => throw new java.lang.AssertionError(reason)
+
+        try
+          assert(handle.boundPort > 0)
+          assert(handle.baseUrl == s"http://127.0.0.1:${handle.boundPort}/")
+          val response = requests.get(handle.baseUrl, check = false)
+          assert(response.statusCode == 200)
+        finally handle.close()
+      }
+    }
+
+    test("service tracks accessed paths for successful GETs only") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val content =
+          "<project>upstream</project>".getBytes(StandardCharsets.UTF_8)
+        withLocalUpstream(sampleMavenPath, content) { upstreamBaseUrl =>
+          val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+          val repoDir = tempDir / "repository"
+          val config = MavenRelayConfig(
+            repoDir = repoDir,
+            upstreamBaseUrl = upstreamBaseUrl,
+            connectTimeoutSeconds = 1,
+            requestTimeoutSeconds = 1
+          )
+          val missingSegments =
+            Seq("com", "example", "missing", "1.0.0", "missing-1.0.0.pom")
+
+          val service = newService(config)
+          try
+            assert(service.accessedPaths.isEmpty)
+
+            assert(
+              service.handle(RelayMethod.Head, sampleSegments).statusCode == 200
+            )
+            assert(service.accessedPaths.isEmpty)
+
+            assert(
+              service.handle(RelayMethod.Get, missingSegments).statusCode == 404
+            )
+            assert(service.accessedPaths.isEmpty)
+
+            assert(
+              service.handle(RelayMethod.Get, sampleSegments).statusCode == 200
+            )
+            assert(service.accessedPaths == Seq(sampleMavenPath))
+
+            assert(
+              service.handle(RelayMethod.Get, sampleSegments).statusCode == 200
+            )
+            assert(service.accessedPaths == Seq(sampleMavenPath))
+          finally service.close()
+
+          // A fresh service over a warm repository must still observe
+          // cache-hit GETs, otherwise re-archiving with a reused repo-dir
+          // would drop files from the lock.
+          val warmService = newService(config)
+          try
+            assert(warmService.accessedPaths.isEmpty)
+            assert(
+              warmService
+                .handle(RelayMethod.Get, sampleSegments)
+                .statusCode == 200
+            )
+            assert(warmService.accessedPaths == Seq(sampleMavenPath))
+          finally warmService.close()
+        }
+      }
+    }
+
     test("GET and HEAD delete cached artifacts that differ from the database") {
       Logger.withLevel(LogLevel.Quiet) {
         val content = "<project>upstream</project>"

--- a/mif/test/src/SandboxTests.scala
+++ b/mif/test/src/SandboxTests.scala
@@ -1,0 +1,297 @@
+package in.avimit.dev.mif
+
+import utest._
+
+object SandboxTests extends TestSuite:
+  private val home = os.Path("/tmp/mif-test-home")
+
+  val tests = Tests {
+    test("SandboxMode parses the documented values") {
+      assert(SandboxMode.parse("bwrap") == Right(SandboxMode.Bwrap))
+      assert(SandboxMode.parse("none") == Right(SandboxMode.Disabled))
+      assert(SandboxMode.parse("BWRAP") == Right(SandboxMode.Bwrap))
+      assert(
+        SandboxMode.parse("chroot").left.exists(_.contains("bwrap, none"))
+      )
+    }
+
+    test("BuildTools detects mill from any invocation shape") {
+      assert(BuildTools.detect(Seq("mill", "__.compile")) == Right(MillSupport))
+      assert(BuildTools.detect(Seq("./mill")) == Right(MillSupport))
+      assert(
+        BuildTools.detect(Seq("/nix/store/abc/bin/mill")) == Right(MillSupport)
+      )
+      assert(
+        BuildTools
+          .detect(Seq("gradle", "build"))
+          .left
+          .exists(reason =>
+            reason.contains("gradle") && reason.contains("mill")
+          )
+      )
+      assert(
+        BuildTools
+          .detect(Seq.empty)
+          .left
+          .exists(_.contains("missing build command"))
+      )
+    }
+
+    test("MillSupport warns about daemon reuse") {
+      val tempDir = os.temp.dir(prefix = "mif-sandbox-test_")
+
+      val noFlag =
+        MillSupport.preflightWarnings(tempDir, Seq("mill", "__.compile"))
+      assert(noFlag.exists(_.contains("--no-daemon")))
+
+      for flag <- Seq("-i", "--interactive", "--no-daemon", "--no-server") do
+        val warnings =
+          MillSupport.preflightWarnings(
+            tempDir,
+            Seq("mill", flag, "__.compile")
+          )
+        assert(warnings.isEmpty)
+
+      os.makeDir.all(tempDir / "out" / "mill-daemon")
+      val stale =
+        MillSupport.preflightWarnings(tempDir, Seq("mill", "-i", "__.compile"))
+      assert(stale.exists(_.contains("mill shutdown")))
+    }
+
+    test("CoursierMirror mirrors both central aliases to the relay") {
+      val rendered = CoursierMirror.properties(
+        "https://repo1.maven.org/maven2",
+        "http://127.0.0.1:43217/"
+      )
+      val golden =
+        """mif0.from=https://repo1.maven.org/maven2
+          |mif0.to=http://127.0.0.1:43217
+          |mif1.from=https://repo.maven.apache.org/maven2
+          |mif1.to=http://127.0.0.1:43217
+          |""".stripMargin
+      assert(rendered == Right(golden))
+
+      val aliased = CoursierMirror.properties(
+        "https://repo.maven.apache.org/maven2/",
+        "http://127.0.0.1:43217"
+      )
+      assert(
+        aliased == Right(
+          golden.replaceFirst(
+            "mif0.from=https://repo1.maven.org/maven2",
+            "mif0.from=https://repo1.maven.org/maven2"
+          )
+        )
+      )
+
+      val custom = CoursierMirror.properties(
+        "https://nexus.example.com/maven2/",
+        "http://127.0.0.1:43217"
+      )
+      assert(
+        custom == Right(
+          "mif0.from=https://nexus.example.com/maven2\nmif0.to=http://127.0.0.1:43217\n"
+        )
+      )
+
+      assert(
+        CoursierMirror.properties("not a url", "http://127.0.0.1:1").isLeft
+      )
+    }
+
+    test("SandboxEnv builds a minimal bwrap environment") {
+      val parent = Map(
+        "PATH" -> "/nix/store/tools/bin:/run/current-system/sw/bin",
+        "TERM" -> "xterm-256color",
+        "LANG" -> "en_US.UTF-8",
+        "JAVA_HOME" -> "/nix/store/jdk",
+        "COURSIER_CACHE" -> "/home/user/.cache/coursier",
+        "COURSIER_MIRRORS" -> "/home/user/mirror.properties",
+        "JAVA_TOOL_OPTIONS" -> "-Xmx1g",
+        "SECRET_TOKEN" -> "do-not-leak"
+      )
+      val (env, warnings) = SandboxEnv.buildBwrap(parent, home)
+
+      assert(env("HOME") == SandboxEnv.bwrapHome.toString)
+      assert(env("PATH") == parent("PATH"))
+      assert(env("JAVA_HOME") == "/nix/store/jdk")
+      assert(!env.contains("TERM"))
+      assert(!env.contains("LANG"))
+      assert(!env.contains("XDG_CACHE_HOME"))
+      assert(!env.contains("XDG_CONFIG_HOME"))
+      assert(!env.contains("XDG_DATA_HOME"))
+      assert(!env.contains("COURSIER_CACHE"))
+      assert(!env.contains("COURSIER_CONFIG_DIR"))
+      assert(!env.contains("COURSIER_MIRRORS"))
+      assert(!env.contains("SECRET_TOKEN"))
+
+      val toolOptions = env("JAVA_TOOL_OPTIONS")
+      assert(toolOptions == s"-Duser.home=${SandboxEnv.bwrapHome}")
+      assert(!toolOptions.contains("-Dcoursier.cache="))
+      assert(!toolOptions.contains("-Dcoursier.config-dir="))
+      assert(!toolOptions.contains("-Dcoursier.mirrors="))
+      assert(!toolOptions.contains("-Dcoursier.ivy.home="))
+      assert(!toolOptions.contains("-Divy.home="))
+      assert(!toolOptions.contains("-Xmx1g"))
+
+      assert(warnings.exists(_.contains("COURSIER_CACHE")))
+      assert(warnings.exists(_.contains("COURSIER_MIRRORS")))
+      assert(warnings.exists(_.contains("JAVA_TOOL_OPTIONS")))
+      assert(!warnings.exists(_.contains("SECRET_TOKEN")))
+    }
+
+    test("SandboxEnv builds an explicit env-only environment") {
+      val parent = Map(
+        "PATH" -> "/nix/store/tools/bin:/run/current-system/sw/bin",
+        "TERM" -> "xterm-256color",
+        "LANG" -> "en_US.UTF-8",
+        "JAVA_HOME" -> "/nix/store/jdk"
+      )
+      val (env, warnings) = SandboxEnv.buildCleanEnv(parent, home)
+
+      assert(env("HOME") == home.toString)
+      assert(env("PATH") == parent("PATH"))
+      assert(env("TERM") == "xterm-256color")
+      assert(env("LANG") == "en_US.UTF-8")
+      assert(env("JAVA_HOME") == "/nix/store/jdk")
+      assert(env("XDG_CACHE_HOME") == (home / ".cache").toString)
+      assert(env("XDG_CONFIG_HOME") == (home / ".config").toString)
+      assert(env("XDG_DATA_HOME") == (home / ".local" / "share").toString)
+      assert(env("COURSIER_CACHE") == (home / ".cache" / "coursier").toString)
+      assert(
+        env("COURSIER_MIRRORS") ==
+          (home / ".config" / "coursier" / "mirror.properties").toString
+      )
+      assert(warnings.isEmpty)
+    }
+
+    test("SandboxEnv inherits PATH only when the host provides it") {
+      val (env, warnings) = SandboxEnv.buildBwrap(Map.empty, home)
+      assert(!env.contains("PATH"))
+      assert(warnings.isEmpty)
+    }
+
+    test("SandboxEnv quotes java options containing spaces") {
+      val spacedHome = os.Path("/tmp/mif test home")
+      val options = SandboxEnv.javaToolOptions(spacedHome)
+      assert(options.contains("\"-Duser.home=/tmp/mif test home\""))
+    }
+
+    test("BubblewrapSandbox argv has load-bearing mount ordering") {
+      val projectDir = os.Path("/home/user/project")
+      val sandboxHome = os.Path("/tmp/mif-archive-home-x")
+      val spec = BubblewrapSandbox.Spec(
+        projectDir = projectDir,
+        sandboxHome = sandboxHome,
+        env = Map("HOME" -> SandboxEnv.bwrapHome.toString, "PATH" -> "/bin"),
+        command = Seq("mill", "-i", "__.prepareOffline")
+      )
+
+      val golden = Seq(
+        "bwrap",
+        "--die-with-parent",
+        "--unshare-pid",
+        "--tmpfs",
+        "/",
+        "--dir",
+        "/bin",
+        "--ro-bind-try",
+        "/bin",
+        "/bin",
+        "--dir",
+        "/lib",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--dir",
+        "/lib64",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--dir",
+        "/usr",
+        "--ro-bind-try",
+        "/usr",
+        "/usr",
+        "--dir",
+        "/nix",
+        "--ro-bind-try",
+        "/nix/store",
+        "/nix/store",
+        "--dir",
+        "/run",
+        "--dir",
+        "/run/current-system",
+        "--ro-bind-try",
+        "/run/current-system/sw",
+        "/run/current-system/sw",
+        "--dir",
+        "/etc",
+        "--ro-bind-try",
+        "/etc/ssl",
+        "/etc/ssl",
+        "--ro-bind-try",
+        "/etc/pki",
+        "/etc/pki",
+        "--dev",
+        "/dev",
+        "--proc",
+        "/proc",
+        "--dir",
+        "/tmp",
+        "--bind",
+        "/home/user/project",
+        "/workdir",
+        "--bind",
+        "/tmp/mif-archive-home-x",
+        "/mif",
+        "--chdir",
+        "/workdir",
+        "--clearenv",
+        "--setenv",
+        "HOME",
+        "/mif",
+        "--setenv",
+        "PATH",
+        "/bin",
+        "--",
+        "mill",
+        "-i",
+        "__.prepareOffline"
+      )
+      assert(BubblewrapSandbox.argv(spec) == golden)
+    }
+
+    test("SandboxStrategy requires bwrap unless none is explicit") {
+      val probeOk = () => Right(())
+      val probeFail = () => Left("bwrap: setting up uid map: Permission denied")
+
+      assert(
+        SandboxStrategy.resolve(SandboxMode.Bwrap, isLinux = true, probeOk) ==
+          Right(SandboxStrategy.Bwrap)
+      )
+
+      val bwrapFail =
+        SandboxStrategy.resolve(SandboxMode.Bwrap, isLinux = true, probeFail)
+      assert(
+        bwrapFail.left.exists(reason =>
+          reason.contains("uid map") && reason.contains("--sandbox none")
+        )
+      )
+
+      val darwinBwrap =
+        SandboxStrategy.resolve(SandboxMode.Bwrap, isLinux = false, probeOk)
+      assert(
+        darwinBwrap.left.exists(reason =>
+          reason.contains("requires Linux") && reason.contains("--sandbox none")
+        )
+      )
+
+      val disabled =
+        SandboxStrategy.resolve(SandboxMode.Disabled, isLinux = true, probeFail)
+      disabled match
+        case Right(SandboxStrategy.CleanEnvOnly(reasons)) =>
+          assert(reasons.exists(_.contains("without filesystem isolation")))
+        case other => assert(false)
+    }
+  }

--- a/readme.md
+++ b/readme.md
@@ -52,12 +52,12 @@ an internal SQLite database under the repository root:
 .mif/repository/.mif/repository.sqlite
 ```
 
-That database is a relay implementation detail. The lock/export workflow will be
-built as a separate layer on top of this repository state.
+That database is a relay implementation detail. The lock/export workflow is
+provided by `mif archive` (see below), which drives the relay for you.
 
-This is the first step of the Maven repository based redesign. It is intended
-to replace the old Coursier-cache scanning flow over time, but the old commands
-are still present for now.
+This is part of the Maven repository based redesign. It is intended to replace
+the old Coursier-cache scanning flow over time, but the old commands are still
+present for now.
 
 Run the relay manually:
 
@@ -116,7 +116,6 @@ mill -i mif.run relay \
 
 Current limitations:
 
-* The lock/export layer is intentionally not implemented in this relay snapshot.
 * Maven Central is the only default upstream.
 * Private repository authentication and proxy authentication are not supported yet.
 * Cached Maven files are treated as archived content. Mutable metadata such as
@@ -124,6 +123,79 @@ Current limitations:
   file or use a fresh repository directory if you need to refresh it.
 * The relay only observes files requested by the build tool. Lazy Mill targets
   that are never evaluated will not be discovered by this layer.
+
+## Archive
+
+`mif archive` records the full Maven file set of a build command into a
+project-level JSON lock. It starts the relay on a free port, runs the build
+command in a clean environment whose Coursier mirror points Maven Central at
+the relay, and then writes every file the relay served into the lock:
+
+```bash
+mif archive -p path/to/project -- mill --no-daemon __.prepareOffline
+```
+
+Everything after `--` is the build command, executed inside the project
+directory. Because the run starts with empty Coursier/Mill caches and a fresh
+`HOME`, the build has to request every dependency through the relay, so the
+lock is a complete record of what the command needs.
+
+By default the lock is written to `<project-dir>/mif.lock.json` (commit this
+file) and the relay repository lives in `<project-dir>/.mif/repository`
+(disposable local state; keep it out of git). The lock records which commands
+produced it and which files each command requested:
+
+```json
+{
+  "version": 1,
+  "kind": "mif-maven-lock",
+  "repositories": [
+    { "id": "central", "type": "maven", "url": "https://repo1.maven.org/maven2" }
+  ],
+  "runs": [
+    { "id": "9f8e7d6c5b4a", "command": ["mill", "--no-daemon", "__.prepareOffline"] }
+  ],
+  "files": [
+    {
+      "repository": "central",
+      "mavenPath": "com/example/foo/1.0.0/foo-1.0.0.jar",
+      "sha256": "sha256-DAOEyJEjhkDsWJUAJ4xVSFcQqai/38MDdTuIovpi6MA=",
+      "size": 49512,
+      "runs": ["9f8e7d6c5b4a"]
+    }
+  ]
+}
+```
+
+Archive runs append: run `mif archive` once per build target and the lock
+unions the results, so one committed lock can cover a whole project. Entries
+are sorted, re-running a recorded command is a no-op, and each file lists the
+ids of all runs that requested it. If an already locked path comes back with
+different content, archive refuses to update the lock and reports every
+mismatched path — either investigate the upstream mutation or rebuild
+deliberately with `--fresh` into a clean `--repo-dir`.
+
+On Linux the build command runs inside a bubblewrap sandbox (`bwrap`): the
+host filesystem is visible read-only, the real home directory, `/tmp`, and the
+environment are masked, and only the project directory and a throwaway
+sandbox home are writable. This is what guarantees warm host caches (like
+`~/.cache/coursier` or `~/.ivy2/local`) cannot silently satisfy dependencies
+outside the relay. If bubblewrap cannot run (for example in a container that
+blocks user namespaces), archive fails with instructions; `--sandbox none`
+opts into a clean-environment run without filesystem isolation. On macOS,
+where bubblewrap does not exist, archive automatically uses the
+clean-environment mode and warns.
+
+Archive limitations:
+
+* Only traffic to the mirrored upstream is captured. Mill distribution
+  bootstrapping, `.mill-jvm-version` JVM downloads, and repositories other
+  than the configured upstream bypass the relay and will be missing from the
+  lock. Use a Nix-provided Mill and `mill-jvm-version: system` (as this
+  repository does) so the build only needs Maven Central.
+* A Mill daemon started outside the sandbox can serve requests with the wrong
+  environment. Archive warns when it finds daemon state; pass `--no-daemon`
+  (or `-i`) in the build command and run `mill shutdown` first.
 
 ## Implementation Details
 


### PR DESCRIPTION
Implements the `archive` command from the relay redesign RFC (#43): record the complete Maven file set of a build command into a project-level JSON lock.

```
mif archive [flags] -- mill --no-daemon __.prepareOffline
```

## What it does

- Starts the Maven relay in-process on an ephemeral port (`MavenRelayHandle` now reports the actually bound port, and tracks every path served with a 200 GET — cache hit or miss — so each run's file set is exact rather than first-toucher attributed).
- Runs the build command in a clean environment. On Linux this is a bubblewrap sandbox: host filesystem read-only, `/tmp` and the real home masked (the JVM derives `user.home` from `/etc/passwd`, and a populated `~/.ivy2/local` is in coursier's default repositories), project dir and a throwaway HOME writable, network namespace shared so the child reaches the relay on 127.0.0.1. Elsewhere (or with `--sandbox none`) a scrubbed-environment fallback is used with a warning; an unusable bwrap on Linux is a hard error.
- Redirects coursier at the relay via `COURSIER_MIRRORS`, `-Dcoursier.mirrors`, and the XDG `mirror.properties` (all pointing at one generated file; both Maven Central aliases are mirrored), with fresh caches so warm host state cannot skip downloads.
- Unions the run into `mif.lock.json`: files carry SRI sha256 (byte-identical to nix `fetchurl` hashes), size, and the ids of every run that requested them; runs are identified by a stable hash of their argv. Re-archiving a recorded command is a no-op diff, different targets append cleanly into one project-level lock, content mismatches are refused with a full conflict report, and `--fresh` rebuilds from the current run only.

The lock is plain JSON serialized with the existing upickle dependency (no new deps) and is `builtins.fromJSON`-readable for the upcoming `codegen`/`verify` layers.

## Verification

- 51 unit tests (`mill mif.test`), `mill mif.checkFormat` and `nix fmt -- --ci` all green.
- End-to-end against a demo mill project: `archive -- mill --no-daemon __.prepareOffline` captured 966 files through the relay (including checksums, parent POMs, and mill's own `mill-libs` bootstrap artifacts); re-running the same command left the lock byte-identical with all relay cache hits; a second command (`demo.compile`) appended as a second run with 926 files attributed to both runs and 40 to `prepareOffline` only.

Part of #43. Follow-ups (not in this PR): `codegen`/`verify` consuming the JSON lock, and wiring archive into the chisel integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)