### PR TITLE
feat: support scala-cli archives

### DIFF
--- a/mif/src/BuildTool.scala
+++ b/mif/src/BuildTool.scala
@@ -41,8 +41,43 @@ object MillSupport extends BuildToolSupport:
 
     Seq(flagWarning, daemonWarning).flatten
 
+object ScalaCliSupport extends BuildToolSupport:
+  def name = "scala-cli"
+
+  private def serverDisabled(command: Seq[String]): Boolean =
+    command.contains("--server=false") ||
+      command.sliding(2).exists(_.toSeq == Seq("--server", "false"))
+
+  def preflightWarnings(
+      projectDir: os.Path,
+      command: Seq[String]
+  ): Seq[String] =
+    val serverWarning =
+      if serverDisabled(command) then None
+      else
+        Some(
+          "scala-cli resolves the large Bloop build-server dependency graph " +
+            "by default; pass `--server=false` for a smaller daemon-free " +
+            "archive, and use the same flag when replaying the build"
+        )
+
+    val buildState = projectDir / ".scala-build"
+    val buildStateWarning =
+      if os.exists(buildState) then
+        Some(
+          s"Scala CLI generated state exists under ${buildState}; run " +
+            "`scala-cli clean .` before archiving so stale compilation " +
+            "outputs cannot hide dependency resolution"
+        )
+      else None
+
+    Seq(serverWarning, buildStateWarning).flatten
+
 object BuildTools:
-  val supported: Map[String, BuildToolSupport] = Map("mill" -> MillSupport)
+  val supported: Map[String, BuildToolSupport] = Map(
+    "mill" -> MillSupport,
+    "scala-cli" -> ScalaCliSupport
+  )
 
   /** Detects the build tool from the executable name, tolerating relative and
     * absolute invocations like `./mill` or `/nix/store/.../bin/mill`.
@@ -51,7 +86,7 @@ object BuildTools:
     command.headOption match
       case None =>
         Left(
-          "missing build command; usage: mif archive [flags] -- mill -i __.prepareOffline"
+          "missing build command; usage: mif archive [flags] -- <build-tool> <arguments>"
         )
       case Some(executable) =>
         val name = executable.split('/').last

--- a/mif/src/Relay.scala
+++ b/mif/src/Relay.scala
@@ -2,6 +2,7 @@ package in.avimit.dev.mif
 
 import java.io.OutputStream
 import java.net.URI
+import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.nio.file.AtomicMoveNotSupportedException
@@ -60,6 +61,29 @@ object MavenPath:
           .replace("+", "%20")
       )
       .mkString("/")
+
+  /** Decodes a raw HTTP path without treating `+` as a form-encoded space.
+    * Maven versions may legitimately contain `+`, while URLDecoder's default
+    * form semantics would corrupt such coordinates.
+    */
+  def fromRawPath(rawPath: String): Either[String, String] =
+    try
+      val segments = rawPath
+        .stripPrefix("/")
+        .split("/", -1)
+        .toSeq
+        .map(segment =>
+          URLDecoder.decode(
+            segment.replace("+", "%2B"),
+            StandardCharsets.UTF_8
+          )
+        )
+      fromSegments(segments)
+    catch
+      case e: IllegalArgumentException =>
+        Left(
+          s"invalid percent-encoding in Maven repository path: ${e.getMessage}"
+        )
 
   // Reserve the empty segment and any dot-leading segment. Dot-leading names are
   // where the relay keeps its own state -- the .mif metadata directory holding the
@@ -288,7 +312,16 @@ class MavenRelayService private (
     closeEither().left.foreach(Logger.warning)
 
   def handle(method: RelayMethod, segments: Seq[String]): RelayResponse =
-    MavenPath.fromSegments(segments) match
+    handlePath(method, MavenPath.fromSegments(segments))
+
+  def handleRawPath(method: RelayMethod, rawPath: String): RelayResponse =
+    handlePath(method, MavenPath.fromRawPath(rawPath))
+
+  private def handlePath(
+      method: RelayMethod,
+      parsedPath: Either[String, String]
+  ): RelayResponse =
+    parsedPath match
       case Left(reason) => textResponse(400, reason)
       case Right(mavenPath) =>
         method match
@@ -812,7 +845,7 @@ case class MavenRelayRoutes(service: MavenRelayService)(implicit
       RelayMethod.fromHttp(request.exchange.getRequestMethod.toString)
     val response =
       if segments.value.isEmpty then rootResponse(method)
-      else service.handle(method, segments.value)
+      else service.handleRawPath(method, request.exchange.getRequestURI)
 
     cask.Response(
       toCaskData(response.body),

--- a/mif/src/Sandbox.scala
+++ b/mif/src/Sandbox.scala
@@ -117,9 +117,9 @@ object SandboxEnv:
       case SandboxStrategy.CleanEnvOnly(_) =>
         buildCleanEnv(parentEnv, sandboxHome, exportEnv)
 
-  /** Minimal environment for the bwrap child. Coursier uses its default config
-    * and cache locations under `user.home`, which JAVA_TOOL_OPTIONS points at
-    * the clean sandbox home.
+  /** Minimal environment for the bwrap child. Paths are explicit because native
+    * launchers such as Scala CLI do not necessarily derive Coursier or XDG
+    * locations from the JVM's `user.home` property.
     */
   private[mif] def buildBwrap(
       parentEnv: Map[String, String],
@@ -129,10 +129,7 @@ object SandboxEnv:
     val (inherited, exported, warnings) =
       parentEntries(parentEnv, bwrapPassthroughKeys, exportEnv)
 
-    val env = inherited ++ Map(
-      "HOME" -> bwrapHome.toString,
-      "JAVA_TOOL_OPTIONS" -> javaToolOptions(bwrapHome)
-    ) ++ exported
+    val env = inherited ++ sandboxPaths(bwrapHome) ++ exported
 
     (env, warnings)
 
@@ -147,15 +144,7 @@ object SandboxEnv:
     val (inherited, exported, warnings) =
       parentEntries(parentEnv, cleanEnvPassthroughKeys, exportEnv)
 
-    val env = inherited ++ Map(
-      "HOME" -> sandboxHome.toString,
-      "XDG_CACHE_HOME" -> (sandboxHome / ".cache").toString,
-      "XDG_CONFIG_HOME" -> (sandboxHome / ".config").toString,
-      "XDG_DATA_HOME" -> (sandboxHome / ".local" / "share").toString,
-      "COURSIER_CACHE" -> coursierCache(sandboxHome).toString,
-      "COURSIER_MIRRORS" -> mirrorFile(sandboxHome).toString,
-      "JAVA_TOOL_OPTIONS" -> javaToolOptions(sandboxHome)
-    ) ++ exported
+    val env = inherited ++ sandboxPaths(sandboxHome) ++ exported
 
     (env, warnings)
 
@@ -187,6 +176,17 @@ object SandboxEnv:
       .toMap
 
     (passthrough ++ pathEntry, exported, ignoredWarnings ++ missingWarnings)
+
+  private def sandboxPaths(home: os.Path): Map[String, String] =
+    Map(
+      "HOME" -> home.toString,
+      "XDG_CACHE_HOME" -> (home / ".cache").toString,
+      "XDG_CONFIG_HOME" -> (home / ".config").toString,
+      "XDG_DATA_HOME" -> (home / ".local" / "share").toString,
+      "COURSIER_CACHE" -> coursierCache(home).toString,
+      "COURSIER_MIRRORS" -> mirrorFile(home).toString,
+      "JAVA_TOOL_OPTIONS" -> javaToolOptions(home)
+    )
 
   /** JVM options every spawned JVM picks up. `-Duser.home` matters because the
     * JVM derives user.home from /etc/passwd, not $HOME.

--- a/mif/test/src/RelayTests.scala
+++ b/mif/test/src/RelayTests.scala
@@ -128,6 +128,15 @@ object RelayTests extends TestSuite:
   val tests = Tests {
     test("MavenPath accepts repository-relative Maven paths") {
       assert(MavenPath.fromSegments(sampleSegments) == Right(sampleMavenPath))
+      assert(
+        MavenPath.fromRawPath("/com/example/a/1.0.0+39/a-1.0.0+39.pom") ==
+          Right("com/example/a/1.0.0+39/a-1.0.0+39.pom")
+      )
+      assert(
+        MavenPath.fromRawPath("/com/example/a/1.0.0%2B39/a.pom") ==
+          Right("com/example/a/1.0.0+39/a.pom")
+      )
+      assert(MavenPath.fromRawPath("/com/example/%XX/a.pom").isLeft)
     }
 
     test("MavenPath rejects unsafe path segments") {
@@ -436,6 +445,39 @@ object RelayTests extends TestSuite:
           val response = requests.get(handle.baseUrl, check = false)
           assert(response.statusCode == 200)
         finally handle.close()
+      }
+    }
+
+    test("relay preserves plus signs in Maven coordinates") {
+      Logger.withLevel(LogLevel.Quiet) {
+        val mavenPath =
+          "ch/epfl/scala/example/0.34.0+39/example-0.34.0+39.pom"
+        val content = "<project>plus-version</project>"
+          .getBytes(StandardCharsets.UTF_8)
+
+        withLocalUpstream(MavenPath.encodeForUri(mavenPath), content) {
+          upstreamBaseUrl =>
+            val tempDir = os.temp.dir(prefix = "mif-relay-test_")
+            val config = MavenRelayConfig(
+              repoDir = tempDir / "repository",
+              upstreamBaseUrl = upstreamBaseUrl,
+              connectTimeoutSeconds = 1,
+              requestTimeoutSeconds = 1
+            )
+            val handle = MavenRelayServer.start("127.0.0.1", 0, config) match
+              case Right(handle) => handle
+              case Left(reason)  => throw new java.lang.AssertionError(reason)
+
+            try
+              val response = requests.get(
+                s"${handle.baseUrl}${mavenPath}",
+                check = false
+              )
+              assert(response.statusCode == 200)
+              assert(response.bytes.sameElements(content))
+              assert(handle.accessedPaths == Seq(mavenPath))
+            finally handle.close()
+        }
       }
     }
 

--- a/mif/test/src/SandboxTests.scala
+++ b/mif/test/src/SandboxTests.scala
@@ -15,18 +15,28 @@ object SandboxTests extends TestSuite:
       )
     }
 
-    test("BuildTools detects mill from any invocation shape") {
+    test("BuildTools detects supported tools from any invocation shape") {
       assert(BuildTools.detect(Seq("mill", "__.compile")) == Right(MillSupport))
       assert(BuildTools.detect(Seq("./mill")) == Right(MillSupport))
       assert(
         BuildTools.detect(Seq("/nix/store/abc/bin/mill")) == Right(MillSupport)
       )
       assert(
+        BuildTools.detect(Seq("scala-cli", "compile", ".")) ==
+          Right(ScalaCliSupport)
+      )
+      assert(BuildTools.detect(Seq("./scala-cli")) == Right(ScalaCliSupport))
+      assert(
+        BuildTools.detect(Seq("/nix/store/abc/bin/scala-cli")) ==
+          Right(ScalaCliSupport)
+      )
+      assert(
         BuildTools
           .detect(Seq("gradle", "build"))
           .left
           .exists(reason =>
-            reason.contains("gradle") && reason.contains("mill")
+            reason.contains("gradle") && reason.contains("mill") &&
+              reason.contains("scala-cli")
           )
       )
       assert(
@@ -56,6 +66,29 @@ object SandboxTests extends TestSuite:
       val stale =
         MillSupport.preflightWarnings(tempDir, Seq("mill", "-i", "__.compile"))
       assert(stale.exists(_.contains("mill shutdown")))
+    }
+
+    test("ScalaCliSupport warns about generated build state") {
+      val tempDir = os.temp.dir(prefix = "mif-scala-cli-test_")
+      val command = Seq("scala-cli", "compile", "--test", ".")
+
+      val defaultServer = ScalaCliSupport.preflightWarnings(tempDir, command)
+      assert(defaultServer.exists(_.contains("--server=false")))
+
+      val daemonless =
+        ScalaCliSupport.preflightWarnings(
+          tempDir,
+          Seq("scala-cli", "compile", "--test", "--server=false", ".")
+        )
+      assert(daemonless.isEmpty)
+
+      os.makeDir.all(tempDir / ".scala-build")
+      val stale = ScalaCliSupport.preflightWarnings(
+        tempDir,
+        Seq("scala-cli", "compile", "--server", "false", ".")
+      )
+      assert(stale.exists(_.contains("scala-cli clean .")))
+      assert(stale.exists(_.contains((tempDir / ".scala-build").toString)))
     }
 
     test("CoursierMirror mirrors both central aliases to the relay") {
@@ -117,12 +150,14 @@ object SandboxTests extends TestSuite:
       assert(env("JAVA_HOME") == "/nix/store/jdk")
       assert(!env.contains("TERM"))
       assert(!env.contains("LANG"))
-      assert(!env.contains("XDG_CACHE_HOME"))
-      assert(!env.contains("XDG_CONFIG_HOME"))
-      assert(!env.contains("XDG_DATA_HOME"))
-      assert(!env.contains("COURSIER_CACHE"))
+      assert(env("XDG_CACHE_HOME") == "/mif/.cache")
+      assert(env("XDG_CONFIG_HOME") == "/mif/.config")
+      assert(env("XDG_DATA_HOME") == "/mif/.local/share")
+      assert(env("COURSIER_CACHE") == "/mif/.cache/coursier")
       assert(!env.contains("COURSIER_CONFIG_DIR"))
-      assert(!env.contains("COURSIER_MIRRORS"))
+      assert(
+        env("COURSIER_MIRRORS") == "/mif/.config/coursier/mirror.properties"
+      )
       assert(!env.contains("SECRET_TOKEN"))
 
       val toolOptions = env("JAVA_TOOL_OPTIONS")

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # Mill Ivy Fetcher
 
-Mill Ivy Fetcher (`mif`) records the Maven artifacts requested by a Mill build
+Mill Ivy Fetcher (`mif`) records the Maven artifacts requested by a Scala build
 and turns them into a Nix-consumable lock file. The lock can then be converted
-into a local Maven repository derivation, allowing Mill/Coursier builds to run in
-a Nix sandbox without network access.
+into a local Maven repository derivation, allowing Mill or Scala CLI builds that
+use Coursier to run in a Nix sandbox without network access.
 
 This repository includes a Chisel integration test (`.#ci-test`) that publishes
 Chisel locally from a locked Maven repository, proving that `mif` can capture a
@@ -11,7 +11,7 @@ large real-world Mill build and replay it offline through Nix.
 
 The workflow is:
 
-1. Run `mif archive` around one or more Mill targets.
+1. Run `mif archive` around one or more build commands.
 2. Commit the generated `mif.lock.json`.
 3. Use `mkMavenRepository` in Nix to materialize the locked Maven repository.
 4. Put that repository in a derivation's inputs so Coursier resolves from the
@@ -21,7 +21,8 @@ The workflow is:
 
 - Nix >= 2.28
 - Flakes with `nix-command` enabled
-- Mill 0.12.7+ or Mill 1.1.0+
+- Mill 0.12.7+ or Mill 1.1.0+ for Mill projects
+- Scala CLI for Scala CLI projects
 - Linux: `bubblewrap` is required for the default archive sandbox
 
 This repository's default dev shell includes `mif`, Mill, and Metals. On Linux,
@@ -66,6 +67,26 @@ the equivalent commands are:
 java -jar ./out/mif/assembly.dest/out.jar archive -- mill --no-daemon __.prepareOffline
 java -jar ./out/mif/assembly.dest/out.jar archive -- mill --no-daemon __.scalaCompilerClasspath
 ```
+
+## Quick start for Scala CLI projects
+
+Remove generated compilation state, then compile both the main and test scopes
+through the archive:
+
+```bash
+scala-cli clean path/to/project
+mif archive -p path/to/project -- scala-cli compile --test --server=false .
+```
+
+Scala CLI does not provide a dedicated dependency-fetch command, so compiling
+both scopes is the closest equivalent. `--server=false` avoids resolving the
+large Bloop build-server dependency graph and makes this a daemon-free one-shot
+capture. Use the same flag when replaying the build because it changes the
+required artifacts. MIF warns when it is omitted but does not block the command.
+
+Like Mill, Scala CLI can use additional repositories or download a selected JVM
+outside Maven Central. Those downloads are not captured; use a Nix-provided JDK
+and keep dependency repositories within the configured MIF upstream.
 
 ## Using a lock from Nix
 
@@ -143,7 +164,7 @@ environment whose Coursier mirror points Maven Central at that relay, runs the
 command after `--`, and writes every file served by the relay into a JSON lock.
 
 ```bash
-mif archive [options] -- mill --no-daemon __.prepareOffline
+mif archive [options] -- <mill|scala-cli> <arguments>
 ```
 
 If a build needs selected variables from the invoking environment, export them
@@ -171,9 +192,9 @@ Important options:
 - `--keep-workdir`: keep the temporary sandbox home for debugging.
 - `--proxy <url>`: HTTP proxy for upstream relay requests.
 
-Everything after `--` is executed inside the project directory. Currently `mif
-archive` supports Mill commands and warns when the command may reuse a Mill daemon
-from outside the archive environment.
+Everything after `--` is executed inside the project directory. `mif archive`
+supports Mill and Scala CLI commands. It warns about daemon or build-server use
+and persisted compilation state that should be cleaned before capture.
 
 A lock has this shape:
 
@@ -339,6 +360,9 @@ to `mill-ivy-fetcher.packages.${system}.mif` directly.
   refresh it.
 - The relay observes only files requested by the build command. Lazy Mill targets
   that are never evaluated will not be discovered.
+- Scala CLI JVM downloads selected by `--jvm` or `using jvm` do not use Maven
+  repositories and are not captured. Prefer a Nix-provided system JDK for offline
+  builds.
 - A Mill daemon started outside the sandbox can serve requests with the wrong
   environment. Run `mill shutdown` first and pass `--no-daemon` or `-i` in the
   archived Mill command.


### PR DESCRIPTION
## Summary

- recognize scala-cli archive commands and provide tool-specific preflight guidance
- expose explicit XDG and Coursier paths so native Scala CLI launchers use the sandbox relay
- recommend daemon-free main and test dependency capture with --server=false
- preserve plus signs in Maven coordinates, including Bloop artifact versions
- document Scala CLI usage and uncaptured JVM download limitations

## Verification

- mill --no-daemon mif.test
- nix fmt -- --ci
- real Scala CLI 1.15.0 archive smoke test using compile --test --server=false
- verified the generated lock contains main and test dependencies and no Bloop artifacts