### PR TITLE
Group Maven artifact fetches by dependency

### DIFF
--- a/.github/integration/chisel-lock.json
+++ b/.github/integration/chisel-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "kind": "mif-maven-lock",
   "repositories": {
     "central": "https://repo1.maven.org/maven2"
@@ -24,6 +24,7 @@
   },
   "artifacts": {
     "ch/epfl/scala/bsp4j/2.2.0-M2": {
+      "narHash": "sha256-riEisSGg7NrufcDdX5mPdkqu6pAghdsa1dwd0H3NSBM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -36,6 +37,7 @@
       }
     },
     "ch/qos/logback/logback-classic/1.5.27": {
+      "narHash": "sha256-M8PW+6akfxRAWQd6H1vUKAcYHsR/8gYavZQyTbja8uE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -48,6 +50,7 @@
       }
     },
     "ch/qos/logback/logback-core/1.5.27": {
+      "narHash": "sha256-7tz18bTQnsAzICii3Ug/ZQLXqNgeD9rNiZKIPHXAHD8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -60,6 +63,7 @@
       }
     },
     "ch/qos/logback/logback-parent/1.5.27": {
+      "narHash": "sha256-yk0LJrb/Gi2ipB4eS2nCg8uVmNTxYuvW/Cl96MNF3l8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -70,6 +74,7 @@
       }
     },
     "co/fs2/fs2-core_3/3.9.3": {
+      "narHash": "sha256-gRbXQZAaXKGOUuWP3/lBm4QFgmdqgCFV05lw9Ca3T3k=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -82,6 +87,7 @@
       }
     },
     "co/fs2/fs2-io_3/3.9.3": {
+      "narHash": "sha256-s5f/QQi9PqhoI2UW2OZV92Gn0YsVU8UvIP6xaBkTFO4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -94,6 +100,7 @@
       }
     },
     "com/47deg/github4s_3/0.33.3": {
+      "narHash": "sha256-8QbLIM0yQLsI+y9JtzgC92Qjnqp/5RpFQ8t6CgjNamo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -106,6 +113,7 @@
       }
     },
     "com/amazonaws/aws-java-sdk-bom/1.12.791": {
+      "narHash": "sha256-g09zmHHl9SL5kPpIedsIFGOH33QUMHOODkLs30m/oFg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -116,6 +124,7 @@
       }
     },
     "com/amazonaws/aws-java-sdk-pom/1.12.791": {
+      "narHash": "sha256-QmLlH3LKGvHOuTr+RJUc750t9DCtdwkhTX9dEdijd0o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -126,6 +135,7 @@
       }
     },
     "com/comcast/ip4s-core_3/3.4.0": {
+      "narHash": "sha256-4DYVx/nXeyzHgd9eLqXuiYVzRpDenJgvjw9W87UqoSk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -138,6 +148,7 @@
       }
     },
     "com/eed3si9n/jarjar/jarjar/1.16.0": {
+      "narHash": "sha256-UYc2LQrGLVFqgIBOYhuAtEL3JupwoeADrbNtgIJdMZg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -149,6 +160,7 @@
       }
     },
     "com/eed3si9n/jarjarabrams/jarjar-abrams-core_3/1.16.0": {
+      "narHash": "sha256-tnNJslu+0f+y//VxAVR5JpF88gAEQJ8UxDfh0GLDgmM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -160,6 +172,7 @@
       }
     },
     "com/eed3si9n/shaded-jawn-parser_3/1.3.2": {
+      "narHash": "sha256-7XTQAaQSSG7zNXUbyQr2mH2MuCmKz8A8RNcOciaJcuw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -172,6 +185,7 @@
       }
     },
     "com/eed3si9n/shaded-scalajson_3/1.0.0-M4": {
+      "narHash": "sha256-VGRRrmntOUUMYlppcclKOR7VBI6vzmkpMGOgtM/TRRE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -184,6 +198,7 @@
       }
     },
     "com/eed3si9n/sjson-new-core_3/0.10.1": {
+      "narHash": "sha256-bwKrCB7krQM2P9kC9n8OSXfgQ7Bd1aSrrnpKF6E+cmU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -194,6 +209,7 @@
       }
     },
     "com/eed3si9n/sjson-new-core_3/0.14.0-M5": {
+      "narHash": "sha256-RNQNkYbLNuElYtCO+4UcIPI4KtZbQ3oQkGeW4iXwpks=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -206,6 +222,7 @@
       }
     },
     "com/eed3si9n/sjson-new-scalajson_3/0.14.0-M5": {
+      "narHash": "sha256-1XznRkoEKgLYu+nq0QKrTJ+TMDaDxLzat+baykMBA+c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -218,6 +235,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-bom/2.19.1": {
+      "narHash": "sha256-K7w+ZdUjzt90b4/zi/0f+PN7fVL2s4zk9t7UJObbeSk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -228,6 +246,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-bom/2.20.0": {
+      "narHash": "sha256-s5OPi1CSgEEe3E6jtaoggsQ0gKskxw8a62fyvPUeM4s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -238,6 +257,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-parent/2.19.2": {
+      "narHash": "sha256-DWUObf2+ywHc4gl9WA7DLWniqFdQrwULas4SD0e1sH0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -248,6 +268,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-parent/2.20": {
+      "narHash": "sha256-uM1b0bq+bdShZkzhfVmGZ2KeZcaDK1ShVLtxnp2rpkc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -258,6 +279,7 @@
       }
     },
     "com/fasterxml/oss-parent/38": {
+      "narHash": "sha256-GBqwomoPPjctY9+Bl30t7vbVukecFssjVJM+aceJm1U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -267,6 +289,7 @@
       }
     },
     "com/fasterxml/oss-parent/50": {
+      "narHash": "sha256-SqC2BvAQQCEx6FOxwA44/VKPfo17WmBC0zo6PCDXSV0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -276,6 +299,7 @@
       }
     },
     "com/fasterxml/oss-parent/68": {
+      "narHash": "sha256-BEI7RSfOVS6ffxk7QRZqMSnZKviWK6dspqBRPbmS8Zo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -286,6 +310,7 @@
       }
     },
     "com/fasterxml/oss-parent/70": {
+      "narHash": "sha256-yVNj/mEDVBU3v97dp2sW6ZmYlpMaKEOcwzAarhZDbpE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -296,6 +321,7 @@
       }
     },
     "com/fasterxml/woodstox/woodstox-core/6.5.1": {
+      "narHash": "sha256-fD2lUC5fGmCWYy52HXtPlLrrU9FgH1EQfLxiukFs8uk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -307,6 +333,7 @@
       }
     },
     "com/github/javaparser/javaparser-core/3.28.0": {
+      "narHash": "sha256-is81Ay9tN8epaOoRaPIk91jaDTwwd4iFjCWseL3FNr0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -319,6 +346,7 @@
       }
     },
     "com/github/javaparser/javaparser-parent/3.28.0": {
+      "narHash": "sha256-2IqHtOi+lDoVV6qhILXIDwFVZL2HY8I23aa2ymBbhh8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -329,6 +357,7 @@
       }
     },
     "com/github/lolgab/mill-mima-worker-api_3/0.2.0": {
+      "narHash": "sha256-Mbn4sedxb2y2acm8p/0mzJbWTIcjAbbXfK0f440/NFo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -341,6 +370,7 @@
       }
     },
     "com/github/lolgab/mill-mima_mill1_3/0.2.0": {
+      "narHash": "sha256-pbGjHbIzRVb/+mkcqLsm0FAyJxyRgITVjC5pS5wf2NQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -353,6 +383,7 @@
       }
     },
     "com/github/luben/zstd-jni/1.5.7-4": {
+      "narHash": "sha256-/vyiPq5Va33XWn5FKXculjv81pPQoNvwZpLNM071n/I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -365,6 +396,7 @@
       }
     },
     "com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-core_2.13/2.13.5": {
+      "narHash": "sha256-QGQouGAHh/gjaahhoAHWdAOUyC66tebMFUNWfaHjaqU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -377,6 +409,7 @@
       }
     },
     "com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-core_2.13/2.36.6": {
+      "narHash": "sha256-tOrjAQZNQ1KQLmhmFkqX3JXHMN+YwMVb23BsI0RxPpM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -388,6 +421,7 @@
       }
     },
     "com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-macros_2.13/2.36.6": {
+      "narHash": "sha256-Xp7f5KhJgvKLQBc0pm5Pu02CCeW1qbSIOExa8XV9b1w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -399,6 +433,7 @@
       }
     },
     "com/github/scopt/scopt_2.13/4.1.0": {
+      "narHash": "sha256-cwrgaIBkwqe/Iyd1+rRCqVrBMqHqEdDDnMunaZWfSms=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -410,6 +445,7 @@
       }
     },
     "com/github/scopt/scopt_3/4.1.0": {
+      "narHash": "sha256-rovE5213gFoWnwR1YJV5xJKh7qXjArimMTDMFicVAV0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -421,6 +457,7 @@
       }
     },
     "com/google/code/findbugs/jsr305/3.0.2": {
+      "narHash": "sha256-g9+oRxLy7d53/y4icvoktpsTAPqpA/7zEkwZ6p/oHcI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -433,6 +470,7 @@
       }
     },
     "com/google/code/gson/gson-parent/2.13.1": {
+      "narHash": "sha256-EnGuR1MDbFnWKIrKvV1a2sSXWEaCE45THW0uoRcH53Q=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -442,6 +480,7 @@
       }
     },
     "com/google/code/gson/gson-parent/2.13.2": {
+      "narHash": "sha256-LYpHnVbp0G/7zw5xI6FnxZxBEgxcM50+vcKbY0jet5w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -452,6 +491,7 @@
       }
     },
     "com/google/code/gson/gson/2.13.1": {
+      "narHash": "sha256-QNsV6MBeeW5XvqVL8/KGq1rZSpjqwrQAtp6+TEhwgJU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -463,6 +503,7 @@
       }
     },
     "com/google/code/gson/gson/2.13.2": {
+      "narHash": "sha256-paQKaa97vKjJyXU/Lovim6+/QBn+DnbMGr3Wu+BtBjw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -475,6 +516,7 @@
       }
     },
     "com/google/errorprone/error_prone_annotations/2.38.0": {
+      "narHash": "sha256-xudEk5jN3aA7gTXivo6dMj205hZH2ypWuJ8ijCIjd8Y=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -486,6 +528,7 @@
       }
     },
     "com/google/errorprone/error_prone_annotations/2.41.0": {
+      "narHash": "sha256-iQpYYJ9xjZP9In6rvrS17PaG0VJ4unwsceE3SapBRdE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -498,6 +541,7 @@
       }
     },
     "com/google/errorprone/error_prone_parent/2.38.0": {
+      "narHash": "sha256-PH0nvjvsZkSn8Z3AyOR/MMV2tptsWcBtpi9fsOqgiEM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -507,6 +551,7 @@
       }
     },
     "com/google/errorprone/error_prone_parent/2.41.0": {
+      "narHash": "sha256-PSMqv0t0yvPqdiyUeQi6Frqlv3KxdWjdbxxKKMh12Nc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -517,6 +562,7 @@
       }
     },
     "com/google/guava/failureaccess/1.0.1": {
+      "narHash": "sha256-teUXLa0DDjjnMaQUqNmTffnXC+YS6W0vl4fGOZrXAMo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -529,6 +575,7 @@
       }
     },
     "com/google/guava/guava-parent/26.0-android": {
+      "narHash": "sha256-cwYFhpuIJco6AaQKQPebYS8x4ZXFS7/cV5EhMmu0CAc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -539,6 +586,7 @@
       }
     },
     "com/google/guava/guava-parent/30.1-jre": {
+      "narHash": "sha256-ub53xD5zNU4yR+VrbMlFIIDaN/kqRwZPbNuBtGSO1Uo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -549,6 +597,7 @@
       }
     },
     "com/google/guava/guava/30.1-jre": {
+      "narHash": "sha256-+s18UtReEs727w+R+0ULlntPvHGCBwHv3rOul/fGHvU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -561,6 +610,7 @@
       }
     },
     "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+      "narHash": "sha256-yiT6ShupcfSld7NPPnR7gwG6FVEQagHUfGd7IfoWJ5E=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -573,6 +623,7 @@
       }
     },
     "com/google/j2objc/j2objc-annotations/1.3": {
+      "narHash": "sha256-//0MyUZxO0O6d3RyHDxYmdNj31XYzsFb2uPoVJo5pH4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -585,6 +636,7 @@
       }
     },
     "com/googlecode/java-diff-utils/diffutils/1.3.0": {
+      "narHash": "sha256-+I419hEPC1jlp+aIV5gRW1d9sBjh7dadODYchfiZ3Qk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -596,6 +648,7 @@
       }
     },
     "com/googlecode/javaewah/JavaEWAH/1.2.3": {
+      "narHash": "sha256-ZRpvRWr9LxxsTrLg07Uu/8II0Kyyp7kdItWKaIgGuHY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -608,6 +661,7 @@
       }
     },
     "com/ibm/icu/icu4j/72.1": {
+      "narHash": "sha256-uP6rRbGwQ5EzDay9aDFLAX6K6hKcuLZZWlNaCvgJ77w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -619,6 +673,7 @@
       }
     },
     "com/lihaoyi/fansi_2.13/0.5.0": {
+      "narHash": "sha256-KBFnRKga+7flqPaXBXO0N/xv9RaKO3J8lRsFrg737XM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -630,6 +685,7 @@
       }
     },
     "com/lihaoyi/fansi_3/0.5.1": {
+      "narHash": "sha256-GikZJI3z3gVCQcKIa2DhyUZ9kKwpRA6C90AJm7zwwKw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -642,6 +698,7 @@
       }
     },
     "com/lihaoyi/fastparse_3/3.1.1": {
+      "narHash": "sha256-+SS+GdCqO3fqpdbYRZTmwmAd3c9n5ZpFKVKGA0AEHI0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -654,6 +711,7 @@
       }
     },
     "com/lihaoyi/geny_2.13/1.1.1": {
+      "narHash": "sha256-LAWGTVX2ubI5WQbg/LoKOwbLDlfOC11PdnPs2NQrml4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -665,6 +723,7 @@
       }
     },
     "com/lihaoyi/geny_3/1.0.0": {
+      "narHash": "sha256-ZEdkoV3jTcDWrJ7y8OQGpyxVwEWFnA9QLd++P3anMbg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -675,6 +734,7 @@
       }
     },
     "com/lihaoyi/geny_3/1.1.1": {
+      "narHash": "sha256-DHU1MhETMcPZjCSL7lYzaxvt1VmF37sPfmXirSg3ACU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -687,6 +747,7 @@
       }
     },
     "com/lihaoyi/mainargs_3/0.7.8": {
+      "narHash": "sha256-ZwqrHP9D8+v70L0sLi/xJZ7rBmxX03uniqN8kZmkx+8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -699,6 +760,7 @@
       }
     },
     "com/lihaoyi/mill-contrib-jmh_3/1.1.2": {
+      "narHash": "sha256-Z3ArbGN993fuyg2TKEvy3hgbBHEVPYKWHiEu8AmOyMc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -711,6 +773,7 @@
       }
     },
     "com/lihaoyi/mill-core-api-daemon_3/1.1.2": {
+      "narHash": "sha256-hnjNfAxFPlwWdwUpvlYDkMfQNoBeNK4WMQ9RNl+f5Po=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -723,6 +786,7 @@
       }
     },
     "com/lihaoyi/mill-core-api-java11_3/1.1.2": {
+      "narHash": "sha256-kEXr9imZgyjDOMICGm0zAbtbjP64oi5Dq2BAZ3JmOT8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -735,6 +799,7 @@
       }
     },
     "com/lihaoyi/mill-core-api_3/1.1.2": {
+      "narHash": "sha256-aJ8mMLWfHjoQIjwwJI5r96WmgmsH/TdXb/PGjO9EREA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -747,6 +812,7 @@
       }
     },
     "com/lihaoyi/mill-core-constants/1.1.2": {
+      "narHash": "sha256-90RYZWFbRHADhQN0TzAFg6/Ku1sOMEJO88vtuDejYG4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -759,6 +825,7 @@
       }
     },
     "com/lihaoyi/mill-core-eval_3/1.1.2": {
+      "narHash": "sha256-FVkTp+fqVXk32oeCBZftQ+H1Me5+pEEybtaEDy5J9OM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -771,6 +838,7 @@
       }
     },
     "com/lihaoyi/mill-core-exec_3/1.1.2": {
+      "narHash": "sha256-EwtVyMJn89C8zCPoqTjMIu2ICEsmTk6vhTxkzuab430=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -783,6 +851,7 @@
       }
     },
     "com/lihaoyi/mill-core-internal-cli_3/1.1.2": {
+      "narHash": "sha256-NQOhirxgluRL7zf//5/45ogQf6eiUASqQjq+dems4ro=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -795,6 +864,7 @@
       }
     },
     "com/lihaoyi/mill-core-internal_3/1.1.2": {
+      "narHash": "sha256-8ZMlxcGUDDy4hxx/nnPBbMGFf3A+1K72J5EmrfZQM/o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -807,6 +877,7 @@
       }
     },
     "com/lihaoyi/mill-core-resolve_3/1.1.2": {
+      "narHash": "sha256-+iwi+BoiMOCg+yXM742HT5c2fC4VCXV4VLft/mX6asg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -819,6 +890,7 @@
       }
     },
     "com/lihaoyi/mill-libs-androidlib-databinding_3/1.1.2": {
+      "narHash": "sha256-zwp6UJH1sJEpU6NoG5KSUyGMv56FYxoAO3ZAaPLeWow=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -831,6 +903,7 @@
       }
     },
     "com/lihaoyi/mill-libs-androidlib_3/1.1.2": {
+      "narHash": "sha256-2L88flQOsQU5HwQ9sO4e7CqdiEF306VL7qHWvLHjke8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -843,6 +916,7 @@
       }
     },
     "com/lihaoyi/mill-libs-daemon-client_3/1.1.2": {
+      "narHash": "sha256-l3uYRF5SYFuqvXyXkTTnBCKLgVeDPH0WayCYxGXyaPU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -855,6 +929,7 @@
       }
     },
     "com/lihaoyi/mill-libs-daemon-server_3/1.1.2": {
+      "narHash": "sha256-vN4H0OGmhUM3xlvGQDCMxm29c2n2Z7e8gQdqAmtDQ9c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -867,6 +942,7 @@
       }
     },
     "com/lihaoyi/mill-libs-groovylib-api_3/1.1.2": {
+      "narHash": "sha256-OjCzZet3uZTPUfaulbuX47zPkRqxwdwaM0PRryqI9rU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -879,6 +955,7 @@
       }
     },
     "com/lihaoyi/mill-libs-groovylib_3/1.1.2": {
+      "narHash": "sha256-4oZERkViife1WhskTLNWLSXznGT6oTi3Uu94rufeJxw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -891,6 +968,7 @@
       }
     },
     "com/lihaoyi/mill-libs-init_3/1.1.2": {
+      "narHash": "sha256-uY01GfK8qQzq9pLGN3W5fpf4ZkF6CbLDyINO9LwBmcU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -903,6 +981,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-api_3/1.1.2": {
+      "narHash": "sha256-t/WUjUPYuYvdNwBrGaPGE6PJ4PilQa2lgGSqFu2vCDE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -915,6 +994,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-classgraph-worker_3/1.1.2": {
+      "narHash": "sha256-NWAvVw95m7ow5fd/cnjctrzPnfEo33sPmE6zkTqngm4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -926,6 +1006,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-jarjarabrams-worker_3/1.1.2": {
+      "narHash": "sha256-qgxMxR1WAt/RlHPgkVsedv59KmZCqFsdQ3HJ6yBgNr0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -937,6 +1018,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-maven-worker_3/1.1.2": {
+      "narHash": "sha256-hI9tidkGp1jCdh+GKFE4yuQYW4qcATM+urH/DjFO3Tk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -948,6 +1030,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-testrunner-entrypoint/1.1.2": {
+      "narHash": "sha256-/Za+OC77NqwXj1DCkHEJqZudN58k4dacem22jzaw69w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -960,6 +1043,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-testrunner_3/1.1.2": {
+      "narHash": "sha256-aei0wemkFI39lG4uwGuiocJvr+b6rvbroz4c0KDbUCg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -972,6 +1056,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-worker_3/1.1.2": {
+      "narHash": "sha256-gmhW171Ql3a/ahMoQ+aPlQn5xSK04M8ukGKaUmizzGA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -984,6 +1069,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib_3/1.1.2": {
+      "narHash": "sha256-sbGRGNCQNuV0ICZGwX31wGTtwmyLkgUecmHxAAMx43A=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -996,6 +1082,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javascriptlib_3/1.1.2": {
+      "narHash": "sha256-IvDhij203Ec3p1OOwwL8pcW0qNlC5N7FTpsQoo5Y0PM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1008,6 +1095,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib-api_3/1.1.2": {
+      "narHash": "sha256-k5qMHp8DXZwJjni5WC8V/Rrubvll45C3ZsHqXgsWHQU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1020,6 +1108,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib-ksp2-api_3/1.1.2": {
+      "narHash": "sha256-4Qc6Q4mgJP6LgPt0gz5BD5dlS04xy3R8pwe8TzhXKCY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1032,6 +1121,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib_3/1.1.2": {
+      "narHash": "sha256-FgS75otH56ZwDbVugpjZTYNL0UFpdmDmoKH7BFmQgzA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1044,6 +1134,7 @@
       }
     },
     "com/lihaoyi/mill-libs-pythonlib_3/1.1.2": {
+      "narHash": "sha256-mg0s5BgQEmwws7QiAwVFUkyZewCOIT5yzztmwFYFbNg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1056,6 +1147,7 @@
       }
     },
     "com/lihaoyi/mill-libs-rpc_3/1.1.2": {
+      "narHash": "sha256-tbfIJz2NqblUqrklY/G6gMeIkctB+RjbOF5KKLOMyzY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1068,6 +1160,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalajslib-api_3/1.1.2": {
+      "narHash": "sha256-ijiMX+T/U6VzkANrudCk5bu7Cb0FhvQjndmI57Ux29w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1080,6 +1173,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalajslib_3/1.1.2": {
+      "narHash": "sha256-j4srBpqsA2DgDkdaZX+8nPxeEiS5npuG7IF4xIDJyAQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1092,6 +1186,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalalib_3/1.1.2": {
+      "narHash": "sha256-BQ3dxgJy+rEuKuHCIpUEn7yMrE2gM1tCfjANlpqFPs0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1104,6 +1199,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalanativelib-api_3/1.1.2": {
+      "narHash": "sha256-WctVwkA0mhzaCRMdtA8iUNhe0QAtPAvYimSOS0BvQ5M=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1116,6 +1212,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalanativelib_3/1.1.2": {
+      "narHash": "sha256-R9IeBpzNJH29cGC6i6OCoijh4emr7WSgU4lWkQBRa8g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1128,6 +1225,7 @@
       }
     },
     "com/lihaoyi/mill-libs-script_3/1.1.2": {
+      "narHash": "sha256-N2d+vHxfjeAnYX1p8CAGKCHDTaRRamdRpMA+vSNzjBc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1140,6 +1238,7 @@
       }
     },
     "com/lihaoyi/mill-libs-tabcomplete_3/1.1.2": {
+      "narHash": "sha256-CLFK8WWs6Kply0A3GRs3FwJLKX+NuFq2ESgUk76+4gY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1152,6 +1251,7 @@
       }
     },
     "com/lihaoyi/mill-libs-util-java11_3/1.1.2": {
+      "narHash": "sha256-WAcJQi9UaitiPcGkM9jqp0RwwxzatzkCg7WBm+ac/bw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1164,6 +1264,7 @@
       }
     },
     "com/lihaoyi/mill-libs-util_3/1.1.2": {
+      "narHash": "sha256-HXau1/dqOJ7neKw5N3QM3ll+/QtFFimXJZzKWI5vwQ0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1176,6 +1277,7 @@
       }
     },
     "com/lihaoyi/mill-libs_3/1.1.2": {
+      "narHash": "sha256-rbA8FWzS6Gl2+eFva5bE8dLYOaaBabVLjowYB7MB8cg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1188,6 +1290,7 @@
       }
     },
     "com/lihaoyi/mill-moduledefs_3/0.13.1": {
+      "narHash": "sha256-wD+xrBo26jkPgWMA5a3oR+DsteeA/hs1vZHniVX7B/8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1200,6 +1303,7 @@
       }
     },
     "com/lihaoyi/mill-runner-autooverride-api_3/1.1.2": {
+      "narHash": "sha256-e/ENKiR+qC/K1zZniDs/Opqd0AC40w8JbNhg/HufX6c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1212,6 +1316,7 @@
       }
     },
     "com/lihaoyi/mill-runner-autooverride-plugin_3.8.1/1.1.2": {
+      "narHash": "sha256-car+dNZEHMizzUChZOIerBvydqQg4j7XJrTRPvMHlN4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1224,6 +1329,7 @@
       }
     },
     "com/lihaoyi/mill-runner-bsp-worker_3/1.1.2": {
+      "narHash": "sha256-EIyB/F+fi11AleIRZ6Mr++nDWItDKBDRfxDIWr2qI1I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1236,6 +1342,7 @@
       }
     },
     "com/lihaoyi/mill-runner-bsp_3/1.1.2": {
+      "narHash": "sha256-r5pGAfsQ6PpPUfCq/JyS/IslbRRdHcgxo/apiXU0D/s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1248,6 +1355,7 @@
       }
     },
     "com/lihaoyi/mill-runner-codesig_3/1.1.2": {
+      "narHash": "sha256-fYRL8ATFQEqwnhkw7rMU1Sl4B/KR39v/HyivQDzPmvA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1260,6 +1368,7 @@
       }
     },
     "com/lihaoyi/mill-runner-daemon_3/1.1.2": {
+      "narHash": "sha256-PzX/ZnaCQ/wbirXHc0mqSeL7EAznEoBOwDKtCe+zaf4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1272,6 +1381,7 @@
       }
     },
     "com/lihaoyi/mill-runner-eclipse_3/1.1.2": {
+      "narHash": "sha256-6Tky/jJmGt/wIJpl77IlAiNIUoeuHdhxY10qq8rauRU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1284,6 +1394,7 @@
       }
     },
     "com/lihaoyi/mill-runner-idea_3/1.1.2": {
+      "narHash": "sha256-byBNEzm90cBaC3vPCW0HPgB9xDE1VF/bkBsd1SczIkI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1296,6 +1407,7 @@
       }
     },
     "com/lihaoyi/mill-runner-launcher_3/1.1.2": {
+      "narHash": "sha256-AaQLCIMyhuvGD5x5hk/Qt5HIbJ1THG/ul950SShb7/0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1308,6 +1420,7 @@
       }
     },
     "com/lihaoyi/mill-runner-meta_3/1.1.2": {
+      "narHash": "sha256-p2kWyFCLIZsq/Wiize9v7kqaHxYbK3s/6i4oSu1Su4s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1320,6 +1433,7 @@
       }
     },
     "com/lihaoyi/mill-runner-server_3/1.1.2": {
+      "narHash": "sha256-i5dHvTAmETSXXo5EwwMFauBhHkAsTS+xFpdShniDkkA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1332,6 +1446,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.11/0.0.1": {
+      "narHash": "sha256-WoWTvE0PH0Ycy8FRHCkpkiLnAW52xcmsTRQKWYmiyHs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1343,6 +1458,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.12/0.0.1": {
+      "narHash": "sha256-lTw5/teSLrk5BXp269+oCEjfXirqtndFz8zmC2STj5s=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1354,6 +1470,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.13/0.0.1": {
+      "narHash": "sha256-eFMM+DEZgS76Icq0WRkp7kHmjZFi5A/b3ap00ogXu8c=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1365,6 +1482,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.14/0.0.1": {
+      "narHash": "sha256-+SyBIYpVbYTnk4JXA9Ysq0tCF4NtZavzRCaEUg1GTOM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1376,6 +1494,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.15/0.0.1": {
+      "narHash": "sha256-Sa7Pf2UMxoPPLix2sgsG0srpKKMyqJS9WiBqdmIOMA0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1387,6 +1506,7 @@
       }
     },
     "com/lihaoyi/mill-scala-compiler-bridge_2.13.16/0.0.1": {
+      "narHash": "sha256-QIILNxiRtTdAZnhxcugQ752YAqnzHCDaf97qrIjQjAw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1398,6 +1518,7 @@
       }
     },
     "com/lihaoyi/os-lib-watch_3/0.11.8": {
+      "narHash": "sha256-4q3tDvj2++/krsEgzsMLe53pvP4/UhYxh4mBOwIrpjE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1410,6 +1531,7 @@
       }
     },
     "com/lihaoyi/os-lib_2.13/0.10.7": {
+      "narHash": "sha256-dgygwmdGXQZHzsQ+VJGsiKN6AqrPxLYa9LomoCDM9t4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1421,6 +1543,7 @@
       }
     },
     "com/lihaoyi/os-lib_3/0.10.7": {
+      "narHash": "sha256-SqaFgOyQ16ScVzoSlKU1FniiUM8q0AP6FrsxDVXPxxk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1432,6 +1555,7 @@
       }
     },
     "com/lihaoyi/os-lib_3/0.11.8": {
+      "narHash": "sha256-/ZppfqwNCF3a0nzhuTRR0mORVMtj7WH87ukL4S7aHxo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1444,6 +1568,7 @@
       }
     },
     "com/lihaoyi/os-zip/0.11.8": {
+      "narHash": "sha256-2anT0NXLtTFR4Jpb4mW1d2GFbFk3P/LymV0eUkP2bOg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1456,6 +1581,7 @@
       }
     },
     "com/lihaoyi/pprint_2.13/0.9.0": {
+      "narHash": "sha256-iizF7zga18awTNYJx0fx9VyvKVRXl5amWBdZSK9AC4g=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1467,6 +1593,7 @@
       }
     },
     "com/lihaoyi/pprint_3/0.9.3": {
+      "narHash": "sha256-jsJXIlLefnWLfTeipIOmUUsko6HYWI1AENlldH1eV78=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1479,6 +1606,7 @@
       }
     },
     "com/lihaoyi/pprint_3/0.9.6": {
+      "narHash": "sha256-pUfDq1R9VRa1++zDkIGFG5Npw3yDzI+S5GWEYvyTpxw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1491,6 +1619,7 @@
       }
     },
     "com/lihaoyi/requests_3/0.9.0": {
+      "narHash": "sha256-pczF9tlxW43kMMzx49ka+zEOm4qZC+vAS33GE3lEMMw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1501,6 +1630,7 @@
       }
     },
     "com/lihaoyi/requests_3/0.9.3": {
+      "narHash": "sha256-BrKBTqRaPcydKo/eVBLP6kxpPyvggxNF8umOP+ufiJw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1513,6 +1643,7 @@
       }
     },
     "com/lihaoyi/scalac-mill-moduledefs-plugin_3.8.1/0.13.1": {
+      "narHash": "sha256-I+fGJE6a+4cmbUaK/jQYeC4r2NHDSxXBYj4vXbLL9Lk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1525,6 +1656,7 @@
       }
     },
     "com/lihaoyi/sourcecode_2.13/0.4.0": {
+      "narHash": "sha256-yqjz1qWGsbautHsYKmuWL2CqEjWEkNoZr2OSMEhjOvM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1536,6 +1668,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.3.0": {
+      "narHash": "sha256-Efyw/OzGr30q1FKgX8DAFcVEi8SFpO/Zgjbc8+yhjl0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1545,6 +1678,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.4.0": {
+      "narHash": "sha256-gWe30/RMuWzIqQNKwDim9xlJ/8XzYPJTNtU2TCYiIiA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1555,6 +1689,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.4.4": {
+      "narHash": "sha256-qSDMufVcqRC9/P3o+5IHIxBA7WXha5oPC3qcv3iaNO4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1567,6 +1702,7 @@
       }
     },
     "com/lihaoyi/ujson_2.13/3.3.1": {
+      "narHash": "sha256-tEAPGJnc7aVQz+fehVQ4ZZ4kVHAnAQgdCuSW5SoLavw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1578,6 +1714,7 @@
       }
     },
     "com/lihaoyi/ujson_3/3.3.1": {
+      "narHash": "sha256-PMkV8zqqee1vdhNwqYruMy2cNiwI0RFkxMjfR2NkVwM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1589,6 +1726,7 @@
       }
     },
     "com/lihaoyi/ujson_3/4.1.0": {
+      "narHash": "sha256-ztiq6IXq1y9fIyg7swGsOrGSKm59aJHljB+49YEyPT4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1599,6 +1737,7 @@
       }
     },
     "com/lihaoyi/ujson_3/4.4.2": {
+      "narHash": "sha256-JFeL9NYiaYBtfds5qzfpx3TBn3wJPUlomt41zt3apqo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1611,6 +1750,7 @@
       }
     },
     "com/lihaoyi/unroll-annotation_3/0.2.0": {
+      "narHash": "sha256-NF7usbUV/qsS7OdVgkCanOWFyfEtqzmEhrHd6rwUxaY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1623,6 +1763,7 @@
       }
     },
     "com/lihaoyi/upack_2.13/3.3.1": {
+      "narHash": "sha256-HrAbidOPnsmPsIRu8Tcgyj/mgBYOZO3jFluXh/4r2BI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1634,6 +1775,7 @@
       }
     },
     "com/lihaoyi/upack_3/3.3.1": {
+      "narHash": "sha256-DnOhMNvGPFjoL9BM4ta6UW9BcgJF7ybmh6rv1hmWnkE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1645,6 +1787,7 @@
       }
     },
     "com/lihaoyi/upack_3/4.1.0": {
+      "narHash": "sha256-FIaAWfWaBa6F7rn4lgDbY12PCuQTvvgWOLu8buoj02g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1655,6 +1798,7 @@
       }
     },
     "com/lihaoyi/upack_3/4.4.2": {
+      "narHash": "sha256-+tHdbk5PwFkv3dl9IOreCqs3dke3z4cXTO+5317jMdk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1667,6 +1811,7 @@
       }
     },
     "com/lihaoyi/upickle-core_2.13/3.3.1": {
+      "narHash": "sha256-+VH7t6E1uEWyrjN1N6RXYtEsJavrKQ9mdMVmHp4Zenk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1678,6 +1823,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/3.3.1": {
+      "narHash": "sha256-PfB5RNFnq7PsZlAMmivCnB3PvkcwTjoxkBpK7e/8dP0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1689,6 +1835,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/4.1.0": {
+      "narHash": "sha256-1rwpLarJ/peYA+ZUgFVZQLa9HNBNJDux0LH3hu+YymA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1699,6 +1846,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/4.4.2": {
+      "narHash": "sha256-67bidGkVlwS464667x7g/8GvxhY0Ep8DPmQG42Kncmk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1711,6 +1859,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits-named-tuples_3/4.4.2": {
+      "narHash": "sha256-Xc1I31VnZY8JBcIZnFnfAs+9Wdgmk7F8wh14iVnqpVo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1723,6 +1872,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_2.13/3.3.1": {
+      "narHash": "sha256-nFsRZM5kZdPTpUI2qZLz3D77VZ3OXEhKLj6m6KZvF0A=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1734,6 +1884,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/3.3.1": {
+      "narHash": "sha256-DDkR/eF4bLO8FQgGSZaafVO4QvuBIMcLaU+gGbLCmFU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1745,6 +1896,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/4.1.0": {
+      "narHash": "sha256-mv04ei5Nr4T8dbELJNaIzdBTFycpUPwSPW43h63oo2c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1755,6 +1907,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/4.4.2": {
+      "narHash": "sha256-xtyZwWRa+vVY0pAE0ZQxlz9nedhBKjKEZzh0u0sSEfQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1767,6 +1920,7 @@
       }
     },
     "com/lihaoyi/upickle_2.13/3.3.1": {
+      "narHash": "sha256-xXWUVtA6S2mOhyv25BRqS9G1VrlgsH7rtHo1hMJzP+4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1778,6 +1932,7 @@
       }
     },
     "com/lihaoyi/upickle_3/3.3.1": {
+      "narHash": "sha256-nOm8qE3clytLAKrvqkTFXVabsNPHOBt+aPaBm+mos2U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1789,6 +1944,7 @@
       }
     },
     "com/lihaoyi/upickle_3/4.1.0": {
+      "narHash": "sha256-MPA/xEgkt/2RHlg5h/VZKuE0eW2/LtNPGRqmuyaEQ8c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1799,6 +1955,7 @@
       }
     },
     "com/lihaoyi/upickle_3/4.4.2": {
+      "narHash": "sha256-kN0eTjeOO9RJDjPEw8Wym/3jxIXg2yLCPMM9SuBR4ZI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1811,6 +1968,7 @@
       }
     },
     "com/lmax/disruptor/3.4.2": {
+      "narHash": "sha256-IYiV/U9IMIGjJym2E6/OPECbcc8wRfsWuc48nmtGIlo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1823,6 +1981,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-core_3/0.6.0": {
+      "narHash": "sha256-cChGHftawGBel5LllRvXnfM2My6pWjLu+tc9YeghzrM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1835,6 +1994,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-requests_3/0.6.0": {
+      "narHash": "sha256-DE2dlLD/r6s48BK5TmRmqO7Ulaznr+CH0O8R9VZ9G9g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1847,6 +2007,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-upickle_3/0.6.0": {
+      "narHash": "sha256-G2xUXJlCGdZJ0GrKtbG50xvczclb0j0BDO6nNlIYS4M=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1859,6 +2020,7 @@
       }
     },
     "com/openhtmltopdf/openhtmltopdf-core/1.0.10": {
+      "narHash": "sha256-0Lu2WaiVpxbxoOrMMHHkNaH8/HwSoBwATZEt+avd7Rg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1870,6 +2032,7 @@
       }
     },
     "com/openhtmltopdf/openhtmltopdf-parent/1.0.10": {
+      "narHash": "sha256-xvKFbkI5pa+WqhFZ1RqvGoHIhVPf9TSIfIVrjQjbb2U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1879,6 +2042,7 @@
       }
     },
     "com/openhtmltopdf/openhtmltopdf-pdfbox/1.0.10": {
+      "narHash": "sha256-ou4BXTG4ZPCYXKyeTPtbjEzumWbUzvqzzj2Fqat5cV8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1890,6 +2054,7 @@
       }
     },
     "com/openhtmltopdf/openhtmltopdf-rtl-support/1.0.10": {
+      "narHash": "sha256-cxu1xSIPcLjbbC3DQWCLhX0hOmiO3EBzeWXo3RgibhI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1901,6 +2066,7 @@
       }
     },
     "com/swoval/file-tree-views/2.1.12": {
+      "narHash": "sha256-GK1YOwDKlK70lsBnIPT+dIO4g9H7ijFIzjOd1MnmUx8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -1913,6 +2079,7 @@
       }
     },
     "com/typesafe/config/1.4.3": {
+      "narHash": "sha256-l6QXv/XYhlVmd3ITPHawTEKN1VxWosAo27twxlEWjdg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1924,6 +2091,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-all/0.64.8": {
+      "narHash": "sha256-ghGP3NTy2NdsmWYt1Qh+Zi3VhiZkvYepCkOqN5WvyH4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1935,6 +2103,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-abbreviation/0.64.8": {
+      "narHash": "sha256-PD3zPNHLzCcl5vkxWuUiBElN5UCCr5kVtiLh+RornWs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1946,6 +2115,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-admonition/0.64.8": {
+      "narHash": "sha256-oQjSOzhUmNG6YS4MawNYuewBs/0Ue0gf2AXLSpQ6SVI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1957,6 +2127,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-anchorlink/0.64.8": {
+      "narHash": "sha256-5ykjRm9WsYyhjJegotu2ahwC+mlCoW3UeOMMBWuxs5Y=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1968,6 +2139,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-aside/0.64.8": {
+      "narHash": "sha256-xfZywHbThd5JDE5gxnbaNO6BvygKKF94dhi19ApJbH0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1979,6 +2151,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-attributes/0.64.8": {
+      "narHash": "sha256-e6jK/I4iRWGLvBPEjOqjFUTT6nYJuccBFTIS5djuqUg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -1990,6 +2163,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-autolink/0.64.8": {
+      "narHash": "sha256-7l1Ezt0IP/G8NL1l/7iryyYo7u4LiNvOrRra8FM9r5w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2001,6 +2175,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-definition/0.64.8": {
+      "narHash": "sha256-8W0AuL5DHggE1xEfg7SaurGRcuBn8rgvS2Wj7ICZm6A=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2012,6 +2187,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-emoji/0.64.8": {
+      "narHash": "sha256-ETJarViahQoXWtDNAk/q1hls1zmU7mhWLFMv5V7wVPs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2023,6 +2199,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-enumerated-reference/0.64.8": {
+      "narHash": "sha256-fGOz6xkHvfABNs0t5f3Y5K9+6UcJLnCkPuYl8YztODE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2034,6 +2211,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-escaped-character/0.64.8": {
+      "narHash": "sha256-M29FZY0p9jWHiwYT7YI3nebfP//qA0Y4uOuhcMkO0PY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2045,6 +2223,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-footnotes/0.64.8": {
+      "narHash": "sha256-4Fsyqf/9xhTZX5/+k5R+6LiMp3q21x3QVlfyotpBdPQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2056,6 +2235,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-gfm-issues/0.64.8": {
+      "narHash": "sha256-OlxPvmmNZ49krvYcjFAcyGqPzZ4REr2mmOfdvMsDP2c=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2067,6 +2247,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-gfm-strikethrough/0.64.8": {
+      "narHash": "sha256-uXM1KZTKAKW1z/uzCkCQhF0DqxbdI49eV7KeRmNlJRk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2078,6 +2259,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-gfm-tasklist/0.64.8": {
+      "narHash": "sha256-aopbj9rvs5r7AFEHAmdtV6TdqG8o/Hm0nzXPI3CEca4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2089,6 +2271,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-gfm-users/0.64.8": {
+      "narHash": "sha256-JcoqrotqxxkK7ofhOw2ZHJ2XnWq+4iUsUEWzdSJbLyo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2100,6 +2283,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-gitlab/0.64.8": {
+      "narHash": "sha256-rDMHGZv9jvfAaczGZAPiVjX06VGiVCbmsLfaLxGPVpk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2111,6 +2295,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-ins/0.64.8": {
+      "narHash": "sha256-VNbSiuoJL09oMNMNQcYIDvnJryMnnlm7BBD0G8IsEiI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2122,6 +2307,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-jekyll-front-matter/0.64.8": {
+      "narHash": "sha256-M/MKclKaxQpw5yAN6Eh96dKIwz2wBWC+1b43Huounew=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2133,6 +2319,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-jekyll-tag/0.64.8": {
+      "narHash": "sha256-oTiUtg7UX3ulbMOs0I8gbCjKOZ9zAYmfJilnqCOU8QU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2144,6 +2331,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-macros/0.64.8": {
+      "narHash": "sha256-rAfCyH5IS9KrMQp/ub3/q6qKlq5g4nv6bvIq8pqfVVo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2155,6 +2343,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-media-tags/0.64.8": {
+      "narHash": "sha256-oIJchB5P/Bl0GPuRBMkDd7ccRWTmiNzSXQVqeZbpVh4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2166,6 +2355,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-resizable-image/0.64.8": {
+      "narHash": "sha256-5B+juLdOxre07G+OCXB/Wnj+wBMOghjASb1+tXeD/ps=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2177,6 +2367,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-superscript/0.64.8": {
+      "narHash": "sha256-hvoU060P4GvcW1jFEcGWny4dyHq6o2qcvZhMMimOfSI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2188,6 +2379,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-tables/0.64.8": {
+      "narHash": "sha256-cToZSmWf2509KUp7VVSCZ2+2kjIIXfeqHq9qAjzT75U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2199,6 +2391,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-toc/0.64.8": {
+      "narHash": "sha256-nW2fR47zPY4JQxHZBPU3+gNEJCwMzHuTcHZqUR0khmc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2210,6 +2403,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-typographic/0.64.8": {
+      "narHash": "sha256-X6oLfRSdYJ38q1gR6fkNfCpCtQK5n6dROgVcG58AAOw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2221,6 +2415,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-wikilink/0.64.8": {
+      "narHash": "sha256-cNdsGP5VL+ki27UN5mtsiP5GC6z7t6EQEe5WecsGy1k=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2232,6 +2427,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-xwiki-macros/0.64.8": {
+      "narHash": "sha256-10DuZtsF27ejL7jf8WKGX3J/rz93ScJdLUVayY/THqE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2243,6 +2439,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-yaml-front-matter/0.64.8": {
+      "narHash": "sha256-kDEbdGBX8P5jZQxgEc8PL/+hKt43ONVyHcEF5u8FcLs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2254,6 +2451,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-ext-youtube-embedded/0.64.8": {
+      "narHash": "sha256-0UI7KMsm03yOL2+Wz1eCzq2YpMq3u4Kw2iZp29fU5qg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2265,6 +2463,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-html2md-converter/0.64.8": {
+      "narHash": "sha256-FGwbzRE9D+q+MqKCC/Q0BS4Eq3qHveD+x8EbIUIQwkI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2276,6 +2475,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-java/0.64.8": {
+      "narHash": "sha256-sELdbEFYoGCVFoeD7RzDNOvp8m3QbBoGU94u349DKRo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2285,6 +2485,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-jira-converter/0.64.8": {
+      "narHash": "sha256-tYJt/4HGyWLN6Qcj6/G/SEc8D9ADi4WqFcPhf9m+ePE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2296,6 +2497,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-pdf-converter/0.64.8": {
+      "narHash": "sha256-rfa4ryl5Ihd41LM90MfnP4wagVvK2mvzYD17xCezS+o=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2307,6 +2509,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-profile-pegdown/0.64.8": {
+      "narHash": "sha256-zjG4ZrhkWu53N7Qf4rqAQCAqAcRyYk3i3+4OXtZUbJE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2318,6 +2521,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-ast/0.64.8": {
+      "narHash": "sha256-vGG3eH09T1i4T4jU1Xoiv3erQuAJANv/p++s10WeMI4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2329,6 +2533,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-builder/0.64.8": {
+      "narHash": "sha256-akSzEvTSY1Rccq/BZ9booriiPLeSVAUG/QPhjSJQsvI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2340,6 +2545,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-collection/0.64.8": {
+      "narHash": "sha256-z9gJRvtk8hnXBqjz5qx6LgEnaceD2MiOPPW0yyTEDJg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2351,6 +2557,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-data/0.64.8": {
+      "narHash": "sha256-XcfU4sMLdWDlxYYit5MaPYOuAGlATeKqk6QDnOAnXgQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2362,6 +2569,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-dependency/0.64.8": {
+      "narHash": "sha256-84aqlZ6zHRqor4SS3OUhzZLooyeujqLE2GbpteMieik=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2373,6 +2581,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-format/0.64.8": {
+      "narHash": "sha256-6NTvDCmmyhXcH2uq0sPOK4BS8aA0kzb1YRoBvceIO+U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2384,6 +2593,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-html/0.64.8": {
+      "narHash": "sha256-TAQCdMUkAR0+dW3HphWIsA9MVHu0iV+A9j6xcen876M=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2395,6 +2605,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-misc/0.64.8": {
+      "narHash": "sha256-4cp0QLifrR+lJRpPufjUPJmatVP2K4jBHXrcX+x1kSM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2406,6 +2617,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-options/0.64.8": {
+      "narHash": "sha256-JSa4RvPBEmobwXef6HMJJ07CXxdNOEmoPxlgwIt5+cw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2417,6 +2629,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-sequence/0.64.8": {
+      "narHash": "sha256-9L3xS/E+7Ie0QVw2gPGYEUTnCHBOYTlZAewOAQGkkAc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2428,6 +2641,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util-visitor/0.64.8": {
+      "narHash": "sha256-04ApzmNhddBD+tAngenN1Tj2AmimWHDO56e6WjIfEYs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2439,6 +2653,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-util/0.64.8": {
+      "narHash": "sha256-eS6vWMGkEJlzh5p5B4nAjsZNotL5P4024+9D6PSHIsU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2450,6 +2665,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark-youtrack-converter/0.64.8": {
+      "narHash": "sha256-41h5v8RZco2ZYnws0hTUZNqAsVKiRLo+xfntlzAQoVo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2461,6 +2677,7 @@
       }
     },
     "com/vladsch/flexmark/flexmark/0.64.8": {
+      "narHash": "sha256-FYR8h3dl3IXwZShyjsh6jQLz+SVfhGFfOtiN9lb77s8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2472,6 +2689,7 @@
       }
     },
     "commons-codec/commons-codec/1.16.0": {
+      "narHash": "sha256-vZG5STY4oey0DLv5RIQ7eJdivphBbwcyrGF4Y4iv4WY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2481,6 +2699,7 @@
       }
     },
     "commons-codec/commons-codec/1.17.0": {
+      "narHash": "sha256-aygLAcrioQxB06eVYg2aE/cgdfplH5WiCXDsDnD6gxs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2491,6 +2710,7 @@
       }
     },
     "commons-codec/commons-codec/1.19.0": {
+      "narHash": "sha256-eaSx+dzlqEHqMcmG5ofqiDX06VOYUyssQyb7zHsbcuU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2503,6 +2723,7 @@
       }
     },
     "commons-io/commons-io/2.20.0": {
+      "narHash": "sha256-1mUuNel8r+TFK608+Afo4YhRkjahOrXWh2OQ4dMqwpk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2515,6 +2736,7 @@
       }
     },
     "commons-logging/commons-logging/1.2": {
+      "narHash": "sha256-xCfmUeM6CvVUDQu6SMwf6nA/XAlQi+1hi9Zxedb+kKI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2526,6 +2748,7 @@
       }
     },
     "de/rototor/pdfbox/graphics2d/0.32": {
+      "narHash": "sha256-aA6M7y2WeNQBUN7/0AwKi84MG2rp4PXqvrvrB3GNlg0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2537,6 +2760,7 @@
       }
     },
     "de/rototor/pdfbox/pdfboxgraphics2d-parent/0.32": {
+      "narHash": "sha256-u/yaHz09MhnH5jGbK7Y9MTKu+kFuKFG0HhRgt7w7FHg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2546,6 +2770,7 @@
       }
     },
     "guru/nidi/graphviz-java-min-deps/0.18.1": {
+      "narHash": "sha256-7J2UuyQqrTip5kTUaAuhqviyX0Fbx0QGOq4I3Zdh724=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2558,6 +2783,7 @@
       }
     },
     "guru/nidi/graphviz-java-parent/0.18.1": {
+      "narHash": "sha256-zaiL/dDoGwCrQ4OBaDHsWUu8eEn4i8tUYpVg/h6z99M=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2568,6 +2794,7 @@
       }
     },
     "guru/nidi/graphviz-java/0.18.1": {
+      "narHash": "sha256-ipigGhL00gat4rP54fvYxFy+hqN8CUhiSE7Yfzp5ouo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2580,6 +2807,7 @@
       }
     },
     "guru/nidi/guru-nidi-parent-pom/1.1.36": {
+      "narHash": "sha256-XBnUt+K3yHmqeDC1fDI4BDAUWpAFzMpRGCy8m3NUIPg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2590,6 +2818,7 @@
       }
     },
     "io/airlift/airbase/112": {
+      "narHash": "sha256-KsbskxKQCJsppZ/JKx19dPhPFeaiCDfm1WjvaOQEHAc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2600,6 +2829,7 @@
       }
     },
     "io/airlift/aircompressor/0.27": {
+      "narHash": "sha256-NQgycAg0bRv+23tuyKxzJ8TW7bwIvQzBY8G9quZsFIo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2612,6 +2842,7 @@
       }
     },
     "io/circe/circe-core_3/0.14.6": {
+      "narHash": "sha256-zxxdm1ZxsdNbFd+fcokhOHT7Awxv3zZWZOlf+xH9zZo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2624,6 +2855,7 @@
       }
     },
     "io/circe/circe-generic_3/0.14.6": {
+      "narHash": "sha256-YnWPSoUJFJvhgxFsnABTZpW/SQzIgZcFKHpQv+jO28w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2636,6 +2868,7 @@
       }
     },
     "io/circe/circe-jawn_3/0.14.6": {
+      "narHash": "sha256-XFwN8ZbEPUIOOSx2at9M8hWrAGrxBRgnIcgxJD3HqFM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2648,6 +2881,7 @@
       }
     },
     "io/circe/circe-numbers_3/0.14.6": {
+      "narHash": "sha256-qJnaJhvBk6PGOhkLXDJ5oUPzHdIuDzfkvleQTXJBL8s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2660,6 +2894,7 @@
       }
     },
     "io/get-coursier/cache-util/2.1.25-M23": {
+      "narHash": "sha256-LYBuAgFV+H+ypaqf5izh7PqZsusxixykQa6y+Rs5Go8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2672,6 +2907,7 @@
       }
     },
     "io/get-coursier/coursier-archive-cache_2.13/2.1.25-M23": {
+      "narHash": "sha256-+kmIGtb2puHrWoqO5M+GDrmgwDOCPcFpeTdR2C1MW34=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2684,6 +2920,7 @@
       }
     },
     "io/get-coursier/coursier-cache_2.13/2.1.25-M23": {
+      "narHash": "sha256-FVAUROZDyP7SQILxop/WkV9M/LcIaniOM30lEKGN6q0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2696,6 +2933,7 @@
       }
     },
     "io/get-coursier/coursier-core_2.13/2.1.25-M23": {
+      "narHash": "sha256-3qn27Z+y9khReExwupwpAQaGGhtm9C1TWoS0Ngp0VLE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2708,6 +2946,7 @@
       }
     },
     "io/get-coursier/coursier-env_2.13/2.1.25-M23": {
+      "narHash": "sha256-e79cU50LPP3vtvKJuNcsuFGVpJRhppepQwI02krO/bE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2720,6 +2959,7 @@
       }
     },
     "io/get-coursier/coursier-exec/2.1.25-M23": {
+      "narHash": "sha256-Sq0PpQU+eSqOVP1oAEbSQ20Ja5GSZPAvLMmVQHzp/iw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2732,6 +2972,7 @@
       }
     },
     "io/get-coursier/coursier-jvm_2.13/2.1.25-M23": {
+      "narHash": "sha256-YaTlbbB8SWwvYnPYfHjOHIH3ABCBQ7TSvyNrCHYMFCY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2744,6 +2985,7 @@
       }
     },
     "io/get-coursier/coursier-paths/2.1.25-M23": {
+      "narHash": "sha256-uTsTgfeaReitRO/ODoL6XFwqFyji4l8gUzZ5lBhPk5g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2756,6 +2998,7 @@
       }
     },
     "io/get-coursier/coursier-proxy-setup/2.1.25-M23": {
+      "narHash": "sha256-RWazGucAhjDLbYLG+bnWfQz49pyzxYIlQeL2OAjhkXA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2768,6 +3011,7 @@
       }
     },
     "io/get-coursier/coursier-util_2.13/2.1.25-M23": {
+      "narHash": "sha256-fIj2AEuXLHibi4Npv80Yn4D7tTYi8ZWNiJbfjrTHWH0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2780,6 +3024,7 @@
       }
     },
     "io/get-coursier/coursier_2.13/2.1.25-M23": {
+      "narHash": "sha256-h57X+w71j6cCaqh1Kf+B8ay6f2JEkAFY7+zgXwmgbPs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2792,6 +3037,7 @@
       }
     },
     "io/get-coursier/dependency_2.13/0.3.2": {
+      "narHash": "sha256-pDXe2GqxAuavfquVejyGrW9UXUkW0OsnOseF+AvWYLY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2804,6 +3050,7 @@
       }
     },
     "io/get-coursier/interface/1.0.28": {
+      "narHash": "sha256-v8/4iV0xr3BasyZXOQ9iFyYHBwWr0X0LGbl4VOj1nss=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2815,6 +3062,7 @@
       }
     },
     "io/get-coursier/jniutils/windows-jni-utils/0.3.3": {
+      "narHash": "sha256-W6m2KKHSnC0dKiAjZH09AbBnafRK4fmYiiaSS0mgu70=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2827,6 +3075,7 @@
       }
     },
     "io/get-coursier/versions_2.13/0.5.1": {
+      "narHash": "sha256-P4KcW9MJGZqmPJwbpy3pN35RCZ1J1fBJNd20iCOEut4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2839,6 +3088,7 @@
       }
     },
     "io/github/alexarchambault/concurrent-reference-hash-map/1.1.0": {
+      "narHash": "sha256-FMro0Pm4zZSvtWh3fWjT7UKnS7z9IeGMr5UEmWKI5cQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2851,6 +3101,7 @@
       }
     },
     "io/github/alexarchambault/data-class_2.13/0.2.7": {
+      "narHash": "sha256-nbwbczShHNbnyuYlLSW4z2emL2gqtRhf688emnq6+QU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2862,6 +3113,7 @@
       }
     },
     "io/github/alexarchambault/is-terminal/0.1.2": {
+      "narHash": "sha256-hELOqV/siozeYUaXGjpSSlotlbPTs1sjeh9J7xj1k2A=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2874,6 +3126,7 @@
       }
     },
     "io/github/alexarchambault/native-terminal/native-terminal-no-ffm/0.0.9.1": {
+      "narHash": "sha256-02A23DeVIAqzQI7bQ06yD1TRSQYrRtMyMKippCRUgtc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2886,6 +3139,7 @@
       }
     },
     "io/github/alexarchambault/windows-ansi/windows-ansi/0.0.6": {
+      "narHash": "sha256-rpWAdC17+1Ivbc2sJ+EyWDVBuLP8FAkSrZtmqVuzH3g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2898,6 +3152,7 @@
       }
     },
     "io/github/classgraph/classgraph/4.8.184": {
+      "narHash": "sha256-ea9gZwuUSvLWrVx0VsCDo6cyd1v/6VjcQwQ2y1f1/xY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2909,6 +3164,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils-parent/4.12": {
+      "narHash": "sha256-lx7Ycd6ytCv/1pWSdPQ44pKTAoraNY2K9ur0NNeupP0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2919,6 +3175,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils-parent/4.15": {
+      "narHash": "sha256-sWzxW44gPOUpv3czdHAUKCJ3i97VZ2R2KKeDuJDv2j0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2929,6 +3186,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils-parent/4.16": {
+      "narHash": "sha256-isE6C7zEcWWkoWjKjbKjsg2JyW2z2HWGSwABzxu5vUk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2939,6 +3197,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils/4.12": {
+      "narHash": "sha256-RujOws0apD2YAbN2t7FnjZ96OyxOGXyKnTI1o94vVm0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2951,6 +3210,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils/4.15": {
+      "narHash": "sha256-sa8c7b+oIzvqoQj+QIPYu/5yoMGhu4rmLbrfwwsFqw8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2963,6 +3223,7 @@
       }
     },
     "io/github/java-diff-utils/java-diff-utils/4.16": {
+      "narHash": "sha256-1vEuNZNtt7J2yDTcAywIyUdqE2/M0mRNdvnuvw9KdrI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -2975,6 +3236,7 @@
       }
     },
     "io/github/json4s/json4s-ast_2.13/4.1.0": {
+      "narHash": "sha256-1oA1ZVLLa4ssz1JXUQzvSi4rR+9NH50CpAJS4uKveCk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2986,6 +3248,7 @@
       }
     },
     "io/github/json4s/json4s-ast_3/4.1.0": {
+      "narHash": "sha256-OAcC5eeMiNLg3Zur2A4jzfPa0ge6nSN/YPz2kFzoUsA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -2997,6 +3260,7 @@
       }
     },
     "io/github/json4s/json4s-core_2.13/4.1.0": {
+      "narHash": "sha256-LZrWym7CgtZGqKujWfuQiNRyKGol5+SGvkePjMrwBDs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3008,6 +3272,7 @@
       }
     },
     "io/github/json4s/json4s-core_3/4.1.0": {
+      "narHash": "sha256-gB5sr6p8eCpbUBjaYvhoQDTGZ3v4cuBlcxHz5LP0btY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3019,6 +3284,7 @@
       }
     },
     "io/github/json4s/json4s-native-core_2.13/4.1.0": {
+      "narHash": "sha256-T4VTGbY8EP0GJG7Rs+k0CEU4QuP/ja5T4vA8Ykaa+LQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3030,6 +3296,7 @@
       }
     },
     "io/github/json4s/json4s-native-core_3/4.1.0": {
+      "narHash": "sha256-WFV7hu2Fgo5fpw7WiFGpLL78ZVH8LnwS98BLPvdi86E=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3041,6 +3308,7 @@
       }
     },
     "io/github/json4s/json4s-native_2.13/4.1.0": {
+      "narHash": "sha256-eqYfSZ2PtV/d70Vtk0jBjUZA6ja4xOWd/Gcbs02D2yU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3052,6 +3320,7 @@
       }
     },
     "io/github/json4s/json4s-native_3/4.1.0": {
+      "narHash": "sha256-M94NOJj1lG2ud2wGLMb1IC+TbTwQhHc+pTz8akf1OGw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3063,6 +3332,7 @@
       }
     },
     "io/github/json4s/json4s-scalap_2.13/4.1.0": {
+      "narHash": "sha256-Wjq2VcKuw1y594x4w3qGGBjDNHvMh20Wghmzln810mQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3074,6 +3344,7 @@
       }
     },
     "io/methvin/directory-watcher/0.19.1": {
+      "narHash": "sha256-Vt244ZAzywCd1bWlZlh/DfJPF/EN7JAnuGod5vSguXo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3085,6 +3356,7 @@
       }
     },
     "io/netty/netty-bom/4.2.6.Final": {
+      "narHash": "sha256-2/3y4l/ZE40K/dt2j4eRhafXleUcvMwfLFwkH2VrADU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3095,6 +3367,7 @@
       }
     },
     "io/undertow/undertow-core/2.2.30.Final": {
+      "narHash": "sha256-f54GLHeZ3srVw2wjvPGoTwjQDzIhvoKVghMCU7yiuRA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3106,6 +3379,7 @@
       }
     },
     "io/undertow/undertow-parent/2.2.30.Final": {
+      "narHash": "sha256-/VNwhinLLw4lXvw3xTTP8CKdcWTssj3Vrf9Jsj6AVf0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3115,6 +3389,7 @@
       }
     },
     "jakarta/inject/jakarta.inject-api/2.0.1": {
+      "narHash": "sha256-8J5hzhQVBuWb0PbgrRPHXRcj6m4iuo9l+IOXbr6ntVA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3126,6 +3401,7 @@
       }
     },
     "jakarta/platform/jakarta.jakartaee-bom/9.1.0": {
+      "narHash": "sha256-Ufw06fqw0QapN7/NjF9FcaOqb9ZdrxgL/hpVDy8Y2xo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3136,6 +3412,7 @@
       }
     },
     "jakarta/platform/jakartaee-api-parent/9.1.0": {
+      "narHash": "sha256-O2JIdzO1B5CnlAgJK28nyS5rvxz2J7/Qui030eQRHG0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3146,6 +3423,7 @@
       }
     },
     "javax/inject/javax.inject/1": {
+      "narHash": "sha256-2bbQOHIRQGVzAnSA6xag+OTdI/aAEEOq9MX4/0TWmeI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3158,6 +3436,7 @@
       }
     },
     "net/java/dev/jna/jna/5.13.0": {
+      "narHash": "sha256-krY/SF4BxJQEdZNTFuXavCSYIQ1xWgl7JaySaqLiPEM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3170,6 +3449,7 @@
       }
     },
     "net/java/dev/jna/jna/5.14.0": {
+      "narHash": "sha256-JlMaZPJktiZ1+wjxSZYMaPpemjqnzQHdniHrfib8/LE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3182,6 +3462,7 @@
       }
     },
     "net/java/dev/jna/jna/5.15.0": {
+      "narHash": "sha256-bQEciaXP89ySUXKK5rL93w3SKGPDUDmgTf0oPQoOZZE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3192,6 +3473,7 @@
       }
     },
     "net/java/dev/jna/jna/5.16.0": {
+      "narHash": "sha256-PZjb6rwNV9WsIbrhvyGNKUo52+2MLAfi4NUsPdfrEvs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3203,6 +3485,7 @@
       }
     },
     "net/java/dev/jna/jna/5.17.0": {
+      "narHash": "sha256-mjQmQd6oKeuVa8Gro7ld/e0f3S1wwg8OcKz8CENM9jM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3215,6 +3498,7 @@
       }
     },
     "net/openhft/java-parent-pom/1.1.28": {
+      "narHash": "sha256-99/N7IIhK3cAz0INSh7RcvjRSWEgi4BJhL/YLixVs2I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3225,6 +3509,7 @@
       }
     },
     "net/openhft/root-parent-pom/1.2.12": {
+      "narHash": "sha256-Q/akDcsWLoq8enyg/GDwvF2jqMZ4ebmPKnJhQ+iRRS4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3235,6 +3520,7 @@
       }
     },
     "net/openhft/zero-allocation-hashing/0.16": {
+      "narHash": "sha256-7GXmHLZ/FiQ5vBFiDqTuY/BVZNLsDXwb6BvD2483Q6g=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3247,6 +3533,7 @@
       }
     },
     "net/sf/jopt-simple/jopt-simple/5.0.4": {
+      "narHash": "sha256-YBBBrBCs4+sXfd2vhA1h5Tv2AxJOUVp+VLAzYEHBKGU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3258,6 +3545,7 @@
       }
     },
     "org/apache/apache/13": {
+      "narHash": "sha256-C75csPH3g7j/KmeyD1tjK3+v0trjf1Cq7JK/4gP8lXM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3267,6 +3555,7 @@
       }
     },
     "org/apache/apache/16": {
+      "narHash": "sha256-/oY5JJuovRFhRaC1WDBejVJtbM9WYHnh3qiZX2RAUao=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3276,6 +3565,7 @@
       }
     },
     "org/apache/apache/19": {
+      "narHash": "sha256-4kQz9l4rn+9Dy03fsV+k/IHgS7PGJms1xxTXdkvuNYE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3285,6 +3575,7 @@
       }
     },
     "org/apache/apache/21": {
+      "narHash": "sha256-e7jHmebi38EBi6jsbmsvSiDZ07kDZDqkDCN2T3VH1HU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3294,6 +3585,7 @@
       }
     },
     "org/apache/apache/29": {
+      "narHash": "sha256-aZlBilsVfBLQ+e7r3bEAJyrzsIyPVOiWnjbJvNtI9DI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3303,6 +3595,7 @@
       }
     },
     "org/apache/apache/30": {
+      "narHash": "sha256-iI3FKLmVTL2JsJ+X7CtTtDPIVRLTccPfPBpD3hdARJg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3312,6 +3605,7 @@
       }
     },
     "org/apache/apache/31": {
+      "narHash": "sha256-tJrvjxLxaeQG8UosBuyYVcnSAb+ScQJcB6pxpqRCG+M=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3322,6 +3616,7 @@
       }
     },
     "org/apache/apache/35": {
+      "narHash": "sha256-4QhnnM8ALYljd/yh+AimNDmsvAIEjeSI+tqlupIQGUo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3332,6 +3627,7 @@
       }
     },
     "org/apache/apache/6": {
+      "narHash": "sha256-/PSYMaYMcDu+9rWdEURqj+GJ7oQLMnYsZKx3vRM+CY4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3342,6 +3638,7 @@
       }
     },
     "org/apache/commons/commons-compress/1.28.0": {
+      "narHash": "sha256-gYvOqJ66e2Xfks4bAYMxgPMVBBEk4AnF3pKFQPQuHEM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3354,6 +3651,7 @@
       }
     },
     "org/apache/commons/commons-lang3/3.18.0": {
+      "narHash": "sha256-KfjfSNnkKZ42DO9h/SZ8unfxSFs6XlXYU6rivssRdR8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3366,6 +3664,7 @@
       }
     },
     "org/apache/commons/commons-lang3/3.8.1": {
+      "narHash": "sha256-ylmT+fha/D/k0y1eFxlGr411tOArO9VkK57VcxzeYR8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3375,6 +3674,7 @@
       }
     },
     "org/apache/commons/commons-math3/3.6.1": {
+      "narHash": "sha256-MUo0pk7Gets9HMs9Yd3fLI48+Cj84m0EnY6JhlaL2ck=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3386,6 +3686,7 @@
       }
     },
     "org/apache/commons/commons-parent/34": {
+      "narHash": "sha256-ugjpThpT6u9T38gHRv6td8tFf/1rGWSgi6eOfIBZ/E4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3395,6 +3696,7 @@
       }
     },
     "org/apache/commons/commons-parent/39": {
+      "narHash": "sha256-/CpB+dYw50nPvEPbIy0UB/XNxXNrlym498px46QeGKs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3404,6 +3706,7 @@
       }
     },
     "org/apache/commons/commons-parent/47": {
+      "narHash": "sha256-CaTDlvj+WoWJ8q/VQb6Suv17M6mpOdJ7X9P/ow4Hywo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3413,6 +3716,7 @@
       }
     },
     "org/apache/commons/commons-parent/58": {
+      "narHash": "sha256-Xix73ZhAD0J+aqvw73oqAibkJ1BW0/DSPwTA01WKrw0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3422,6 +3726,7 @@
       }
     },
     "org/apache/commons/commons-parent/69": {
+      "narHash": "sha256-b7jKbxI66uRcSUZ3IOwprTx52ekURuVeNFfIZpVuABM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3432,6 +3737,7 @@
       }
     },
     "org/apache/commons/commons-parent/85": {
+      "narHash": "sha256-mWbgUoRQncv9E+1b2QlqvKmu/ML2JcDq2AULedPKRzo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3442,6 +3748,7 @@
       }
     },
     "org/apache/commons/commons-text/1.14.0": {
+      "narHash": "sha256-Sf+F53KPPKH+79FB+8K4j6jq3XoaOkOZ+beZDNVLkXw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3453,6 +3760,7 @@
       }
     },
     "org/apache/cxf/cxf-bom/4.0.9": {
+      "narHash": "sha256-p0AHQPqZM/5XdQMlIv+qHrer4lci5LmPTolsE/vL9lQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3463,6 +3771,7 @@
       }
     },
     "org/apache/cxf/cxf/4.0.9": {
+      "narHash": "sha256-AAYwmPR9TvUyTBkHhKy4jiodUpwjZsxBggjSds6epTE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3473,6 +3782,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis-default-flava/2.0": {
+      "narHash": "sha256-JAaWmoUOrNbjR/7jIo8UoVCjkUqifUiTQMDDzM5Ics0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3483,6 +3793,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis-java5-flava/2.0": {
+      "narHash": "sha256-drzkrQsES8TRE+Xfc1kofOesSrdHz9Z8Pky/vyR+Xtc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3493,6 +3804,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis/2.0": {
+      "narHash": "sha256-SG5ZxS14XBi7p3aIxnUum5Nwdi3t2VAqxwXr3EayeYc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3503,6 +3815,7 @@
       }
     },
     "org/apache/groovy/groovy-bom/4.0.27": {
+      "narHash": "sha256-YuSYtaaSXZ8wPCSmO0jJXq5hdAYrjlBrTR7DYjvTV8Q=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3513,6 +3826,7 @@
       }
     },
     "org/apache/httpcomponents/httpclient/4.5.14": {
+      "narHash": "sha256-TEU/h3fZISzPxk+8TyN2+j5X34r4LEVvMwcb8Xxoxxo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3524,6 +3838,7 @@
       }
     },
     "org/apache/httpcomponents/httpcomponents-client/4.5.14": {
+      "narHash": "sha256-1lu+NzyUazY6xtKu5CzdPufgxKDWrSY9Tl5BE5a/hNo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3533,6 +3848,7 @@
       }
     },
     "org/apache/httpcomponents/httpcomponents-core/4.4.16": {
+      "narHash": "sha256-uAxTX9a1bs+59RwhTWvUzrN3K7A1aHntm9+7TtFUG4E=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3542,6 +3858,7 @@
       }
     },
     "org/apache/httpcomponents/httpcomponents-parent/11": {
+      "narHash": "sha256-UTTAM9mMDaXhd7e4MPM/YMB8IK76qPY38tbvijCh71o=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3551,6 +3868,7 @@
       }
     },
     "org/apache/httpcomponents/httpcore/4.4.16": {
+      "narHash": "sha256-sIInroeBP5QT6Nyg6C5sj0xpejoaNaOfTjm9lw/+byM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3562,6 +3880,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-api/2.25.1": {
+      "narHash": "sha256-1Gi+zBgbDW5v1CrR8XxA3xx87Dici4yIgzI6h6Rdr0Y=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3574,6 +3893,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-bom/2.25.1": {
+      "narHash": "sha256-WuhQuFiAtRkxY3zDyJOYVoPVv9Jv3b3T8DhXry5dfto=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3584,6 +3904,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-core/2.25.1": {
+      "narHash": "sha256-k9Wu/MVjGWsqPss2P14M0iewkoojanJhO7bViqgMgF4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3596,6 +3917,7 @@
       }
     },
     "org/apache/logging/log4j/log4j/2.25.1": {
+      "narHash": "sha256-LfDhguyrNoDhsW+d//n1PGrx+3CHdZMv8PxbQOnBiqY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3606,6 +3928,7 @@
       }
     },
     "org/apache/maven/maven-api-core/4.0.0-alpha-12": {
+      "narHash": "sha256-P/5wdZK6pHgux+GABgyOYdNSHzI53UdN6pLanAXwApU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3617,6 +3940,7 @@
       }
     },
     "org/apache/maven/maven-api-meta/4.0.0-alpha-12": {
+      "narHash": "sha256-R4mwJiIsEIotEr/UuOHE1Z7VGyMpXaJSX+OivlEdPag=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3628,6 +3952,7 @@
       }
     },
     "org/apache/maven/maven-api-model/4.0.0-alpha-12": {
+      "narHash": "sha256-zFKrZH9eLkazPAyVg4JY+Vjnlxd3WvGcJPb61QH8QcA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3639,6 +3964,7 @@
       }
     },
     "org/apache/maven/maven-api-plugin/4.0.0-alpha-12": {
+      "narHash": "sha256-HSERUYO9T7w24UScQA3XV18ovYsgoGSRPpKvS2TaNQ0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3650,6 +3976,7 @@
       }
     },
     "org/apache/maven/maven-api-settings/4.0.0-alpha-12": {
+      "narHash": "sha256-c3XKXso7Hn9qp/d8vAyBeVbn2i92/MEZnmblJd8eo5k=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3661,6 +3988,7 @@
       }
     },
     "org/apache/maven/maven-api-spi/4.0.0-alpha-12": {
+      "narHash": "sha256-WyagJG5Ni3sSTJPoNX75hL02K7KW8Ou1tJYtdVXPIzc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3672,6 +4000,7 @@
       }
     },
     "org/apache/maven/maven-api-toolchain/4.0.0-alpha-12": {
+      "narHash": "sha256-GNepH6Vah/sPBejH/XUXSN64ovPiajv2/5RSk4U9I1c=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3683,6 +4012,7 @@
       }
     },
     "org/apache/maven/maven-api-xml/4.0.0-alpha-12": {
+      "narHash": "sha256-AidTTuL5ZVkpgg3dpT7AzHU647qlxRC1kPXjssDD+B0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3694,6 +4024,7 @@
       }
     },
     "org/apache/maven/maven-api/4.0.0-alpha-12": {
+      "narHash": "sha256-GL66fAzbhuQk0p5FM5fLPXOREVexf+xUM4h/fekesZk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3703,6 +4034,7 @@
       }
     },
     "org/apache/maven/maven-builder-support/4.0.0-alpha-12": {
+      "narHash": "sha256-JK2LsBMpISnRNeWxW5MUdSzhGsN7iHN6wPQBtoGlUHc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3714,6 +4046,7 @@
       }
     },
     "org/apache/maven/maven-model-builder/4.0.0-alpha-12": {
+      "narHash": "sha256-rMLktGqkfvuhO4QCNb8xiXjPlXK+x2Z9Q9Gtfy0LrFI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3725,6 +4058,7 @@
       }
     },
     "org/apache/maven/maven-model/4.0.0-alpha-12": {
+      "narHash": "sha256-yeh+HUgLCQWoQte7ynlrDebpoue3avlopZfFzhsFTZs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3736,6 +4070,7 @@
       }
     },
     "org/apache/maven/maven-parent/40": {
+      "narHash": "sha256-erXr3d59gFUjqgw14vTOAmQC6BqbVy9LX+0nrJGbru0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3745,6 +4080,7 @@
       }
     },
     "org/apache/maven/maven-parent/41": {
+      "narHash": "sha256-AAJsROX/9qnC9m9vp8ODujovSyT1heVu7+jeoHdtb7Q=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3754,6 +4090,7 @@
       }
     },
     "org/apache/maven/maven-parent/45": {
+      "narHash": "sha256-tUWNdKdNsa+9YrroQ3xxO22oAGRfxy3TJ/qhx50+QZA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3763,6 +4100,7 @@
       }
     },
     "org/apache/maven/maven-repository-metadata/4.0.0-alpha-12": {
+      "narHash": "sha256-txnISFoQ601owUcjq/AKiLx32cLqVnVhMWssvksK+j8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3774,6 +4112,7 @@
       }
     },
     "org/apache/maven/maven-resolver-provider/4.0.0-alpha-12": {
+      "narHash": "sha256-AQ4uoaiKGR7kOxmGqPhhK8R+cG2glhF2bEd+t8SlZcg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3785,6 +4124,7 @@
       }
     },
     "org/apache/maven/maven-xml-impl/4.0.0-alpha-12": {
+      "narHash": "sha256-0f9RCC5Oo+/OeMNsCBy4PYudNhO56pyfvf3ZR32U7AU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3796,6 +4136,7 @@
       }
     },
     "org/apache/maven/maven/4.0.0-alpha-12": {
+      "narHash": "sha256-i1KfgdALhNhnhfVRJW3w2hxhFOuNjJOi9N4KSB2fNSc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3805,6 +4146,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-api/2.0.10": {
+      "narHash": "sha256-9qQilLrf79iQY5F9CrESrt4Uvvvq/aZLKxozbG7gOAs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3816,6 +4158,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-connector-basic/2.0.10": {
+      "narHash": "sha256-khuD5KwB80/JRXJ+y12mtWuUO7JNN6m/YfnlX9XipRQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3827,6 +4170,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-impl/2.0.0-alpha-8": {
+      "narHash": "sha256-y9beVTbRIihmJNQ3xz7tSgdUlkKmgn7mUs+FSH9phxY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3838,6 +4182,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-named-locks/2.0.0-alpha-8": {
+      "narHash": "sha256-7SfNAxfNs/bhHY4p0e7dj6s8WgqZms6cJMZIjUOp7GQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3849,6 +4194,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-spi/2.0.10": {
+      "narHash": "sha256-vHGZXWGY5gjvAPEfCE0OF2m9b2fWmJPH8NyMqONyEsM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3860,6 +4206,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-supplier/2.0.0-alpha-8": {
+      "narHash": "sha256-G79lFkkfp2zJ8Re95IMg/xCsJwTFveM97UaT3fuk8xw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3871,6 +4218,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-transport-apache/2.0.0-alpha-8": {
+      "narHash": "sha256-v/0SXVUdYo6w81fgElcKd98WfiQMTYOD5IExx6eZXUE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3882,6 +4230,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-transport-file/2.0.0-alpha-8": {
+      "narHash": "sha256-7t/xWcxidEQdLmVochreONE3ZhH0hvGyipfxOLRVIdo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3893,6 +4242,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-transport-http/2.0.0-alpha-2": {
+      "narHash": "sha256-zzxSiW3Y6xZv7GxtJX7CR+aAjjJHgHNfCidAuHl/7cA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3904,6 +4254,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver-util/2.0.10": {
+      "narHash": "sha256-8nx4gNdMvVLpWObBxn1lqtR8AIM4BPI1ZoDwCAQ7v90=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3915,6 +4266,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver/2.0.0-alpha-2": {
+      "narHash": "sha256-TWMa1qGbRjJ1oPwelqqsUsmY3gT9PFdTAD2UiYJpFoE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3924,6 +4276,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver/2.0.0-alpha-8": {
+      "narHash": "sha256-XSgt85e4sVqHeuhCRjh3v+wrVjhPKFSyAeVSjv5VDL4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3933,6 +4286,7 @@
       }
     },
     "org/apache/maven/resolver/maven-resolver/2.0.10": {
+      "narHash": "sha256-rT+DMbVL09R3LtMejBjzXux3P7v72LtNZWRzVsyAyCE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3942,6 +4296,7 @@
       }
     },
     "org/apache/pdfbox/fontbox/2.0.24": {
+      "narHash": "sha256-Eg7l85BYsOyKeHV9/ckBYkjPym/arRSnvwb/6NCVpys=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3953,6 +4308,7 @@
       }
     },
     "org/apache/pdfbox/pdfbox-parent/2.0.24": {
+      "narHash": "sha256-ICTFAOwx219wrYzK5mF/1OW1cygG8UE2+U0pbgyXQwM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3962,6 +4318,7 @@
       }
     },
     "org/apache/pdfbox/pdfbox/2.0.24": {
+      "narHash": "sha256-eEAoPEnv7GeLNCJg3s8y+eMscBhUb7MXk5q4TN4HPTQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3973,6 +4330,7 @@
       }
     },
     "org/apache/pdfbox/xmpbox/2.0.24": {
+      "narHash": "sha256-8KfMOrkesYsGwXdXFmj/YAjcWHZAoqH1HMOE9KKmCSc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -3984,6 +4342,7 @@
       }
     },
     "org/apache/tika/tika-core/3.2.3": {
+      "narHash": "sha256-4m68NftTJlaaX6Cm7KB460AZKBSMzYMi1cOzLW5KtLA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -3996,6 +4355,7 @@
       }
     },
     "org/apache/tika/tika-parent/3.2.3": {
+      "narHash": "sha256-4nJXW5RUUEL+ebaLPbbh64o1N1mppZLITlRAyQ2JTGQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4006,6 +4366,7 @@
       }
     },
     "org/apache/xbean/xbean-reflect/3.7": {
+      "narHash": "sha256-KDCfNSN/4lfWIt7lnb/etPu3UbviMK6O5LkuUc1k8dY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4018,6 +4379,7 @@
       }
     },
     "org/apache/xbean/xbean/3.7": {
+      "narHash": "sha256-hQ6BKMV103yvpc04Dqoa6+xu2BKxQcO5UqNKngv3Hnc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4028,6 +4390,7 @@
       }
     },
     "org/checkerframework/checker-qual/3.5.0": {
+      "narHash": "sha256-pmDCPARSYcGncoFv8dMJYHJSUQo6xqHusvTuSyX+aWk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4040,6 +4403,7 @@
       }
     },
     "org/chipsalliance/firtool-resolver_2.13/2.0.1": {
+      "narHash": "sha256-8X/G9hzDoyrLZg/LNcP/Nc9gmRJr+tRipRAjnZheVRw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4051,6 +4415,7 @@
       }
     },
     "org/codehaus/plexus/plexus-archiver/4.10.1": {
+      "narHash": "sha256-V78TEbISDyOT2q3cGzklO0CZIbRlR56IonMmP4ZSXRs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4063,6 +4428,7 @@
       }
     },
     "org/codehaus/plexus/plexus-classworlds/2.6.0": {
+      "narHash": "sha256-XASW2MjUrG0xb6LQUAxW+wrAlfdLmfd6uWOfIX9lG7Y=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4075,6 +4441,7 @@
       }
     },
     "org/codehaus/plexus/plexus-container-default/2.1.1": {
+      "narHash": "sha256-DK+ZrlOIQSrf9ag7xK5V8hsl1tdPKrZRXx37hBks4VY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4087,6 +4454,7 @@
       }
     },
     "org/codehaus/plexus/plexus-containers/2.1.1": {
+      "narHash": "sha256-afcnIR7Mw3Sm+5OePirFq6ZGzRbiDdBCJ8rZfljph4s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4097,6 +4465,7 @@
       }
     },
     "org/codehaus/plexus/plexus-interpolation/1.26": {
+      "narHash": "sha256-FU0+o1H8n7UgIrJk061kwkQD/a/murGhteUdZ/4bCoo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4108,6 +4477,7 @@
       }
     },
     "org/codehaus/plexus/plexus-io/3.5.1": {
+      "narHash": "sha256-vkD6MyZJVBgzCsuc5XuFGy+8EH5dMMmj78c1P5vKE+I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4120,6 +4490,7 @@
       }
     },
     "org/codehaus/plexus/plexus-utils/4.0.2": {
+      "narHash": "sha256-hclcJrJ5oXBltuxyHskIjmRV8Mz9Pxp8TplXxgB4m/4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4132,6 +4503,7 @@
       }
     },
     "org/codehaus/plexus/plexus-xml/4.0.3": {
+      "narHash": "sha256-NQmzClj63TkwNoZs4tlqFCgf3euHIYxxeCVri/ugfDY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4143,6 +4515,7 @@
       }
     },
     "org/codehaus/plexus/plexus/16": {
+      "narHash": "sha256-1tqQUI0k1BqWObUjkDp3NgmvXy83q1cZONaar5Fgycs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4152,6 +4525,7 @@
       }
     },
     "org/codehaus/plexus/plexus/18": {
+      "narHash": "sha256-f2hAcXSAUEhPF81cdgaj0xRsbDleUMWv+c3l9TvjSP8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4162,6 +4536,7 @@
       }
     },
     "org/codehaus/plexus/plexus/23": {
+      "narHash": "sha256-akFxmP1IXKzrjuU/JOW+kWgOuLwvqhN5CB82rJwLdJg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4172,6 +4547,7 @@
       }
     },
     "org/codehaus/plexus/plexus/5.1": {
+      "narHash": "sha256-nRLuEdJgPVbznR6pacHpqqHEFFw8+soqa7Q902ozoz4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4182,6 +4558,7 @@
       }
     },
     "org/codehaus/plexus/plexus/6.5": {
+      "narHash": "sha256-RfB5TMTwKFoq0uOnpU+Xs+fOLIDEddabf7WV9y0spz8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4192,6 +4569,7 @@
       }
     },
     "org/codehaus/woodstox/stax2-api/4.2.1": {
+      "narHash": "sha256-nzk1oHCt9bc/wIDmBwYTmua9D4aKthAd2irYwwfFWKg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4203,6 +4581,7 @@
       }
     },
     "org/eclipse/ee4j/project/1.0.6": {
+      "narHash": "sha256-O/vvCwy9adc26IWsFejnSCjH/Qc749h2+VolMYqwuD0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4212,6 +4591,7 @@
       }
     },
     "org/eclipse/ee4j/project/1.0.7": {
+      "narHash": "sha256-DsMqamX0Nws0CZH0/Lt9ia44XK1cYMozf/dr5RLegZM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4222,6 +4602,7 @@
       }
     },
     "org/eclipse/jetty/jetty-bom/10.0.20": {
+      "narHash": "sha256-Wvan8j+I2/aBIYI94stASpv2ixrjjdlED2GMqmoL+6k=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4231,6 +4612,7 @@
       }
     },
     "org/eclipse/jetty/jetty-bom/10.0.25": {
+      "narHash": "sha256-/eIhaPYg5ke5IPE7PkB37msRdI5Wic4goVLaOCc3jzE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4240,6 +4622,7 @@
       }
     },
     "org/eclipse/jetty/jetty-bom/11.0.26": {
+      "narHash": "sha256-bdmdM0NKG3YQO9jFlK9+75zfmgDqFxB9YzxqFt3LC5U=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4250,6 +4633,7 @@
       }
     },
     "org/eclipse/jgit/org.eclipse.jgit-parent/6.10.1.202505221210-r": {
+      "narHash": "sha256-9B0sZIdbB0WCn+o9I4pCrTTGrmn+jrUmJxbaRNdftQk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4260,6 +4644,7 @@
       }
     },
     "org/eclipse/jgit/org.eclipse.jgit/6.10.1.202505221210-r": {
+      "narHash": "sha256-qqHffUYtpWRZATJHDvtQ6wQD00wxyOT5eY0mj38Tu3o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4272,6 +4657,7 @@
       }
     },
     "org/eclipse/lsp4j/org.eclipse.lsp4j.generator/0.20.1": {
+      "narHash": "sha256-crpw5WA/1fe14d2Oer86Y8uDLQ8NDP3K+53OIr1Sj64=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4284,6 +4670,7 @@
       }
     },
     "org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.20.1": {
+      "narHash": "sha256-0yaQeS10hpPTLf5EcUAF+cC+szxJkZ9jIbnOMGdO0WY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4296,6 +4683,7 @@
       }
     },
     "org/eclipse/xtend/org.eclipse.xtend.lib.macro/2.28.0": {
+      "narHash": "sha256-ahRfcQy3OaedJwTNQNW7HRzrGdTOo3cwPJafeahB4bg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4308,6 +4696,7 @@
       }
     },
     "org/eclipse/xtend/org.eclipse.xtend.lib/2.28.0": {
+      "narHash": "sha256-xghLEmi2uOqBdYSqULKxmy6/PVFRpDnHzf5koGauWBE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4320,6 +4709,7 @@
       }
     },
     "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.28.0": {
+      "narHash": "sha256-f3ofynWSpJn7zfGhosED8cjuv/0Edg3got26l0ZpRGg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4332,6 +4722,7 @@
       }
     },
     "org/eclipse/xtext/xtext-dev-bom/2.28.0": {
+      "narHash": "sha256-mRoiSdQRKZienVjYnlLCxvaNAL0/LhkpL+CYoREFwbA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4342,6 +4733,7 @@
       }
     },
     "org/fusesource/fusesource-pom/1.12": {
+      "narHash": "sha256-bP6V8bPeozOobgbUzIgMC90iL28usSlmI9X36UTHZws=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4352,6 +4744,7 @@
       }
     },
     "org/fusesource/jansi/jansi/2.4.1": {
+      "narHash": "sha256-ctFo1PFnISeFNxWzWp1DRwuw2/u0gVUEudpRboPzJaY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4364,6 +4757,7 @@
       }
     },
     "org/http4s/http4s-circe_3/0.23.25": {
+      "narHash": "sha256-lNOPWnSTxxF7XSwAFoSMhw/o5xU1R9jmIc7Q7scqY9E=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4376,6 +4770,7 @@
       }
     },
     "org/http4s/http4s-client_3/0.23.25": {
+      "narHash": "sha256-0b4K5MLjH6+IEgEo5hIyb3/V0TgpRG8kCR1mdpU9ZFk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4388,6 +4783,7 @@
       }
     },
     "org/http4s/http4s-core_3/0.23.25": {
+      "narHash": "sha256-tmMsIQkTwujKYSfzs5dG8W40Xmftu2bDbAza1W1zIRk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4400,6 +4796,7 @@
       }
     },
     "org/http4s/http4s-crypto_3/0.2.4": {
+      "narHash": "sha256-y8kZ78OC21mxXU0rMRMXlv7KeXIbHWDMpV/Yb+aMUJY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4412,6 +4809,7 @@
       }
     },
     "org/http4s/http4s-jawn_3/0.23.25": {
+      "narHash": "sha256-3hVSFiOfPrBZ6lWGRZ2ILh+hG4qXwfO/pjsFqBa3WLU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4424,6 +4822,7 @@
       }
     },
     "org/jboss/jboss-parent/23": {
+      "narHash": "sha256-oDmvCEToXeEUzAR2QgufBrMXIi1yiPqayHxnPj5i834=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4433,6 +4832,7 @@
       }
     },
     "org/jboss/jboss-parent/34": {
+      "narHash": "sha256-elpcoYOeNeexIcwNzZSgJgEmqDOJxeUmY+edrTc1yQc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4442,6 +4842,7 @@
       }
     },
     "org/jboss/jboss-parent/35": {
+      "narHash": "sha256-R9v4UgZ4MzAkJp5S4yKvjoP5n8kXXZFMnUOcAsqhv4Y=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4451,6 +4852,7 @@
       }
     },
     "org/jboss/jboss-parent/36": {
+      "narHash": "sha256-melNYwNbfffRzYPRJwYbBjBE9l6S3Fr/di06PhsiG8k=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4460,6 +4862,7 @@
       }
     },
     "org/jboss/jboss-parent/39": {
+      "narHash": "sha256-BK47fRx/cXMU3zii7ZvvkZL+aKFSIpRTCla63OmioIU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4469,6 +4872,7 @@
       }
     },
     "org/jboss/jboss-parent/43": {
+      "narHash": "sha256-bmO7r/tUNR6DQG7/59/ZGsmuPkZR5TU38VypX37roc0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4478,6 +4882,7 @@
       }
     },
     "org/jboss/logging/jboss-logging/3.4.1.Final": {
+      "narHash": "sha256-812JoIz4bngf5V7ngE2qgZ6yYpAAcLwMVuObYXXzat0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4487,6 +4892,7 @@
       }
     },
     "org/jboss/logging/jboss-logging/3.4.3.Final": {
+      "narHash": "sha256-f9JrZTFWYRtxm1hpJCY2F5juipD/LL6jUu+Iqzs8FwY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4498,6 +4904,7 @@
       }
     },
     "org/jboss/threads/jboss-threads/3.1.0.Final": {
+      "narHash": "sha256-Xz3Yvyt4VYTKmj69GW6F9BQGLbvQofU9C5NgpdnMEcI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4509,6 +4916,7 @@
       }
     },
     "org/jboss/xnio/xnio-all/3.8.16.Final": {
+      "narHash": "sha256-sLpBlUi3fT1G3Ty4HbtJiV08lD7hMdx0rLYV4AvyGw8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4518,6 +4926,7 @@
       }
     },
     "org/jboss/xnio/xnio-api/3.8.16.Final": {
+      "narHash": "sha256-estdK34Za9OSj9xBv2RaExNvKNOC8PK037aykoraURE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4529,6 +4938,7 @@
       }
     },
     "org/jboss/xnio/xnio-nio/3.8.16.Final": {
+      "narHash": "sha256-I1NCeEi5Dyhk6gqL+Ap18hELP5fWiai//kf1icMy1ns=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4540,6 +4950,7 @@
       }
     },
     "org/jetbrains/annotations/24.0.1": {
+      "narHash": "sha256-BK4EhlI2MuB73FodqOYyWAhR033g7fnXH4sJ4uE87n0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4551,6 +4962,7 @@
       }
     },
     "org/jgrapht/jgrapht-core/1.4.0": {
+      "narHash": "sha256-krB+8bXnW0in6tNW3XQ4At1tqltpQA31C8vwAD5sUzQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4563,6 +4975,7 @@
       }
     },
     "org/jgrapht/jgrapht/1.4.0": {
+      "narHash": "sha256-znqGWOYTYvodYhftTSIpbZnRmocuF2yUpR6/8zqeioI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4573,6 +4986,7 @@
       }
     },
     "org/jheaps/jheaps/0.11": {
+      "narHash": "sha256-8WxKa+gzaA/WcQ7E3l1rr52Svi4KtOrCK5enMial86E=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4585,6 +4999,7 @@
       }
     },
     "org/jline/jline-native/3.25.1": {
+      "narHash": "sha256-nz3JAXPUDLI9KGYrsSnbyyvTmaUahhGHi7Y62Lm6T90=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4597,6 +5012,7 @@
       }
     },
     "org/jline/jline-native/3.27.1": {
+      "narHash": "sha256-L+v7a1SjHf+ZqYMLCk6Eoc51UbOOwBpnEZs8IbFj/f8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4609,6 +5025,7 @@
       }
     },
     "org/jline/jline-native/3.29.0": {
+      "narHash": "sha256-KgKU0EJ5eY6uiDbaDMm2EbP0oAtrvinmkWlxuqw/3WQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4621,6 +5038,7 @@
       }
     },
     "org/jline/jline-parent/3.22.0": {
+      "narHash": "sha256-eXw1+3sFlqdSilf535y3i+RA32hGyvz93XWB0l2C5BI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4631,6 +5049,7 @@
       }
     },
     "org/jline/jline-parent/3.24.1": {
+      "narHash": "sha256-DZvutoy0QkJg2uJB4o2otQ3RlgzpM4mmIt/vWeSOr+8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4641,6 +5060,7 @@
       }
     },
     "org/jline/jline-parent/3.25.1": {
+      "narHash": "sha256-BikCSkuq1O09icEi9hRobXVWucvUa3GJcxxqoinzTcc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4651,6 +5071,7 @@
       }
     },
     "org/jline/jline-parent/3.27.1": {
+      "narHash": "sha256-UoyWFOH/VlcCzHSmAfKpGKDK8T3QotEFMj7TDnAFKnI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4661,6 +5082,7 @@
       }
     },
     "org/jline/jline-parent/3.29.0": {
+      "narHash": "sha256-AXy28dmu0l2MfcCNNxJIXZ+fJgXsrqsNWtGjmUlPUYw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4671,6 +5093,7 @@
       }
     },
     "org/jline/jline-reader/3.25.1": {
+      "narHash": "sha256-th++Spe6e7q7fTmFeV30rCMaijXVFVSBG4FGWI8n7CY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4683,6 +5106,7 @@
       }
     },
     "org/jline/jline-reader/3.29.0": {
+      "narHash": "sha256-m3TQyVpghuJTaHIKSbS0V8ZJAL1QVV0uJHf4p8586uM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4695,6 +5119,7 @@
       }
     },
     "org/jline/jline-terminal-jna/3.25.1": {
+      "narHash": "sha256-4H9yzINlcRjUvWCOcALRysuo9J29L9CEUmZT/tyEi+o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4707,6 +5132,7 @@
       }
     },
     "org/jline/jline-terminal-jni/3.27.1": {
+      "narHash": "sha256-QoyZpKyEmPqaez2iv/KJ68Bl/fZlKXF4cMrjvCaWTLU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4719,6 +5145,7 @@
       }
     },
     "org/jline/jline-terminal-jni/3.29.0": {
+      "narHash": "sha256-UZEi5HYNwGSdUpWTZWo+4JXVXkkRvnfMdoR6L1Dr9/8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4731,6 +5158,7 @@
       }
     },
     "org/jline/jline-terminal/3.25.1": {
+      "narHash": "sha256-M6WY8VF31DuzU8CJJNMbWd1gmgFkdLxKcK6BzR56uuA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4743,6 +5171,7 @@
       }
     },
     "org/jline/jline-terminal/3.27.1": {
+      "narHash": "sha256-tv4BBKyLUHj/04srhmn+FC4QtEWwkoQHKL93i5fwj8w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4755,6 +5184,7 @@
       }
     },
     "org/jline/jline-terminal/3.29.0": {
+      "narHash": "sha256-YBoMP+awP9aQQIaM3RDVRG0iCU65DvIOYw2UsmMVQhg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4767,6 +5197,7 @@
       }
     },
     "org/jline/jline/3.22.0": {
+      "narHash": "sha256-edxiVaJ0iIMVP3erxXrzrBcNHt6plsS1m0vCuOz1abg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4779,6 +5210,7 @@
       }
     },
     "org/jline/jline/3.24.1": {
+      "narHash": "sha256-enFGVmqDzRx43RAiShWUqZHM6M7/KXX4aFW+nksbaPQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4791,6 +5223,7 @@
       }
     },
     "org/jline/jline/3.25.1": {
+      "narHash": "sha256-GTJbIER5v37K9uIKUSgmEqXIVSKwIx/3oYlmvqHpzg4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4803,6 +5236,7 @@
       }
     },
     "org/jline/jline/3.26.3": {
+      "narHash": "sha256-OhQAWhUSyzpSyfDC9rst1X4pcsKiPU2QjFLoPYd91fg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4815,6 +5249,7 @@
       }
     },
     "org/jline/jline/3.27.1": {
+      "narHash": "sha256-y2y4cWXD1Bhk3YRFDIRzcI4pl5uWS0UjmUZu1HaRtI8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4827,6 +5262,7 @@
       }
     },
     "org/jline/jline/3.29.0": {
+      "narHash": "sha256-SGaQjVyWcF72B9/Wv6WsNK8+Yx5yZ66C30S0gq/OT3Y=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4839,6 +5275,7 @@
       }
     },
     "org/jline/jline/3.30.6": {
+      "narHash": "sha256-QP+ke0mCN+/m4/64Q8Q4yY7hIIgoqWemuDOvOSVENLE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4851,6 +5288,7 @@
       }
     },
     "org/jsoup/jsoup/1.15.4": {
+      "narHash": "sha256-pkjEaOA0BypP2YHhQKmQs8lW6yHX4juFlcE0rJqzoTI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4862,6 +5300,7 @@
       }
     },
     "org/junit/junit-bom/5.10.0": {
+      "narHash": "sha256-21sXlVXzW1JaO+rAwkSLzntqm+j4z8Oq3GXGIjPYaUE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4871,6 +5310,7 @@
       }
     },
     "org/junit/junit-bom/5.10.1": {
+      "narHash": "sha256-1c7bxfZACWBOska6Orh/omyOdY81hlpREpRufdwwjv4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4880,6 +5320,7 @@
       }
     },
     "org/junit/junit-bom/5.10.2": {
+      "narHash": "sha256-B+PJk8v+wHuhDStnRc4EJjhmXjHoEBVPe+XFRBcBnFs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4890,6 +5331,7 @@
       }
     },
     "org/junit/junit-bom/5.13.1": {
+      "narHash": "sha256-FB7QZInKyvY3albCyuunUc64zWhvL3OP0MhZed6QQPU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4900,6 +5342,7 @@
       }
     },
     "org/junit/junit-bom/5.13.2": {
+      "narHash": "sha256-4G97sHarSS/uF9F0zqcHTMFcToEpIM967acAb6YgC+Q=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4910,6 +5353,7 @@
       }
     },
     "org/junit/junit-bom/5.13.4": {
+      "narHash": "sha256-fLwHSpSF6swDb2zrYGgeJrTHUrVgJhPJxBPqUCsLcoE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4920,6 +5364,7 @@
       }
     },
     "org/junit/junit-bom/5.14.2": {
+      "narHash": "sha256-CsHLiGsnCgXiYfjNsh/ySzLHegzdFqXuIbbQ7GwDTaQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4930,6 +5375,7 @@
       }
     },
     "org/junit/junit-bom/5.8.0-M1": {
+      "narHash": "sha256-eldjBYUR0v52PvwjLQ4YzcWmRR6s5WCWjWnxa5jnvqc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4940,6 +5386,7 @@
       }
     },
     "org/junit/junit-bom/5.8.2": {
+      "narHash": "sha256-QBoV+BDyC5t08U/M8iEfG1stzCT23fYh61FLYVfBvu0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4949,6 +5396,7 @@
       }
     },
     "org/junit/junit-bom/5.9.3": {
+      "narHash": "sha256-b8NRy9u3mookuN/1l0jIc5bxB3l+axQrG4qA6YEWDT8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4958,6 +5406,7 @@
       }
     },
     "org/log4s/log4s_3/1.10.0": {
+      "narHash": "sha256-X6H2rdTXZMltDESMbrOga+P954mQZSUJK1w4AJItWTw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4970,6 +5419,7 @@
       }
     },
     "org/mockito/mockito-bom/4.11.0": {
+      "narHash": "sha256-T6mltJmfhoi0tQnauEwjxgKg9MKi/UweZ5MnJtKptxI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -4980,6 +5430,7 @@
       }
     },
     "org/mockito/mockito-bom/5.7.0": {
+      "narHash": "sha256-AMDgrpIGoyAtGQAUxudKCTSpLW+EU8w6X2ZpoITeJzo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -4989,6 +5440,7 @@
       }
     },
     "org/nibor/autolink/autolink/0.6.0": {
+      "narHash": "sha256-+ZIVpI/cSN20xOaZ7flkUMoTABS2l/L4OcMm5mqt+1I=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5000,6 +5452,7 @@
       }
     },
     "org/openjdk/jmh/jmh-core/1.37": {
+      "narHash": "sha256-hmq73oq/5ddAvQIGW7HABxkOKxPCj2UGsb0zlwWp8gk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5011,6 +5464,7 @@
       }
     },
     "org/openjdk/jmh/jmh-parent/1.37": {
+      "narHash": "sha256-7cjnaAfV3nYbHorrGrK5tMUmqgA0ex1m9hfPWncWAhM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5020,6 +5474,7 @@
       }
     },
     "org/ow2/asm/asm-commons/9.8": {
+      "narHash": "sha256-xEVsG5Tfm7PfUQ1AiQX+hflk9hKa9hS1b+pYwTz+St8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5031,6 +5486,7 @@
       }
     },
     "org/ow2/asm/asm-tree/9.8": {
+      "narHash": "sha256-RAXYjGc3bzDHffxblvqo4MpHcvn6qzUxALMgsypL1oc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5042,6 +5498,7 @@
       }
     },
     "org/ow2/asm/asm-tree/9.9.1": {
+      "narHash": "sha256-bpW7/rDmlBZ/HJ6hJslK1mRoNJHWIHxyzqRDg757mVc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5054,6 +5511,7 @@
       }
     },
     "org/ow2/asm/asm/9.8": {
+      "narHash": "sha256-jJ4HtBQQAkpJ8ohTzn3vveUR20k/wWKL6gXZ4buWelI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5065,6 +5523,7 @@
       }
     },
     "org/ow2/asm/asm/9.9.1": {
+      "narHash": "sha256-QwoFUayo0lC3kYVhNmoD40G99yuB1dyLadsXf3FJxsQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5077,6 +5536,7 @@
       }
     },
     "org/ow2/ow2/1.5.1": {
+      "narHash": "sha256-/r2DFKgqLJGqIN9ygOdD/rjXRC5mrSI3ObkkPmY99uw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5087,6 +5547,7 @@
       }
     },
     "org/scala-lang/modules/scala-asm/9.6.0-scala-1": {
+      "narHash": "sha256-ISQuCMNxxOfPHtlWTq6RgNgcP2XY73qvS4+AMlKI6C8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5099,6 +5560,7 @@
       }
     },
     "org/scala-lang/modules/scala-asm/9.9.0-scala-1": {
+      "narHash": "sha256-eQrBrknk3x8fv5bsuYTFlAYDdYDF/O73s4YF+EgK/vs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5111,6 +5573,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_2.13/2.11.0": {
+      "narHash": "sha256-vKdbRpuHolnwENaLvy5Fk/+vIOiU9hQ9G0WC8TpmhpY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5122,6 +5585,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_2.13/2.13.0": {
+      "narHash": "sha256-8MJilZ4MSyAIPTV4NXY8MqoXKcAQacdCElbDKgHNp6E=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5134,6 +5598,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_3/2.12.0": {
+      "narHash": "sha256-7Au54pBxOqfKN0FC7rReGntTXjSItkHo6lXkvMfri6A=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5146,6 +5611,7 @@
       }
     },
     "org/scala-lang/modules/scala-parallel-collections_3/1.2.0": {
+      "narHash": "sha256-b3c+8vBjvNQ2PetaZ1DL7Mi7b1tLVVcJGH8Ufok9ZLQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5158,6 +5624,7 @@
       }
     },
     "org/scala-lang/modules/scala-parser-combinators_3/2.1.0": {
+      "narHash": "sha256-ZRku7/GCUu8Mi3M1HfyBfj/3cfr4h5yuxEUP0dAm24s=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5170,6 +5637,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_2.13/2.1.0": {
+      "narHash": "sha256-weXoY4jV7T2KA0ajs/Jtve9VgblXjoFs9bOJHHotuEw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5181,6 +5649,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_2.13/2.2.0": {
+      "narHash": "sha256-YBGMrv5Ik9vG+2AlnBM0klVz7W3G0UDmsesE8mrM6So=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5192,6 +5661,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_2.13/2.4.0": {
+      "narHash": "sha256-BLvjUdvcFtQGxpKdg7D+TOa06Chipiqk9kOc8bt+Se4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5204,6 +5674,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_3/2.0.1": {
+      "narHash": "sha256-Jeyeq0WavLCUszVtSved7egkBjoFibOjps/aMVz0SGU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5216,6 +5687,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_3/2.1.0": {
+      "narHash": "sha256-8EwpMiJQgg2flTYWTOfdK+uChe4Z9G5qIQg5mha8Sws=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5227,6 +5699,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_3/2.4.0": {
+      "narHash": "sha256-MRFpTbQduSCHCUFrc/K8I/HnZJyyoXmpER+FbjEY+lQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5239,6 +5712,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.11": {
+      "narHash": "sha256-7sLAt/GJM58xz4SsjAGuEGkQVf1QNBMAm45ifAnxc4U=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5251,6 +5725,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.12": {
+      "narHash": "sha256-TL2MlJdMbE+/0wJai4fXoeBeM0TCYmLTN+Pmb9CLJYQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5263,6 +5738,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.13": {
+      "narHash": "sha256-LfoaXaevY+uH2CF6a1jczGLPT0WlwaNQ91vi4VYix3k=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5275,6 +5751,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.14": {
+      "narHash": "sha256-MamYhRGg4FJOVU6tVrrE/RdYgB9dxPMh678s7u0nhD4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5287,6 +5764,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.15": {
+      "narHash": "sha256-0a8N86/EaBh/6u7WPoMZGSELWMz/VvGB4/npMEQmAlo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5299,6 +5777,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.16": {
+      "narHash": "sha256-gTuwF3Q+5XMam3x97kD+BrpJQ2KNBqPuMYHF/pUGZqE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5311,6 +5790,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.17": {
+      "narHash": "sha256-UQN62ObFxUnhjDIuoL9DqVZLFLCuEcEN1jUa9JRS1NA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5323,6 +5803,7 @@
       }
     },
     "org/scala-lang/scala-compiler/2.13.18": {
+      "narHash": "sha256-4fKKJNnd3AmiV2kZ6YqPzFLBrithMmMb5Yveil0Rahg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5335,6 +5816,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.11": {
+      "narHash": "sha256-s843wvE2iVkowYjeBZo6/F4CDx36htK6KrJrdQMlwb0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5347,6 +5829,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.12": {
+      "narHash": "sha256-xx4mY18Ch+MD+9zVggvPY7rCbGIg67BrxgGCJpGCU8Y=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5359,6 +5842,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.13": {
+      "narHash": "sha256-LDklwtF2bPUEUuWKB2XWLGnNKivwipLh+5HW6F8J6YQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5371,6 +5855,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.14": {
+      "narHash": "sha256-/u5CfLUDnRlUU8Av2LVG22Z5Bizl0JxZpIahJMGw+lc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5383,6 +5868,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.15": {
+      "narHash": "sha256-usVVeWfMUINWSWlTxoOI6cvgfK7yGTLCClQdAC/ggrM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5395,6 +5881,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.16": {
+      "narHash": "sha256-5RdV0lVjCsQh6hQ2+jwjTLB3/2b/euPVAfIzIIqIFaA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5407,6 +5894,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.17": {
+      "narHash": "sha256-ivYki/w9mBq9FvkWfyiMF6jITOAcbM/P6xl7MIpuOt4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5419,6 +5907,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.18": {
+      "narHash": "sha256-qPCumuireZMHVgXGvyQX3+im/h4UZg6i5PhT8SrpLLw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5431,6 +5920,7 @@
       }
     },
     "org/scala-lang/scala-library/3.8.1": {
+      "narHash": "sha256-WHIVyIRmRBhxZaYKODHQ6THv2zAMksL/Xjjb7YrYwOk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5443,6 +5933,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.11": {
+      "narHash": "sha256-CBWt8FmDfqaqmad4Alvzwt+EQ4oQ37OWqu93qj5yp6Y=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5455,6 +5946,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.12": {
+      "narHash": "sha256-lDqxNuv/7kRpGZkNnK+H2WzWFmxH86BKPDqPgMHDiT0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5467,6 +5959,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.13": {
+      "narHash": "sha256-3Q6+8a4pnv/7DUH58DqgWgSRDXwoh3ehHSOKttkU1ho=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5479,6 +5972,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.14": {
+      "narHash": "sha256-haVa/e3h5GPmWecF0h5SN9z7c2swfY/Bk4Jk7mNhzaI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5491,6 +5985,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.15": {
+      "narHash": "sha256-r/LIIhSUCy5KCR722FiPJqzp3O3H2ryJHq3SQvQ4IDc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5503,6 +5998,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.16": {
+      "narHash": "sha256-sScAUkA/ZR5986tVzSvunj7hG8Y5kT3Fc534XTonboQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5515,6 +6011,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.17": {
+      "narHash": "sha256-cBletVuFV4JToL9XA0qxNWsldXBtxlBlYFKoUWp8iYE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5527,6 +6024,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.18": {
+      "narHash": "sha256-WmVnyDrFEPK/RuKG4Gd45CwC8ASQhONB0rR/YlaL8Pw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5539,6 +6037,7 @@
       }
     },
     "org/scala-lang/scala3-compiler_3/3.3.4": {
+      "narHash": "sha256-NF7ocMimi5o7qDXu7hTntcElwuvslspXZhl82wDE9d4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5551,6 +6050,7 @@
       }
     },
     "org/scala-lang/scala3-compiler_3/3.8.1": {
+      "narHash": "sha256-Ytl7sA2ijKrfbSJ6LCOJv2ha1c2UX8p/Y6lUIf/A1Kk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5563,6 +6063,7 @@
       }
     },
     "org/scala-lang/scala3-interfaces/3.3.4": {
+      "narHash": "sha256-VwvRrGkkl/UGFePjsHseL9zJWYIYWS5WBn7EihFxio4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5575,6 +6076,7 @@
       }
     },
     "org/scala-lang/scala3-interfaces/3.8.1": {
+      "narHash": "sha256-Tf9B0E3dZj9XXLALSQYd9WaIiEj1vA7V97ZOzaE9T0c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5587,6 +6089,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.3.4": {
+      "narHash": "sha256-WGNPZ861ieX1K2WXF2cd8AjQgEqXsDdSmzDWt0Dm9qA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5599,6 +6102,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.3.7": {
+      "narHash": "sha256-Y2e4VZfgRJm+3dkz2bfmC8sOf+mns2DR3dejFh0jMlk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5610,6 +6114,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.7.1": {
+      "narHash": "sha256-rReYLhZ+dlTJI1hy5bdF8DVBninNOOducrW0/IRdZBg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5620,6 +6125,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.7.4": {
+      "narHash": "sha256-Z88HdEBC/j+9VgMWXZnd4PxA7s8MSHbdZ20e1X/sVJU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5632,6 +6138,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.8.1": {
+      "narHash": "sha256-eJ/OvrECwmgQ4IdHjs9SWiGQDSvwz9O8KaJtJvUC6Do=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5644,6 +6151,7 @@
       }
     },
     "org/scala-lang/scala3-repl_3/3.8.1": {
+      "narHash": "sha256-WI6Iatal2/VHaaiaLJ6KJyyNsM3c9JYR14sjPBR6NhU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5656,6 +6164,7 @@
       }
     },
     "org/scala-lang/scala3-sbt-bridge/3.3.4": {
+      "narHash": "sha256-J1jZZIrmpvtrrsam32uaSWslPcjcXRLuKPSxNJeTxU4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5667,6 +6176,7 @@
       }
     },
     "org/scala-lang/scala3-sbt-bridge/3.8.1": {
+      "narHash": "sha256-uvOgmvpF4DPK+ii6GjbqX8+bZHgIexYzjWZFIREUrU0=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5679,6 +6189,7 @@
       }
     },
     "org/scala-lang/tasty-core_3/3.3.4": {
+      "narHash": "sha256-yGxVxS9g63LQLaDY+ld2pRWk5+YtdN/lFQyg7RCsUqU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5691,6 +6202,7 @@
       }
     },
     "org/scala-lang/tasty-core_3/3.8.1": {
+      "narHash": "sha256-DwkLZkHfZasJpt2f3ngUWP6aES9x+RAHbVe+W588PfI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5703,6 +6215,7 @@
       }
     },
     "org/scala-sbt/compiler-bridge_2.13/2.0.0-M13": {
+      "narHash": "sha256-H+4fbTjEtzi9fKIJiQXExtzNIiHYXJbaf0rJJAz66wA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5714,6 +6227,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.0": {
+      "narHash": "sha256-kdhnLABjzV1Lh6v4riLEv+WZV8y8SwOz7+0oipj1VK4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5725,6 +6239,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.3": {
+      "narHash": "sha256-3qHFQYsCPNX8g8x8zzeohQW7ChdzKTDjHolXMCvCVM4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5736,6 +6251,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.7": {
+      "narHash": "sha256-UkzhJOBwgDdz//SJKjICT94MaV+V1J8esBtWb3ySepM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5748,6 +6264,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.8": {
+      "narHash": "sha256-53uq670YflTDqDN/Lr87kOU0by5Lh8pyKJjj8K4jRsQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5759,6 +6276,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.8.1": {
+      "narHash": "sha256-tLJJs16yPK4GAiyrbyXtl3G497aiJKze8g3rRpWE/TE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5770,6 +6288,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.9.5": {
+      "narHash": "sha256-LkbXaBzBU/wJxXK6cfC33+4VvM6rY+KgXwh+DHRNXiY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5781,6 +6300,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.9.6": {
+      "narHash": "sha256-eoR6Yr7WqrlHh0VOpdTWM9NqhtSjjGSDdMDGqNEX8H4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5793,6 +6313,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/2.0.0-M13": {
+      "narHash": "sha256-J+OlgiyCvE4VWR29gvaSVW92zIGPqK9M+dEoan0i+RI=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5807,6 +6328,7 @@
       }
     },
     "org/scala-sbt/io_3/1.10.5": {
+      "narHash": "sha256-vggMUrcbxuksvoxFO+PyiVWfy7TK3gaANeLy7S4NxMc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5819,6 +6341,7 @@
       }
     },
     "org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18": {
+      "narHash": "sha256-6TDTztSMioLAVO1G6oweJwI1q4Uoc3WF5iiBSd+74No=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5831,6 +6354,7 @@
       }
     },
     "org/scala-sbt/launcher-interface/1.5.2": {
+      "narHash": "sha256-TuMJJCOCXNJhp8+zseST5FbRPs8mXZSvK49DzyLA2io=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5843,6 +6367,7 @@
       }
     },
     "org/scala-sbt/sbinary_3/0.5.1": {
+      "narHash": "sha256-ZuK0klxDWGRMWduT0Hfa4Un6dZbLhMQ0bJ2cnqsVTQE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5855,6 +6380,7 @@
       }
     },
     "org/scala-sbt/test-interface/1.0": {
+      "narHash": "sha256-JfoybnLVYiewk1eDDLTgKkba155f2tqDeNHglFlzjyc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5867,6 +6393,7 @@
       }
     },
     "org/scala-sbt/util-control_3/2.0.0-RC8": {
+      "narHash": "sha256-cdJTXsKoFjCv1n9rsQqI1B4yAx1tsq2ejJdEzNOh1sE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5879,6 +6406,7 @@
       }
     },
     "org/scala-sbt/util-core_3/2.0.0-RC8": {
+      "narHash": "sha256-KSsBtrDp3CKtL72vueuvLIOJ25ZTM3s+6anWqKO/A9c=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5891,6 +6419,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.0": {
+      "narHash": "sha256-b4XUbGvSg64I0rIJW9oCPOYtZSUPLTVih3P82xPc6O0=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5902,6 +6431,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.3": {
+      "narHash": "sha256-iuhWC23fDMrtmKePlpIuTcTJpIwItK3jswWO47pcWKM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5913,6 +6443,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.7": {
+      "narHash": "sha256-YRTgPzQUROVG0SpFyxjRxC8cQMKtLVi42pGgnzRJH94=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5925,6 +6456,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.8": {
+      "narHash": "sha256-63Yg/W6M7/Dz1wlITWTxWuSbxxq0anR4TCO2R7ctCGM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5936,6 +6468,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.8.2": {
+      "narHash": "sha256-adaqwCf2+d+9sqEWTY3SgXgyBCdxsfod+DeyDc+BZfg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5947,6 +6480,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.9.4": {
+      "narHash": "sha256-xMhveTNCrNhrMsRyk4bNfN82ZJy7Yvs8JJC4l3Xn288=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -5958,6 +6492,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.9.8": {
+      "narHash": "sha256-4aUy5S+XwD/Ya+5AI9DIWqgM1cj2MHOcMeO/otUvyIg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5970,6 +6505,7 @@
       }
     },
     "org/scala-sbt/util-interface/2.0.0-RC8": {
+      "narHash": "sha256-uD7BqSvcJA2qtNHbb9uvb2eMU9KehFVYE/rWW+qDIGQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5984,6 +6520,7 @@
       }
     },
     "org/scala-sbt/util-logging_3/2.0.0-RC8": {
+      "narHash": "sha256-MLXlFcG5zWxhL9gd3wjgTsACKet3eYefgLE1Sgj5bjg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -5996,6 +6533,7 @@
       }
     },
     "org/scala-sbt/util-relation_3/2.0.0-RC8": {
+      "narHash": "sha256-3se9PDEGfne6k35yliXuvqUBLdJYiYv/+i7JrDr/N6k=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6008,6 +6546,7 @@
       }
     },
     "org/scala-sbt/zinc-apiinfo_3/2.0.0-M13": {
+      "narHash": "sha256-F9Kx5W+PhSeGOVm6Y4EV0g3rFOBc8y4q0e1ykxl88eU=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6020,6 +6559,7 @@
       }
     },
     "org/scala-sbt/zinc-classfile_3/2.0.0-M13": {
+      "narHash": "sha256-Vy8f/Ch2qUl4xGj07uJAhT5LNovJTwwW7Ewc1GBaUZs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6032,6 +6572,7 @@
       }
     },
     "org/scala-sbt/zinc-classpath_3/2.0.0-M13": {
+      "narHash": "sha256-IQp10GDTnl/xtGGJdOBsxh6I57HUCSjeDLwfzDqHYTQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6044,6 +6585,7 @@
       }
     },
     "org/scala-sbt/zinc-compile-core_3/2.0.0-M13": {
+      "narHash": "sha256-XdBGPKHbZ3bBIUkXEh3Hq3zKFb7hfGwFaj6Ecw7ds7o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6056,6 +6598,7 @@
       }
     },
     "org/scala-sbt/zinc-core_3/2.0.0-M13": {
+      "narHash": "sha256-FKa12RrLCosOpxN18rRcxyduParY6eTSDJAqtzwBz0I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6068,6 +6611,7 @@
       }
     },
     "org/scala-sbt/zinc-persist_3/2.0.0-M13": {
+      "narHash": "sha256-uJPt9e7966ntAm0VVFIF9AXidk/C3Uvzr3Ap4dbQJ64=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6080,6 +6624,7 @@
       }
     },
     "org/scala-sbt/zinc_3/2.0.0-M13": {
+      "narHash": "sha256-U+7EWaJtjh6mAm+wpqUiOJnYM5jfrLmg4bU9vOIPo0w=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6092,6 +6637,7 @@
       }
     },
     "org/scalacheck/scalacheck_2.13/1.18.0": {
+      "narHash": "sha256-BaFWVU6wQuCGxJWpdeZz6/AnHqnviLoIJLq9EH5m+ac=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6103,6 +6649,7 @@
       }
     },
     "org/scalacheck/scalacheck_3/1.18.0": {
+      "narHash": "sha256-gN3vCEFGvpfOa6eMv3MytCkKe1kS9gbMpY1Fse6qlWs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6114,6 +6661,7 @@
       }
     },
     "org/scalactic/scalactic_2.13/3.2.19": {
+      "narHash": "sha256-jhCuVKYBPwHIs3ZAWns6idVrdj6h3SCsYqHvI3lnPVU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6125,6 +6673,7 @@
       }
     },
     "org/scalactic/scalactic_3/3.2.19": {
+      "narHash": "sha256-/ZViolp5xcLW8lhfZVBiwgk8WW6dpVU2CEiJyFSHRwc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6136,6 +6685,7 @@
       }
     },
     "org/scalameta/common_2.13/4.13.8": {
+      "narHash": "sha256-6qvNSXvyGihsmjMkPui2NGeKaOpr5DqCIcnfiA3oq6U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6147,6 +6697,7 @@
       }
     },
     "org/scalameta/io_2.13/4.13.8": {
+      "narHash": "sha256-G0fNTCTHXRyXvHlJBHjWSa9tS1joCDrtQQg03KKTwSU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6158,6 +6709,7 @@
       }
     },
     "org/scalameta/mdoc-cli_2.13/2.7.2": {
+      "narHash": "sha256-hWZs6Y2xqyXCek6nn+TDnOtCf5nSqOLtpdXoCVFeV4w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6169,6 +6721,7 @@
       }
     },
     "org/scalameta/mdoc-interfaces/2.7.2": {
+      "narHash": "sha256-pmKTsXUOzupML4WAdZO8ySJ+uqKH5t2oZP0iWNM8XJo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6180,6 +6733,7 @@
       }
     },
     "org/scalameta/mdoc-parser_2.13/2.7.2": {
+      "narHash": "sha256-f0LPJ4Na/WrEpS1MsrBbEWYzObDb4camODV7QLLqaIs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6191,6 +6745,7 @@
       }
     },
     "org/scalameta/mdoc-runtime_2.13/2.7.2": {
+      "narHash": "sha256-BImDiOxuhL/KlqjbJl19BLnuPIEmbHoDLLXjXtTOHIM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6202,6 +6757,7 @@
       }
     },
     "org/scalameta/mdoc_2.13/2.7.2": {
+      "narHash": "sha256-U+t6lQga8QyFmN7QahVbDKhI7oDtmT8BEvi7PvLrfMI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6213,6 +6769,7 @@
       }
     },
     "org/scalameta/metaconfig-core_2.13/0.16.0": {
+      "narHash": "sha256-5vhmyr7IQA7f5w+tlNRhK6mBXM+ZV5aNQ0+YiutVw3U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6224,6 +6781,7 @@
       }
     },
     "org/scalameta/metaconfig-pprint_2.13/0.16.0": {
+      "narHash": "sha256-ojylwqqn3+Invm+ozertc6Eo7daKklG0Cav3Ap5Me/U=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6235,6 +6793,7 @@
       }
     },
     "org/scalameta/metaconfig-typesafe-config_2.13/0.16.0": {
+      "narHash": "sha256-cajEXzemKnZVWGVxoVl07FLiQ0V2PWla6JqUCYsrAhw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6246,6 +6805,7 @@
       }
     },
     "org/scalameta/parsers_2.13/4.13.8": {
+      "narHash": "sha256-7JSL/McRLzOaigQyI6mUnF2RMg6/GXfrue/SeaHVNpY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6257,6 +6817,7 @@
       }
     },
     "org/scalameta/scalameta_2.13/4.13.8": {
+      "narHash": "sha256-H+nBRtqwO/Ah1n+bpQSYEcag6bNVj3+8Whl2zhgWcCI=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6268,6 +6829,7 @@
       }
     },
     "org/scalameta/trees_2.13/4.13.8": {
+      "narHash": "sha256-+V7R1nkJOeaJeNR//3Kb+80r0eTQu7mK2cfyobvbc14=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6279,6 +6841,7 @@
       }
     },
     "org/scalatest/scalatest-compatible/3.2.19": {
+      "narHash": "sha256-QJfQYqoteHsk7AHiZS+tPUCSD8IJM5kGuLuzS32Ke/w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6290,6 +6853,7 @@
       }
     },
     "org/scalatest/scalatest-core_2.13/3.2.19": {
+      "narHash": "sha256-3XSaQ/ntwZ2R7PSu6UDMo8GDCK3/OcKSOffmmpaVH4A=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6301,6 +6865,7 @@
       }
     },
     "org/scalatest/scalatest-core_3/3.2.19": {
+      "narHash": "sha256-Z1zULaUB7BaoO2h0MVpSxtRTEMRO9ZS0SaTbZ8gSJYs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6312,6 +6877,7 @@
       }
     },
     "org/scalatest/scalatest-diagrams_2.13/3.2.19": {
+      "narHash": "sha256-tXe9dUwawD4VRhBHsNMCypUhf9awvdBCDPJ3S6phoJA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6323,6 +6889,7 @@
       }
     },
     "org/scalatest/scalatest-diagrams_3/3.2.19": {
+      "narHash": "sha256-J7LqjERd6LETXUuknLc9DpUfP65T5tknEkFkH8MSasY=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6334,6 +6901,7 @@
       }
     },
     "org/scalatest/scalatest-featurespec_2.13/3.2.19": {
+      "narHash": "sha256-OF038SbiC12tU9PwoE59hkrfKZLdsdmNSezSYEDQi+Y=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6345,6 +6913,7 @@
       }
     },
     "org/scalatest/scalatest-featurespec_3/3.2.19": {
+      "narHash": "sha256-SjGl4hyAp3AoqJLl/BsKNnKTB2wJApgyRTFsZ+73+iE=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6356,6 +6925,7 @@
       }
     },
     "org/scalatest/scalatest-flatspec_2.13/3.2.19": {
+      "narHash": "sha256-8LEq7xCQgJ4iUjM/Ch51S2L1kTrUDuA2kPW5wjFy16M=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6367,6 +6937,7 @@
       }
     },
     "org/scalatest/scalatest-flatspec_3/3.2.19": {
+      "narHash": "sha256-JhpMTLtELou4gkvkZl4+Te6eMKf7UbFfQxQBCHhy3Xs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6378,6 +6949,7 @@
       }
     },
     "org/scalatest/scalatest-freespec_2.13/3.2.19": {
+      "narHash": "sha256-RG+ut4z0jN45Ba8fKwxb2spUonjSJbReu740mSur7eU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6389,6 +6961,7 @@
       }
     },
     "org/scalatest/scalatest-freespec_3/3.2.19": {
+      "narHash": "sha256-h9BpK3yD1oZk/XBtp4ZloX56o1UmnUXkD/h9oolGvmc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6400,6 +6973,7 @@
       }
     },
     "org/scalatest/scalatest-funspec_2.13/3.2.19": {
+      "narHash": "sha256-L0y42CHrvPmdPO4OklfcOGtFPQYYnzibFMhAWF9oZtQ=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6411,6 +6985,7 @@
       }
     },
     "org/scalatest/scalatest-funspec_3/3.2.19": {
+      "narHash": "sha256-Mk2VVYKM1WK0p7O+RODqpltfABc8MijENanAT/2K/Ck=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6422,6 +6997,7 @@
       }
     },
     "org/scalatest/scalatest-funsuite_2.13/3.2.19": {
+      "narHash": "sha256-xGA61MUUu1tflVkXPP5h3skK0qyeldNbhNZL/4CvUks=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6433,6 +7009,7 @@
       }
     },
     "org/scalatest/scalatest-funsuite_3/3.2.19": {
+      "narHash": "sha256-Quxw2JI2kkb8EVag3YhmJmdfoLgcZRcjarsSOlL8LGo=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6444,6 +7021,7 @@
       }
     },
     "org/scalatest/scalatest-matchers-core_2.13/3.2.19": {
+      "narHash": "sha256-LzzzqKRkUG+NerHydzBhwkwAWzgmfQGna8m5bZqATew=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6455,6 +7033,7 @@
       }
     },
     "org/scalatest/scalatest-matchers-core_3/3.2.19": {
+      "narHash": "sha256-PXyySa6/Pa7S1QXYPrsLeztU8IbX/nNmBAkG1NFebuU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6466,6 +7045,7 @@
       }
     },
     "org/scalatest/scalatest-mustmatchers_2.13/3.2.19": {
+      "narHash": "sha256-aPdCRoiDu/bI/hI5GF2Qd3JiQcLjfDIf5KFviuT65sg=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6477,6 +7057,7 @@
       }
     },
     "org/scalatest/scalatest-mustmatchers_3/3.2.19": {
+      "narHash": "sha256-81vJFhgFsI56pWxuA/1Q/nz7rrtoxDrheSszXTOMuD4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6488,6 +7069,7 @@
       }
     },
     "org/scalatest/scalatest-propspec_2.13/3.2.19": {
+      "narHash": "sha256-p8KvwhipoUo6TpnOiKNelTVjWNJlEQUtTKZz6gWDax8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6499,6 +7081,7 @@
       }
     },
     "org/scalatest/scalatest-propspec_3/3.2.19": {
+      "narHash": "sha256-eP/dYyMSUXBIPo1LWk3Z+bFqRfviGm+imlFNd99gZ2w=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6510,6 +7093,7 @@
       }
     },
     "org/scalatest/scalatest-refspec_2.13/3.2.19": {
+      "narHash": "sha256-dDY3xx5BCRcaie2Oh1fbm/B1dQqxuogmiHwzib/cbXs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6521,6 +7105,7 @@
       }
     },
     "org/scalatest/scalatest-refspec_3/3.2.19": {
+      "narHash": "sha256-0K+Ybyz+IOa/Y4RAqgyvnockwb7aihZ8IPa6x9exARM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6532,6 +7117,7 @@
       }
     },
     "org/scalatest/scalatest-shouldmatchers_2.13/3.2.19": {
+      "narHash": "sha256-sc1vIZu7mP156sPUkpYqFgKJO+a/0HKVZwBEeUqqrD8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6543,6 +7129,7 @@
       }
     },
     "org/scalatest/scalatest-shouldmatchers_3/3.2.19": {
+      "narHash": "sha256-O0ZmsKg6EYvw8CejdDCqv3K3xsRsJDoYlePj0dqG40s=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6554,6 +7141,7 @@
       }
     },
     "org/scalatest/scalatest-wordspec_2.13/3.2.19": {
+      "narHash": "sha256-mcTlj0f3DX6j0S4vH5ShEs4HhKsinMHLlCD5YvNgV3I=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6565,6 +7153,7 @@
       }
     },
     "org/scalatest/scalatest-wordspec_3/3.2.19": {
+      "narHash": "sha256-r+sDSgRAhdpAe3Ghy78juXO41xfC9kePgO/e5vvzWwc=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6576,6 +7165,7 @@
       }
     },
     "org/scalatest/scalatest_2.13/3.2.19": {
+      "narHash": "sha256-vviVaYJHCL1eA8EJSFht2XGaIIcaI3ezHdyG3m7iLBA=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6587,6 +7177,7 @@
       }
     },
     "org/scalatest/scalatest_3/3.2.19": {
+      "narHash": "sha256-SiwuMF2muB4DdTGy0LuHAQtpgluFIEIPgFE0lcu5wkM=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6598,6 +7189,7 @@
       }
     },
     "org/scalatestplus/scalacheck-1-18_2.13/3.2.19.0": {
+      "narHash": "sha256-gCkIhhAIZ6jfxoB5isA5OxYPr9fA1EvMClPftgjVYEU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6609,6 +7201,7 @@
       }
     },
     "org/scalatestplus/scalacheck-1-18_3/3.2.19.0": {
+      "narHash": "sha256-F1oBM2VkwrO4ZtwL7egiZxNGkl5hPyw1CBOzOUs5xf8=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6620,6 +7213,7 @@
       }
     },
     "org/scodec/scodec-bits_3/1.1.38": {
+      "narHash": "sha256-9A0057XrgOQqlJseVl+eJXY1tc+roSlJgs42eOEQ7rg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6632,6 +7226,7 @@
       }
     },
     "org/slf4j/jcl-over-slf4j/1.7.30": {
+      "narHash": "sha256-pgUH+SySv5n8WpPCn+fegWnYPT0oayL/d97V7kngf+8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6644,6 +7239,7 @@
       }
     },
     "org/slf4j/jcl-over-slf4j/1.7.36": {
+      "narHash": "sha256-IT81eIE8CJL4E++dte6I5K9qBud4mhZo3SfjprCo0tk=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6653,6 +7249,7 @@
       }
     },
     "org/slf4j/jcl-over-slf4j/2.0.11": {
+      "narHash": "sha256-CYy6sDQHW3shEfZMB/hEa+C7H50oCfiOnxr+T8LvXUw=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6664,6 +7261,7 @@
       }
     },
     "org/slf4j/jul-to-slf4j/1.7.30": {
+      "narHash": "sha256-iDTgHtSLZ0V5faJlfeVUX6dskfsPk8MnC2HFVGOjSm8=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6676,6 +7274,7 @@
       }
     },
     "org/slf4j/slf4j-api/1.7.36": {
+      "narHash": "sha256-3t0HBZS5a++AZ/JBFEmUBcfGCfc6azF0QRYD4zcsBss=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6688,6 +7287,7 @@
       }
     },
     "org/slf4j/slf4j-api/2.0.17": {
+      "narHash": "sha256-nAfMqycj+sgYHBLR6kQq2HRZQ9hs9keK7oIa1IVslls=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6700,6 +7300,7 @@
       }
     },
     "org/slf4j/slf4j-bom/2.0.11": {
+      "narHash": "sha256-WHSd5XTZO4qqIQKxzbdBWzSpZp0f5G1BH3Lw/U/w3rs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6709,6 +7310,7 @@
       }
     },
     "org/slf4j/slf4j-bom/2.0.17": {
+      "narHash": "sha256-bz/LEZ+MqjeCAHkg7DS29TiziWydHoFlrtU5wBRk1Xk=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6719,6 +7321,7 @@
       }
     },
     "org/slf4j/slf4j-parent/1.7.30": {
+      "narHash": "sha256-nmncTonxk94tmAg8ULUcFpcaVyW6MR3TFwCbl/tdSsM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6729,6 +7332,7 @@
       }
     },
     "org/slf4j/slf4j-parent/1.7.36": {
+      "narHash": "sha256-g63yvIFGexvoTEJsa5hSJyMFP2efa6Seic4sUoqioSQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6739,6 +7343,7 @@
       }
     },
     "org/slf4j/slf4j-parent/2.0.11": {
+      "narHash": "sha256-2A4Jk5Y2x2d6IuOtCPjQ3pn7Y2ryOa/k+iZtMtk87v4=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6748,6 +7353,7 @@
       }
     },
     "org/slf4j/slf4j-parent/2.0.17": {
+      "narHash": "sha256-1zHw/E9kAnw4t/AVodwbOyt3399uViG7tEV5d36ffoY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6758,6 +7364,7 @@
       }
     },
     "org/snakeyaml/snakeyaml-engine/3.0.1": {
+      "narHash": "sha256-tVO0+Sw+SDj4a0flX0JEDO0rhzx7fiEUqWi2tWthVys=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6770,6 +7377,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/5": {
+      "narHash": "sha256-5Z/lnIYrD82dPJXIja7vNYyE/q2zlq/hlUa+MGmF8ZE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6780,6 +7388,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/7": {
+      "narHash": "sha256-RjCCOnJGtuxZ8M5BtNSNtCpYYB04xxG5kt2xwcoHxSg=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6790,6 +7399,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/9": {
+      "narHash": "sha256-xfUYO2N60QaaJ49IUjqK5GwD9jNi4+pcF1RH1eO0qUY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6800,6 +7410,7 @@
       }
     },
     "org/springframework/spring-framework-bom/5.3.39": {
+      "narHash": "sha256-R6p3ezBeu31MiTd6CgNe6wSlQt8eScR2fZbbI4IfdUs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6810,6 +7421,7 @@
       }
     },
     "org/testcontainers/testcontainers-bom/1.21.3": {
+      "narHash": "sha256-Hh7H54U3NOp5CAsPI2/SoKhPdj1JyZ/ELGiLRWI+3PE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6820,6 +7432,7 @@
       }
     },
     "org/tukaani/xz/1.10": {
+      "narHash": "sha256-FgMhwpVQZWNySQWh5uKxl0l5ekOSIHsbL1tPVEj7+wo=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6832,6 +7445,7 @@
       }
     },
     "org/typelevel/case-insensitive_3/1.4.0": {
+      "narHash": "sha256-sR2wR0qHreCK8OyGSZi75f6vIirgwRTFYNar+8p18l4=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6844,6 +7458,7 @@
       }
     },
     "org/typelevel/cats-core_3/2.10.0": {
+      "narHash": "sha256-M81Tl8F6X5FzE6NTPFG4lzF+RdRE7SVQIcBJ6wdoRwY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6856,6 +7471,7 @@
       }
     },
     "org/typelevel/cats-effect-kernel_3/3.5.2": {
+      "narHash": "sha256-17BIkxLZOz9o5PyO916uKQZ8wdssZ057Rr28VSdBv5E=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6868,6 +7484,7 @@
       }
     },
     "org/typelevel/cats-effect-std_3/3.5.2": {
+      "narHash": "sha256-ZppCQQSTSci1xIIhX37SniRuOiYxDR7KflRPLS6lIaQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6880,6 +7497,7 @@
       }
     },
     "org/typelevel/cats-effect_3/3.5.2": {
+      "narHash": "sha256-/QuPTZ9je3B/UY95X1RB4WIEg5tYTgjqigz53PpEQrQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6892,6 +7510,7 @@
       }
     },
     "org/typelevel/cats-kernel_3/2.10.0": {
+      "narHash": "sha256-nD7d+KiYB8/Vu+X8p40YWPDVmE1IIxLffHmA58I4eUs=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6904,6 +7523,7 @@
       }
     },
     "org/typelevel/cats-parse_3/1.0.0": {
+      "narHash": "sha256-Oz0nFK+hA2kUVIKGV+OdZz1uD9VHHs/89YqMUFhstuc=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6916,6 +7536,7 @@
       }
     },
     "org/typelevel/jawn-fs2_3/2.4.0": {
+      "narHash": "sha256-lZxmdXU6WDL4x8lTs9A7qJZNxqkpIGlRwpeUfR/TkiE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6928,6 +7549,7 @@
       }
     },
     "org/typelevel/jawn-parser_3/1.5.1": {
+      "narHash": "sha256-d7sHbShY51hEHuahGZ+avFdGSJfITlitjJxR7D0hnMY=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6940,6 +7562,7 @@
       }
     },
     "org/typelevel/literally_3/1.1.0": {
+      "narHash": "sha256-O4UuuI5bBGdnHQFitxOLuDkqssdpZoLbs+L+mrRGGiE=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6952,6 +7575,7 @@
       }
     },
     "org/typelevel/log4cats-core_3/2.6.0": {
+      "narHash": "sha256-rmD7VWe85zmCIk0bbaDK3l2LJPMhooHIX+J3T4pQFfw=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6964,6 +7588,7 @@
       }
     },
     "org/typelevel/log4cats-slf4j_3/2.6.0": {
+      "narHash": "sha256-ItfqAbRqntLu/kA8xXXWJbsh/yzpslrb7DT9z6Ljw5o=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6976,6 +7601,7 @@
       }
     },
     "org/typelevel/paiges-core_2.13/0.4.4": {
+      "narHash": "sha256-lqh++iCpOhAGEVao2rJBwBc8tu/tI3SJHNYBh7S5n4M=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -6987,6 +7613,7 @@
       }
     },
     "org/typelevel/vault_3/3.5.0": {
+      "narHash": "sha256-h9M+jyBGllgPw4OyYG78Tzv+4taVzdkvyAmGvkWKWZQ=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -6999,6 +7626,7 @@
       }
     },
     "org/virtuslab/scala-cli/config_3/1.9.1": {
+      "narHash": "sha256-KeJbln0kmCGtrw1nD+N/56g0BTswntHOLhZ0o9QRSvA=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -7011,6 +7639,7 @@
       }
     },
     "org/virtuslab/scala-cli/specification-level_3/1.9.1": {
+      "narHash": "sha256-Yr2gMfsi7CKUGQQzkY5QHV2V7zMVpZgLzrkb+8oyVoM=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -7023,6 +7652,7 @@
       }
     },
     "org/virtuslab/using_directives/1.1.4": {
+      "narHash": "sha256-jdareuzJsZqjT9xd7fPjlAfp4Mzz4CTceG7cHtJlo9Y=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -7034,6 +7664,7 @@
       }
     },
     "org/wildfly/client/wildfly-client-config/1.0.1.Final": {
+      "narHash": "sha256-mRFb3hKLVUJZhp/PX0E/R0TAlKf4Mt1P58e8gmSpRQU=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -7045,6 +7676,7 @@
       }
     },
     "org/wildfly/common/wildfly-common/1.5.4.Final": {
+      "narHash": "sha256-Ma7isxLJUO+QFI9CusAmLlRB9L5bIm9QGgGAwY7yQPs=",
       "runs": [
         "ee52a000ca94"
       ],
@@ -7056,6 +7688,7 @@
       }
     },
     "software/amazon/awssdk/aws-sdk-java-pom/2.33.4": {
+      "narHash": "sha256-SGeKNpJwovuATeTVpYVf4k5/q4NSGtZUMEmA3RKEA98=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"
@@ -7066,6 +7699,7 @@
       }
     },
     "software/amazon/awssdk/bom/2.33.4": {
+      "narHash": "sha256-vFTUCIYZsEbggVdG2xPKWKTBcaYsnUIFyR4Ua1MT5+I=",
       "runs": [
         "d81ebcaa333f",
         "ee52a000ca94"

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
             };
             mifPackage = pkgs.callPackage ./package.nix { };
             ciTest = pkgs.callPackage ./.github/integration/chisel.nix { mif = mifPackage; };
+            mavenRepository = pkgs.mkMavenRepository {
+              lockFile = ./mif.lock.json;
+            };
+            representativeArtifact = builtins.head (builtins.attrValues mavenRepository.artifacts);
           in
           {
             _module.args.pkgs = pkgs;
@@ -61,13 +65,23 @@
 
             packages.mif = mifPackage;
 
-            packages.mif-maven-repository = pkgs.mkMavenRepository {
-              lockFile = ./mif.lock.json;
-            };
+            packages.mif-maven-repository = mavenRepository;
 
             packages.mif-jar = mifPackage;
 
             packages.ci-test = ciTest;
+
+            checks.maven-fetch-environment =
+              assert pkgs.lib.assertMsg (
+                representativeArtifact.impureEnvVars == pkgs.lib.fetchers.proxyImpureEnvVars
+              ) "Maven artifact fetches must inherit Nix's proxy and custom CA environment";
+              assert pkgs.lib.assertMsg (
+                pkgs.lib.hasInfix "NIX_SSL_CERT_FILE:-" representativeArtifact.buildCommand
+                && pkgs.lib.hasInfix "/etc/ssl/certs/ca-bundle.crt" representativeArtifact.buildCommand
+              ) "Maven artifact fetches must prefer NIX_SSL_CERT_FILE and fall back to cacert";
+              pkgs.runCommand "maven-fetch-environment-check" { } ''
+                touch "$out"
+              '';
 
             devShells.default = pkgs.mkShell {
               nativeBuildInputs = [

--- a/mif.lock.json
+++ b/mif.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "kind": "mif-maven-lock",
   "repositories": {
     "central": "https://repo1.maven.org/maven2"
@@ -24,6 +24,7 @@
   },
   "artifacts": {
     "ch/epfl/scala/bsp4j/2.2.0-M2": {
+      "narHash": "sha256-riEisSGg7NrufcDdX5mPdkqu6pAghdsa1dwd0H3NSBM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -36,6 +37,7 @@
       }
     },
     "ch/qos/logback/logback-classic/1.5.27": {
+      "narHash": "sha256-M8PW+6akfxRAWQd6H1vUKAcYHsR/8gYavZQyTbja8uE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -48,6 +50,7 @@
       }
     },
     "ch/qos/logback/logback-core/1.5.27": {
+      "narHash": "sha256-7tz18bTQnsAzICii3Ug/ZQLXqNgeD9rNiZKIPHXAHD8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -60,6 +63,7 @@
       }
     },
     "ch/qos/logback/logback-parent/1.5.27": {
+      "narHash": "sha256-yk0LJrb/Gi2ipB4eS2nCg8uVmNTxYuvW/Cl96MNF3l8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -70,6 +74,7 @@
       }
     },
     "com/amazonaws/aws-java-sdk-bom/1.12.791": {
+      "narHash": "sha256-g09zmHHl9SL5kPpIedsIFGOH33QUMHOODkLs30m/oFg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -80,6 +85,7 @@
       }
     },
     "com/amazonaws/aws-java-sdk-pom/1.12.791": {
+      "narHash": "sha256-QmLlH3LKGvHOuTr+RJUc750t9DCtdwkhTX9dEdijd0o=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -90,6 +96,7 @@
       }
     },
     "com/eed3si9n/jarjar/jarjar/1.16.0": {
+      "narHash": "sha256-UYc2LQrGLVFqgIBOYhuAtEL3JupwoeADrbNtgIJdMZg=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -101,6 +108,7 @@
       }
     },
     "com/eed3si9n/jarjarabrams/jarjar-abrams-core_3/1.16.0": {
+      "narHash": "sha256-tnNJslu+0f+y//VxAVR5JpF88gAEQJ8UxDfh0GLDgmM=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -112,6 +120,7 @@
       }
     },
     "com/eed3si9n/shaded-jawn-parser_3/1.3.2": {
+      "narHash": "sha256-7XTQAaQSSG7zNXUbyQr2mH2MuCmKz8A8RNcOciaJcuw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -124,6 +133,7 @@
       }
     },
     "com/eed3si9n/shaded-scalajson_3/1.0.0-M4": {
+      "narHash": "sha256-VGRRrmntOUUMYlppcclKOR7VBI6vzmkpMGOgtM/TRRE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -136,6 +146,7 @@
       }
     },
     "com/eed3si9n/sjson-new-core_3/0.10.1": {
+      "narHash": "sha256-bwKrCB7krQM2P9kC9n8OSXfgQ7Bd1aSrrnpKF6E+cmU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -146,6 +157,7 @@
       }
     },
     "com/eed3si9n/sjson-new-core_3/0.14.0-M5": {
+      "narHash": "sha256-RNQNkYbLNuElYtCO+4UcIPI4KtZbQ3oQkGeW4iXwpks=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -158,6 +170,7 @@
       }
     },
     "com/eed3si9n/sjson-new-scalajson_3/0.14.0-M5": {
+      "narHash": "sha256-1XznRkoEKgLYu+nq0QKrTJ+TMDaDxLzat+baykMBA+c=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -170,6 +183,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-bom/2.19.1": {
+      "narHash": "sha256-K7w+ZdUjzt90b4/zi/0f+PN7fVL2s4zk9t7UJObbeSk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -180,6 +194,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-bom/2.20.0": {
+      "narHash": "sha256-s5OPi1CSgEEe3E6jtaoggsQ0gKskxw8a62fyvPUeM4s=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -190,6 +205,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-parent/2.19.2": {
+      "narHash": "sha256-DWUObf2+ywHc4gl9WA7DLWniqFdQrwULas4SD0e1sH0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -200,6 +216,7 @@
       }
     },
     "com/fasterxml/jackson/jackson-parent/2.20": {
+      "narHash": "sha256-uM1b0bq+bdShZkzhfVmGZ2KeZcaDK1ShVLtxnp2rpkc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -210,6 +227,7 @@
       }
     },
     "com/fasterxml/oss-parent/68": {
+      "narHash": "sha256-BEI7RSfOVS6ffxk7QRZqMSnZKviWK6dspqBRPbmS8Zo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -220,6 +238,7 @@
       }
     },
     "com/fasterxml/oss-parent/70": {
+      "narHash": "sha256-yVNj/mEDVBU3v97dp2sW6ZmYlpMaKEOcwzAarhZDbpE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -230,6 +249,7 @@
       }
     },
     "com/github/javaparser/javaparser-core/3.28.0": {
+      "narHash": "sha256-is81Ay9tN8epaOoRaPIk91jaDTwwd4iFjCWseL3FNr0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -242,6 +262,7 @@
       }
     },
     "com/github/javaparser/javaparser-parent/3.28.0": {
+      "narHash": "sha256-2IqHtOi+lDoVV6qhILXIDwFVZL2HY8I23aa2ymBbhh8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -252,6 +273,7 @@
       }
     },
     "com/github/luben/zstd-jni/1.5.7-4": {
+      "narHash": "sha256-/vyiPq5Va33XWn5FKXculjv81pPQoNvwZpLNM071n/I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -264,6 +286,7 @@
       }
     },
     "com/github/plokhotnyuk/jsoniter-scala/jsoniter-scala-core_2.13/2.13.5": {
+      "narHash": "sha256-QGQouGAHh/gjaahhoAHWdAOUyC66tebMFUNWfaHjaqU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -276,6 +299,7 @@
       }
     },
     "com/google/code/findbugs/jsr305/3.0.2": {
+      "narHash": "sha256-g9+oRxLy7d53/y4icvoktpsTAPqpA/7zEkwZ6p/oHcI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -288,6 +312,7 @@
       }
     },
     "com/google/code/gson/gson-parent/2.13.2": {
+      "narHash": "sha256-LYpHnVbp0G/7zw5xI6FnxZxBEgxcM50+vcKbY0jet5w=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -298,6 +323,7 @@
       }
     },
     "com/google/code/gson/gson/2.13.2": {
+      "narHash": "sha256-paQKaa97vKjJyXU/Lovim6+/QBn+DnbMGr3Wu+BtBjw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -310,6 +336,7 @@
       }
     },
     "com/google/errorprone/error_prone_annotations/2.41.0": {
+      "narHash": "sha256-iQpYYJ9xjZP9In6rvrS17PaG0VJ4unwsceE3SapBRdE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -322,6 +349,7 @@
       }
     },
     "com/google/errorprone/error_prone_parent/2.41.0": {
+      "narHash": "sha256-PSMqv0t0yvPqdiyUeQi6Frqlv3KxdWjdbxxKKMh12Nc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -332,6 +360,7 @@
       }
     },
     "com/google/guava/failureaccess/1.0.1": {
+      "narHash": "sha256-teUXLa0DDjjnMaQUqNmTffnXC+YS6W0vl4fGOZrXAMo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -344,6 +373,7 @@
       }
     },
     "com/google/guava/guava-parent/26.0-android": {
+      "narHash": "sha256-cwYFhpuIJco6AaQKQPebYS8x4ZXFS7/cV5EhMmu0CAc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -354,6 +384,7 @@
       }
     },
     "com/google/guava/guava-parent/30.1-jre": {
+      "narHash": "sha256-ub53xD5zNU4yR+VrbMlFIIDaN/kqRwZPbNuBtGSO1Uo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -364,6 +395,7 @@
       }
     },
     "com/google/guava/guava/30.1-jre": {
+      "narHash": "sha256-+s18UtReEs727w+R+0ULlntPvHGCBwHv3rOul/fGHvU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -376,6 +408,7 @@
       }
     },
     "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+      "narHash": "sha256-yiT6ShupcfSld7NPPnR7gwG6FVEQagHUfGd7IfoWJ5E=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -388,6 +421,7 @@
       }
     },
     "com/google/j2objc/j2objc-annotations/1.3": {
+      "narHash": "sha256-//0MyUZxO0O6d3RyHDxYmdNj31XYzsFb2uPoVJo5pH4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -400,6 +434,7 @@
       }
     },
     "com/googlecode/javaewah/JavaEWAH/1.2.3": {
+      "narHash": "sha256-ZRpvRWr9LxxsTrLg07Uu/8II0Kyyp7kdItWKaIgGuHY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -412,6 +447,7 @@
       }
     },
     "com/lihaoyi/cask-util_3/0.11.3": {
+      "narHash": "sha256-OVvKsvQCFET9il7ade/V4sPaaJ6G5FMFPZpqP28R3Js=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -423,6 +459,7 @@
       }
     },
     "com/lihaoyi/cask_3/0.11.3": {
+      "narHash": "sha256-U8hag9SViepXiMGSXHQVESVjU45rv1hUrIW7r0BE0PM=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -434,6 +471,7 @@
       }
     },
     "com/lihaoyi/castor_3/0.3.0": {
+      "narHash": "sha256-vI8QLKUH1i5zsRNodPOUDCVTQYbJ2eJY46tuV3U1/Vc=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -445,6 +483,7 @@
       }
     },
     "com/lihaoyi/fansi_3/0.5.0": {
+      "narHash": "sha256-s3ItneZfIaYSTMajdcRG5dLKf+4Egd3i5a2jEJVMKDk=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -456,6 +495,7 @@
       }
     },
     "com/lihaoyi/fansi_3/0.5.1": {
+      "narHash": "sha256-GikZJI3z3gVCQcKIa2DhyUZ9kKwpRA6C90AJm7zwwKw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -468,6 +508,7 @@
       }
     },
     "com/lihaoyi/fastparse_3/3.1.1": {
+      "narHash": "sha256-+SS+GdCqO3fqpdbYRZTmwmAd3c9n5ZpFKVKGA0AEHI0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -480,6 +521,7 @@
       }
     },
     "com/lihaoyi/geny_3/1.1.1": {
+      "narHash": "sha256-DHU1MhETMcPZjCSL7lYzaxvt1VmF37sPfmXirSg3ACU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -492,6 +534,7 @@
       }
     },
     "com/lihaoyi/mainargs_3/0.5.0": {
+      "narHash": "sha256-ZW4lRCyHw8B6uZT8i8RV4MCVv8UNgKAG7JY31tktzuQ=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -503,6 +546,7 @@
       }
     },
     "com/lihaoyi/mainargs_3/0.7.8": {
+      "narHash": "sha256-ZwqrHP9D8+v70L0sLi/xJZ7rBmxX03uniqN8kZmkx+8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -515,6 +559,7 @@
       }
     },
     "com/lihaoyi/mill-core-api-daemon_3/1.1.2": {
+      "narHash": "sha256-hnjNfAxFPlwWdwUpvlYDkMfQNoBeNK4WMQ9RNl+f5Po=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -527,6 +572,7 @@
       }
     },
     "com/lihaoyi/mill-core-api-java11_3/1.1.2": {
+      "narHash": "sha256-kEXr9imZgyjDOMICGm0zAbtbjP64oi5Dq2BAZ3JmOT8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -539,6 +585,7 @@
       }
     },
     "com/lihaoyi/mill-core-api_3/1.1.2": {
+      "narHash": "sha256-aJ8mMLWfHjoQIjwwJI5r96WmgmsH/TdXb/PGjO9EREA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -551,6 +598,7 @@
       }
     },
     "com/lihaoyi/mill-core-constants/1.1.2": {
+      "narHash": "sha256-90RYZWFbRHADhQN0TzAFg6/Ku1sOMEJO88vtuDejYG4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -563,6 +611,7 @@
       }
     },
     "com/lihaoyi/mill-core-eval_3/1.1.2": {
+      "narHash": "sha256-FVkTp+fqVXk32oeCBZftQ+H1Me5+pEEybtaEDy5J9OM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -575,6 +624,7 @@
       }
     },
     "com/lihaoyi/mill-core-exec_3/1.1.2": {
+      "narHash": "sha256-EwtVyMJn89C8zCPoqTjMIu2ICEsmTk6vhTxkzuab430=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -587,6 +637,7 @@
       }
     },
     "com/lihaoyi/mill-core-internal-cli_3/1.1.2": {
+      "narHash": "sha256-NQOhirxgluRL7zf//5/45ogQf6eiUASqQjq+dems4ro=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -599,6 +650,7 @@
       }
     },
     "com/lihaoyi/mill-core-internal_3/1.1.2": {
+      "narHash": "sha256-8ZMlxcGUDDy4hxx/nnPBbMGFf3A+1K72J5EmrfZQM/o=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -611,6 +663,7 @@
       }
     },
     "com/lihaoyi/mill-core-resolve_3/1.1.2": {
+      "narHash": "sha256-+iwi+BoiMOCg+yXM742HT5c2fC4VCXV4VLft/mX6asg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -623,6 +676,7 @@
       }
     },
     "com/lihaoyi/mill-libs-androidlib-databinding_3/1.1.2": {
+      "narHash": "sha256-zwp6UJH1sJEpU6NoG5KSUyGMv56FYxoAO3ZAaPLeWow=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -635,6 +689,7 @@
       }
     },
     "com/lihaoyi/mill-libs-androidlib_3/1.1.2": {
+      "narHash": "sha256-2L88flQOsQU5HwQ9sO4e7CqdiEF306VL7qHWvLHjke8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -647,6 +702,7 @@
       }
     },
     "com/lihaoyi/mill-libs-daemon-client_3/1.1.2": {
+      "narHash": "sha256-l3uYRF5SYFuqvXyXkTTnBCKLgVeDPH0WayCYxGXyaPU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -659,6 +715,7 @@
       }
     },
     "com/lihaoyi/mill-libs-daemon-server_3/1.1.2": {
+      "narHash": "sha256-vN4H0OGmhUM3xlvGQDCMxm29c2n2Z7e8gQdqAmtDQ9c=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -671,6 +728,7 @@
       }
     },
     "com/lihaoyi/mill-libs-groovylib-api_3/1.1.2": {
+      "narHash": "sha256-OjCzZet3uZTPUfaulbuX47zPkRqxwdwaM0PRryqI9rU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -683,6 +741,7 @@
       }
     },
     "com/lihaoyi/mill-libs-groovylib_3/1.1.2": {
+      "narHash": "sha256-4oZERkViife1WhskTLNWLSXznGT6oTi3Uu94rufeJxw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -695,6 +754,7 @@
       }
     },
     "com/lihaoyi/mill-libs-init_3/1.1.2": {
+      "narHash": "sha256-uY01GfK8qQzq9pLGN3W5fpf4ZkF6CbLDyINO9LwBmcU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -707,6 +767,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-api_3/1.1.2": {
+      "narHash": "sha256-t/WUjUPYuYvdNwBrGaPGE6PJ4PilQa2lgGSqFu2vCDE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -719,6 +780,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-classgraph-worker_3/1.1.2": {
+      "narHash": "sha256-NWAvVw95m7ow5fd/cnjctrzPnfEo33sPmE6zkTqngm4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -730,6 +792,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-jarjarabrams-worker_3/1.1.2": {
+      "narHash": "sha256-qgxMxR1WAt/RlHPgkVsedv59KmZCqFsdQ3HJ6yBgNr0=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -741,6 +804,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-testrunner-entrypoint/1.1.2": {
+      "narHash": "sha256-/Za+OC77NqwXj1DCkHEJqZudN58k4dacem22jzaw69w=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -753,6 +817,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-testrunner_3/1.1.2": {
+      "narHash": "sha256-aei0wemkFI39lG4uwGuiocJvr+b6rvbroz4c0KDbUCg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -765,6 +830,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib-worker_3/1.1.2": {
+      "narHash": "sha256-gmhW171Ql3a/ahMoQ+aPlQn5xSK04M8ukGKaUmizzGA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -777,6 +843,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javalib_3/1.1.2": {
+      "narHash": "sha256-sbGRGNCQNuV0ICZGwX31wGTtwmyLkgUecmHxAAMx43A=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -789,6 +856,7 @@
       }
     },
     "com/lihaoyi/mill-libs-javascriptlib_3/1.1.2": {
+      "narHash": "sha256-IvDhij203Ec3p1OOwwL8pcW0qNlC5N7FTpsQoo5Y0PM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -801,6 +869,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib-api_3/1.1.2": {
+      "narHash": "sha256-k5qMHp8DXZwJjni5WC8V/Rrubvll45C3ZsHqXgsWHQU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -813,6 +882,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib-ksp2-api_3/1.1.2": {
+      "narHash": "sha256-4Qc6Q4mgJP6LgPt0gz5BD5dlS04xy3R8pwe8TzhXKCY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -825,6 +895,7 @@
       }
     },
     "com/lihaoyi/mill-libs-kotlinlib_3/1.1.2": {
+      "narHash": "sha256-FgS75otH56ZwDbVugpjZTYNL0UFpdmDmoKH7BFmQgzA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -837,6 +908,7 @@
       }
     },
     "com/lihaoyi/mill-libs-pythonlib_3/1.1.2": {
+      "narHash": "sha256-mg0s5BgQEmwws7QiAwVFUkyZewCOIT5yzztmwFYFbNg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -849,6 +921,7 @@
       }
     },
     "com/lihaoyi/mill-libs-rpc_3/1.1.2": {
+      "narHash": "sha256-tbfIJz2NqblUqrklY/G6gMeIkctB+RjbOF5KKLOMyzY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -861,6 +934,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalajslib-api_3/1.1.2": {
+      "narHash": "sha256-ijiMX+T/U6VzkANrudCk5bu7Cb0FhvQjndmI57Ux29w=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -873,6 +947,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalajslib_3/1.1.2": {
+      "narHash": "sha256-j4srBpqsA2DgDkdaZX+8nPxeEiS5npuG7IF4xIDJyAQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -885,6 +960,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalalib_3/1.1.2": {
+      "narHash": "sha256-BQ3dxgJy+rEuKuHCIpUEn7yMrE2gM1tCfjANlpqFPs0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -897,6 +973,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalanativelib-api_3/1.1.2": {
+      "narHash": "sha256-WctVwkA0mhzaCRMdtA8iUNhe0QAtPAvYimSOS0BvQ5M=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -909,6 +986,7 @@
       }
     },
     "com/lihaoyi/mill-libs-scalanativelib_3/1.1.2": {
+      "narHash": "sha256-R9IeBpzNJH29cGC6i6OCoijh4emr7WSgU4lWkQBRa8g=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -921,6 +999,7 @@
       }
     },
     "com/lihaoyi/mill-libs-script_3/1.1.2": {
+      "narHash": "sha256-N2d+vHxfjeAnYX1p8CAGKCHDTaRRamdRpMA+vSNzjBc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -933,6 +1012,7 @@
       }
     },
     "com/lihaoyi/mill-libs-tabcomplete_3/1.1.2": {
+      "narHash": "sha256-CLFK8WWs6Kply0A3GRs3FwJLKX+NuFq2ESgUk76+4gY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -945,6 +1025,7 @@
       }
     },
     "com/lihaoyi/mill-libs-util-java11_3/1.1.2": {
+      "narHash": "sha256-WAcJQi9UaitiPcGkM9jqp0RwwxzatzkCg7WBm+ac/bw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -957,6 +1038,7 @@
       }
     },
     "com/lihaoyi/mill-libs-util_3/1.1.2": {
+      "narHash": "sha256-HXau1/dqOJ7neKw5N3QM3ll+/QtFFimXJZzKWI5vwQ0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -969,6 +1051,7 @@
       }
     },
     "com/lihaoyi/mill-libs_3/1.1.2": {
+      "narHash": "sha256-rbA8FWzS6Gl2+eFva5bE8dLYOaaBabVLjowYB7MB8cg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -981,6 +1064,7 @@
       }
     },
     "com/lihaoyi/mill-moduledefs_3/0.13.1": {
+      "narHash": "sha256-wD+xrBo26jkPgWMA5a3oR+DsteeA/hs1vZHniVX7B/8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -993,6 +1077,7 @@
       }
     },
     "com/lihaoyi/mill-runner-autooverride-api_3/1.1.2": {
+      "narHash": "sha256-e/ENKiR+qC/K1zZniDs/Opqd0AC40w8JbNhg/HufX6c=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1005,6 +1090,7 @@
       }
     },
     "com/lihaoyi/mill-runner-autooverride-plugin_3.8.1/1.1.2": {
+      "narHash": "sha256-car+dNZEHMizzUChZOIerBvydqQg4j7XJrTRPvMHlN4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1017,6 +1103,7 @@
       }
     },
     "com/lihaoyi/mill-runner-bsp-worker_3/1.1.2": {
+      "narHash": "sha256-EIyB/F+fi11AleIRZ6Mr++nDWItDKBDRfxDIWr2qI1I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1029,6 +1116,7 @@
       }
     },
     "com/lihaoyi/mill-runner-bsp_3/1.1.2": {
+      "narHash": "sha256-r5pGAfsQ6PpPUfCq/JyS/IslbRRdHcgxo/apiXU0D/s=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1041,6 +1129,7 @@
       }
     },
     "com/lihaoyi/mill-runner-codesig_3/1.1.2": {
+      "narHash": "sha256-fYRL8ATFQEqwnhkw7rMU1Sl4B/KR39v/HyivQDzPmvA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1053,6 +1142,7 @@
       }
     },
     "com/lihaoyi/mill-runner-daemon_3/1.1.2": {
+      "narHash": "sha256-PzX/ZnaCQ/wbirXHc0mqSeL7EAznEoBOwDKtCe+zaf4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1065,6 +1155,7 @@
       }
     },
     "com/lihaoyi/mill-runner-eclipse_3/1.1.2": {
+      "narHash": "sha256-6Tky/jJmGt/wIJpl77IlAiNIUoeuHdhxY10qq8rauRU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1077,6 +1168,7 @@
       }
     },
     "com/lihaoyi/mill-runner-idea_3/1.1.2": {
+      "narHash": "sha256-byBNEzm90cBaC3vPCW0HPgB9xDE1VF/bkBsd1SczIkI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1089,6 +1181,7 @@
       }
     },
     "com/lihaoyi/mill-runner-launcher_3/1.1.2": {
+      "narHash": "sha256-AaQLCIMyhuvGD5x5hk/Qt5HIbJ1THG/ul950SShb7/0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1101,6 +1194,7 @@
       }
     },
     "com/lihaoyi/mill-runner-meta_3/1.1.2": {
+      "narHash": "sha256-p2kWyFCLIZsq/Wiize9v7kqaHxYbK3s/6i4oSu1Su4s=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1113,6 +1207,7 @@
       }
     },
     "com/lihaoyi/mill-runner-server_3/1.1.2": {
+      "narHash": "sha256-i5dHvTAmETSXXo5EwwMFauBhHkAsTS+xFpdShniDkkA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1125,6 +1220,7 @@
       }
     },
     "com/lihaoyi/os-lib-watch_3/0.11.8": {
+      "narHash": "sha256-4q3tDvj2++/krsEgzsMLe53pvP4/UhYxh4mBOwIrpjE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1137,6 +1233,7 @@
       }
     },
     "com/lihaoyi/os-lib_3/0.10.0": {
+      "narHash": "sha256-iBOIuHljzuG/5WmtpxeACNOXjZIpGcoL8W4eWNFx2g4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1148,6 +1245,7 @@
       }
     },
     "com/lihaoyi/os-lib_3/0.11.8": {
+      "narHash": "sha256-/ZppfqwNCF3a0nzhuTRR0mORVMtj7WH87ukL4S7aHxo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1160,6 +1258,7 @@
       }
     },
     "com/lihaoyi/os-zip/0.11.8": {
+      "narHash": "sha256-2anT0NXLtTFR4Jpb4mW1d2GFbFk3P/LymV0eUkP2bOg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1172,6 +1271,7 @@
       }
     },
     "com/lihaoyi/pprint_3/0.9.0": {
+      "narHash": "sha256-MEwNByunQji2bQpCXZPk78xoVIV3iymUxm7AVA5BNfE=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1183,6 +1283,7 @@
       }
     },
     "com/lihaoyi/pprint_3/0.9.3": {
+      "narHash": "sha256-jsJXIlLefnWLfTeipIOmUUsko6HYWI1AENlldH1eV78=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1195,6 +1296,7 @@
       }
     },
     "com/lihaoyi/pprint_3/0.9.6": {
+      "narHash": "sha256-pUfDq1R9VRa1++zDkIGFG5Npw3yDzI+S5GWEYvyTpxw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1207,6 +1309,7 @@
       }
     },
     "com/lihaoyi/requests_3/0.9.2": {
+      "narHash": "sha256-q0byKv+E3dZd2NukxbYC3HOx7dKK0U2kCTDT3Z60u78=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1218,6 +1321,7 @@
       }
     },
     "com/lihaoyi/requests_3/0.9.3": {
+      "narHash": "sha256-BrKBTqRaPcydKo/eVBLP6kxpPyvggxNF8umOP+ufiJw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1230,6 +1334,7 @@
       }
     },
     "com/lihaoyi/scalac-mill-moduledefs-plugin_3.8.1/0.13.1": {
+      "narHash": "sha256-I+fGJE6a+4cmbUaK/jQYeC4r2NHDSxXBYj4vXbLL9Lk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1242,6 +1347,7 @@
       }
     },
     "com/lihaoyi/scalasql-core_3/0.3.1": {
+      "narHash": "sha256-Zg1l+b6WX8fLj3stzE8NPyVNbMyjvBE/ryAug4pHFd4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1253,6 +1359,7 @@
       }
     },
     "com/lihaoyi/scalasql-operations_3/0.3.1": {
+      "narHash": "sha256-8mBkwB7MIpiydz+uYF5QBM8nmEJUX/SDlopklGdry+I=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1264,6 +1371,7 @@
       }
     },
     "com/lihaoyi/scalasql-query_3/0.3.1": {
+      "narHash": "sha256-L/tcGQnJyZy0f75AsqvDosEpj56MWDTvyy+fytyukS4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1275,6 +1383,7 @@
       }
     },
     "com/lihaoyi/scalasql_3/0.3.1": {
+      "narHash": "sha256-rW/6ryjRmoj9xYEPvbutYzUiPZjixELhCjzgaUPHQjA=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1286,6 +1395,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.3.0": {
+      "narHash": "sha256-Efyw/OzGr30q1FKgX8DAFcVEi8SFpO/Zgjbc8+yhjl0=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1295,6 +1405,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.4.0": {
+      "narHash": "sha256-gWe30/RMuWzIqQNKwDim9xlJ/8XzYPJTNtU2TCYiIiA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1305,6 +1416,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.4.2": {
+      "narHash": "sha256-ph5IAqW1Wef7qt0UFnYLwxtK73yUtjtrklwuQyPurHU=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1316,6 +1428,7 @@
       }
     },
     "com/lihaoyi/sourcecode_3/0.4.4": {
+      "narHash": "sha256-qSDMufVcqRC9/P3o+5IHIxBA7WXha5oPC3qcv3iaNO4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1328,6 +1441,7 @@
       }
     },
     "com/lihaoyi/ujson_3/3.3.1": {
+      "narHash": "sha256-JAVk8dzLxusRiNIzorsgHVkSUtfw2siSaZ/T2yXf6wI=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1337,6 +1451,7 @@
       }
     },
     "com/lihaoyi/ujson_3/4.0.2": {
+      "narHash": "sha256-whWA0HFGm7k0PCN9AIrLW+3rsd045W87xp/gta5jts4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1348,6 +1463,7 @@
       }
     },
     "com/lihaoyi/ujson_3/4.4.2": {
+      "narHash": "sha256-JFeL9NYiaYBtfds5qzfpx3TBn3wJPUlomt41zt3apqo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1360,6 +1476,7 @@
       }
     },
     "com/lihaoyi/unroll-annotation_3/0.2.0": {
+      "narHash": "sha256-NF7usbUV/qsS7OdVgkCanOWFyfEtqzmEhrHd6rwUxaY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1372,6 +1489,7 @@
       }
     },
     "com/lihaoyi/upack_3/3.3.1": {
+      "narHash": "sha256-izGyzTG79gd4Zsvl+/zyQ/hrxz65XG3KGc6HSEs/x4M=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1381,6 +1499,7 @@
       }
     },
     "com/lihaoyi/upack_3/4.0.2": {
+      "narHash": "sha256-1H1E0RNNasfJYTlqDHYr3zar6NoADTHiA+zB8QfWMck=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1392,6 +1511,7 @@
       }
     },
     "com/lihaoyi/upack_3/4.4.2": {
+      "narHash": "sha256-+tHdbk5PwFkv3dl9IOreCqs3dke3z4cXTO+5317jMdk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1404,6 +1524,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/3.3.1": {
+      "narHash": "sha256-z49gnkBwtbJ8wfOFIw0Xj4tESUfqoMVEQb/9sCAiNkE=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1413,6 +1534,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/4.0.2": {
+      "narHash": "sha256-AzUWAaCeGbs0i03qSIbaiMMchGvSme8AT8WG9vPNTBk=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1424,6 +1546,7 @@
       }
     },
     "com/lihaoyi/upickle-core_3/4.4.2": {
+      "narHash": "sha256-67bidGkVlwS464667x7g/8GvxhY0Ep8DPmQG42Kncmk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1436,6 +1559,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits-named-tuples_3/4.4.2": {
+      "narHash": "sha256-Xc1I31VnZY8JBcIZnFnfAs+9Wdgmk7F8wh14iVnqpVo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1448,6 +1572,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/3.3.1": {
+      "narHash": "sha256-2K9pCISnwpqzFFirwFuSmCc8kfj3+tyiSXuMjsK5Ydg=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1457,6 +1582,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/4.0.2": {
+      "narHash": "sha256-n1j7lDpBB+UqKI9/+NhiH41dpqDUnYIUf9NmYdVV/x4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1468,6 +1594,7 @@
       }
     },
     "com/lihaoyi/upickle-implicits_3/4.4.2": {
+      "narHash": "sha256-xtyZwWRa+vVY0pAE0ZQxlz9nedhBKjKEZzh0u0sSEfQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1480,6 +1607,7 @@
       }
     },
     "com/lihaoyi/upickle_3/3.3.1": {
+      "narHash": "sha256-AgxpuiGp/i9YQJraMkArzl2cdCWjvgX7nDq8KtlaJIM=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1489,6 +1617,7 @@
       }
     },
     "com/lihaoyi/upickle_3/4.0.2": {
+      "narHash": "sha256-B0JMSGDuPvH3DUWmZUI7Mg9ZITs+S34mshJt8pYYIFs=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1500,6 +1629,7 @@
       }
     },
     "com/lihaoyi/upickle_3/4.4.2": {
+      "narHash": "sha256-kN0eTjeOO9RJDjPEw8Wym/3jxIXg2yLCPMM9SuBR4ZI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1512,6 +1642,7 @@
       }
     },
     "com/lihaoyi/utest_3/0.8.5": {
+      "narHash": "sha256-PCgbJzqoQ5GhwEtOyMbo3I92fDU/luPOGCimiMDNE0M=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1523,6 +1654,7 @@
       }
     },
     "com/lmax/disruptor/3.4.2": {
+      "narHash": "sha256-IYiV/U9IMIGjJym2E6/OPECbcc8wRfsWuc48nmtGIlo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1535,6 +1667,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-core_3/0.6.0": {
+      "narHash": "sha256-cChGHftawGBel5LllRvXnfM2My6pWjLu+tc9YeghzrM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1547,6 +1680,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-requests_3/0.6.0": {
+      "narHash": "sha256-DE2dlLD/r6s48BK5TmRmqO7Ulaznr+CH0O8R9VZ9G9g=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1559,6 +1693,7 @@
       }
     },
     "com/lumidion/sonatype-central-client-upickle_3/0.6.0": {
+      "narHash": "sha256-G2xUXJlCGdZJ0GrKtbG50xvczclb0j0BDO6nNlIYS4M=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1571,6 +1706,7 @@
       }
     },
     "com/swoval/file-tree-views/2.1.12": {
+      "narHash": "sha256-GK1YOwDKlK70lsBnIPT+dIO4g9H7ijFIzjOd1MnmUx8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1583,6 +1719,7 @@
       }
     },
     "commons-codec/commons-codec/1.17.0": {
+      "narHash": "sha256-aygLAcrioQxB06eVYg2aE/cgdfplH5WiCXDsDnD6gxs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1593,6 +1730,7 @@
       }
     },
     "commons-codec/commons-codec/1.19.0": {
+      "narHash": "sha256-eaSx+dzlqEHqMcmG5ofqiDX06VOYUyssQyb7zHsbcuU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1605,6 +1743,7 @@
       }
     },
     "commons-io/commons-io/2.20.0": {
+      "narHash": "sha256-1mUuNel8r+TFK608+Afo4YhRkjahOrXWh2OQ4dMqwpk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1617,6 +1756,7 @@
       }
     },
     "guru/nidi/graphviz-java-min-deps/0.18.1": {
+      "narHash": "sha256-7J2UuyQqrTip5kTUaAuhqviyX0Fbx0QGOq4I3Zdh724=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1629,6 +1769,7 @@
       }
     },
     "guru/nidi/graphviz-java-parent/0.18.1": {
+      "narHash": "sha256-zaiL/dDoGwCrQ4OBaDHsWUu8eEn4i8tUYpVg/h6z99M=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1639,6 +1780,7 @@
       }
     },
     "guru/nidi/graphviz-java/0.18.1": {
+      "narHash": "sha256-ipigGhL00gat4rP54fvYxFy+hqN8CUhiSE7Yfzp5ouo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1651,6 +1793,7 @@
       }
     },
     "guru/nidi/guru-nidi-parent-pom/1.1.36": {
+      "narHash": "sha256-XBnUt+K3yHmqeDC1fDI4BDAUWpAFzMpRGCy8m3NUIPg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1661,6 +1804,7 @@
       }
     },
     "io/airlift/airbase/112": {
+      "narHash": "sha256-KsbskxKQCJsppZ/JKx19dPhPFeaiCDfm1WjvaOQEHAc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1671,6 +1815,7 @@
       }
     },
     "io/airlift/aircompressor/0.27": {
+      "narHash": "sha256-NQgycAg0bRv+23tuyKxzJ8TW7bwIvQzBY8G9quZsFIo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1683,6 +1828,7 @@
       }
     },
     "io/get-coursier/cache-util/2.1.25-M23": {
+      "narHash": "sha256-LYBuAgFV+H+ypaqf5izh7PqZsusxixykQa6y+Rs5Go8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1695,6 +1841,7 @@
       }
     },
     "io/get-coursier/coursier-archive-cache_2.13/2.1.25-M23": {
+      "narHash": "sha256-+kmIGtb2puHrWoqO5M+GDrmgwDOCPcFpeTdR2C1MW34=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1707,6 +1854,7 @@
       }
     },
     "io/get-coursier/coursier-cache_2.13/2.1.25-M23": {
+      "narHash": "sha256-FVAUROZDyP7SQILxop/WkV9M/LcIaniOM30lEKGN6q0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1719,6 +1867,7 @@
       }
     },
     "io/get-coursier/coursier-core_2.13/2.1.25-M23": {
+      "narHash": "sha256-3qn27Z+y9khReExwupwpAQaGGhtm9C1TWoS0Ngp0VLE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1731,6 +1880,7 @@
       }
     },
     "io/get-coursier/coursier-env_2.13/2.1.25-M23": {
+      "narHash": "sha256-e79cU50LPP3vtvKJuNcsuFGVpJRhppepQwI02krO/bE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1743,6 +1893,7 @@
       }
     },
     "io/get-coursier/coursier-exec/2.1.25-M23": {
+      "narHash": "sha256-Sq0PpQU+eSqOVP1oAEbSQ20Ja5GSZPAvLMmVQHzp/iw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1755,6 +1906,7 @@
       }
     },
     "io/get-coursier/coursier-jvm_2.13/2.1.25-M23": {
+      "narHash": "sha256-YaTlbbB8SWwvYnPYfHjOHIH3ABCBQ7TSvyNrCHYMFCY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1767,6 +1919,7 @@
       }
     },
     "io/get-coursier/coursier-paths/2.1.25-M23": {
+      "narHash": "sha256-uTsTgfeaReitRO/ODoL6XFwqFyji4l8gUzZ5lBhPk5g=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1779,6 +1932,7 @@
       }
     },
     "io/get-coursier/coursier-proxy-setup/2.1.25-M23": {
+      "narHash": "sha256-RWazGucAhjDLbYLG+bnWfQz49pyzxYIlQeL2OAjhkXA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1791,6 +1945,7 @@
       }
     },
     "io/get-coursier/coursier-util_2.13/2.1.25-M23": {
+      "narHash": "sha256-fIj2AEuXLHibi4Npv80Yn4D7tTYi8ZWNiJbfjrTHWH0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1803,6 +1958,7 @@
       }
     },
     "io/get-coursier/coursier_2.13/2.1.25-M23": {
+      "narHash": "sha256-h57X+w71j6cCaqh1Kf+B8ay6f2JEkAFY7+zgXwmgbPs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1815,6 +1971,7 @@
       }
     },
     "io/get-coursier/dependency_2.13/0.3.2": {
+      "narHash": "sha256-pDXe2GqxAuavfquVejyGrW9UXUkW0OsnOseF+AvWYLY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1827,6 +1984,7 @@
       }
     },
     "io/get-coursier/jniutils/windows-jni-utils/0.3.3": {
+      "narHash": "sha256-W6m2KKHSnC0dKiAjZH09AbBnafRK4fmYiiaSS0mgu70=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1839,6 +1997,7 @@
       }
     },
     "io/get-coursier/versions_2.13/0.5.1": {
+      "narHash": "sha256-P4KcW9MJGZqmPJwbpy3pN35RCZ1J1fBJNd20iCOEut4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1851,6 +2010,7 @@
       }
     },
     "io/github/alexarchambault/concurrent-reference-hash-map/1.1.0": {
+      "narHash": "sha256-FMro0Pm4zZSvtWh3fWjT7UKnS7z9IeGMr5UEmWKI5cQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1863,6 +2023,7 @@
       }
     },
     "io/github/alexarchambault/is-terminal/0.1.2": {
+      "narHash": "sha256-hELOqV/siozeYUaXGjpSSlotlbPTs1sjeh9J7xj1k2A=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1875,6 +2036,7 @@
       }
     },
     "io/github/alexarchambault/native-terminal/native-terminal-no-ffm/0.0.9.1": {
+      "narHash": "sha256-02A23DeVIAqzQI7bQ06yD1TRSQYrRtMyMKippCRUgtc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1887,6 +2049,7 @@
       }
     },
     "io/github/alexarchambault/windows-ansi/windows-ansi/0.0.6": {
+      "narHash": "sha256-rpWAdC17+1Ivbc2sJ+EyWDVBuLP8FAkSrZtmqVuzH3g=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1899,6 +2062,7 @@
       }
     },
     "io/github/classgraph/classgraph/4.8.184": {
+      "narHash": "sha256-ea9gZwuUSvLWrVx0VsCDo6cyd1v/6VjcQwQ2y1f1/xY=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1910,6 +2074,7 @@
       }
     },
     "io/netty/netty-bom/4.2.6.Final": {
+      "narHash": "sha256-2/3y4l/ZE40K/dt2j4eRhafXleUcvMwfLFwkH2VrADU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1920,6 +2085,7 @@
       }
     },
     "io/undertow/undertow-core/2.3.18.Final": {
+      "narHash": "sha256-U9TbuZ0AeAzKiaKM3tQ77J8/1VSDl4srn4yWkspp9g0=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1931,6 +2097,7 @@
       }
     },
     "io/undertow/undertow-parent/2.3.18.Final": {
+      "narHash": "sha256-k0XDJ1CEryOWVlRRbUJGezfLGBCmzm7CiuURDuWElLs=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -1940,6 +2107,7 @@
       }
     },
     "jakarta/platform/jakarta.jakartaee-bom/9.1.0": {
+      "narHash": "sha256-Ufw06fqw0QapN7/NjF9FcaOqb9ZdrxgL/hpVDy8Y2xo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1950,6 +2118,7 @@
       }
     },
     "jakarta/platform/jakartaee-api-parent/9.1.0": {
+      "narHash": "sha256-O2JIdzO1B5CnlAgJK28nyS5rvxz2J7/Qui030eQRHG0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1960,6 +2129,7 @@
       }
     },
     "javax/inject/javax.inject/1": {
+      "narHash": "sha256-2bbQOHIRQGVzAnSA6xag+OTdI/aAEEOq9MX4/0TWmeI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1972,6 +2142,7 @@
       }
     },
     "net/java/dev/jna/jna/5.15.0": {
+      "narHash": "sha256-bQEciaXP89ySUXKK5rL93w3SKGPDUDmgTf0oPQoOZZE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1982,6 +2153,7 @@
       }
     },
     "net/java/dev/jna/jna/5.17.0": {
+      "narHash": "sha256-mjQmQd6oKeuVa8Gro7ld/e0f3S1wwg8OcKz8CENM9jM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -1994,6 +2166,7 @@
       }
     },
     "net/openhft/java-parent-pom/1.1.28": {
+      "narHash": "sha256-99/N7IIhK3cAz0INSh7RcvjRSWEgi4BJhL/YLixVs2I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2004,6 +2177,7 @@
       }
     },
     "net/openhft/root-parent-pom/1.2.12": {
+      "narHash": "sha256-Q/akDcsWLoq8enyg/GDwvF2jqMZ4ebmPKnJhQ+iRRS4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2014,6 +2188,7 @@
       }
     },
     "net/openhft/zero-allocation-hashing/0.16": {
+      "narHash": "sha256-7GXmHLZ/FiQ5vBFiDqTuY/BVZNLsDXwb6BvD2483Q6g=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2026,6 +2201,7 @@
       }
     },
     "org/apache/apache/19": {
+      "narHash": "sha256-4kQz9l4rn+9Dy03fsV+k/IHgS7PGJms1xxTXdkvuNYE=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2035,6 +2211,7 @@
       }
     },
     "org/apache/apache/31": {
+      "narHash": "sha256-tJrvjxLxaeQG8UosBuyYVcnSAb+ScQJcB6pxpqRCG+M=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2045,6 +2222,7 @@
       }
     },
     "org/apache/apache/35": {
+      "narHash": "sha256-4QhnnM8ALYljd/yh+AimNDmsvAIEjeSI+tqlupIQGUo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2055,6 +2233,7 @@
       }
     },
     "org/apache/apache/6": {
+      "narHash": "sha256-/PSYMaYMcDu+9rWdEURqj+GJ7oQLMnYsZKx3vRM+CY4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2065,6 +2244,7 @@
       }
     },
     "org/apache/commons/commons-compress/1.28.0": {
+      "narHash": "sha256-gYvOqJ66e2Xfks4bAYMxgPMVBBEk4AnF3pKFQPQuHEM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2077,6 +2257,7 @@
       }
     },
     "org/apache/commons/commons-lang3/3.18.0": {
+      "narHash": "sha256-KfjfSNnkKZ42DO9h/SZ8unfxSFs6XlXYU6rivssRdR8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2089,6 +2270,7 @@
       }
     },
     "org/apache/commons/commons-lang3/3.8.1": {
+      "narHash": "sha256-ylmT+fha/D/k0y1eFxlGr411tOArO9VkK57VcxzeYR8=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2098,6 +2280,7 @@
       }
     },
     "org/apache/commons/commons-parent/47": {
+      "narHash": "sha256-CaTDlvj+WoWJ8q/VQb6Suv17M6mpOdJ7X9P/ow4Hywo=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2107,6 +2290,7 @@
       }
     },
     "org/apache/commons/commons-parent/69": {
+      "narHash": "sha256-b7jKbxI66uRcSUZ3IOwprTx52ekURuVeNFfIZpVuABM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2117,6 +2301,7 @@
       }
     },
     "org/apache/commons/commons-parent/85": {
+      "narHash": "sha256-mWbgUoRQncv9E+1b2QlqvKmu/ML2JcDq2AULedPKRzo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2127,6 +2312,7 @@
       }
     },
     "org/apache/cxf/cxf-bom/4.0.9": {
+      "narHash": "sha256-p0AHQPqZM/5XdQMlIv+qHrer4lci5LmPTolsE/vL9lQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2137,6 +2323,7 @@
       }
     },
     "org/apache/cxf/cxf/4.0.9": {
+      "narHash": "sha256-AAYwmPR9TvUyTBkHhKy4jiodUpwjZsxBggjSds6epTE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2147,6 +2334,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis-default-flava/2.0": {
+      "narHash": "sha256-JAaWmoUOrNbjR/7jIo8UoVCjkUqifUiTQMDDzM5Ics0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2157,6 +2345,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis-java5-flava/2.0": {
+      "narHash": "sha256-drzkrQsES8TRE+Xfc1kofOesSrdHz9Z8Pky/vyR+Xtc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2167,6 +2356,7 @@
       }
     },
     "org/apache/geronimo/genesis/genesis/2.0": {
+      "narHash": "sha256-SG5ZxS14XBi7p3aIxnUum5Nwdi3t2VAqxwXr3EayeYc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2177,6 +2367,7 @@
       }
     },
     "org/apache/groovy/groovy-bom/4.0.27": {
+      "narHash": "sha256-YuSYtaaSXZ8wPCSmO0jJXq5hdAYrjlBrTR7DYjvTV8Q=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2187,6 +2378,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-api/2.25.1": {
+      "narHash": "sha256-1Gi+zBgbDW5v1CrR8XxA3xx87Dici4yIgzI6h6Rdr0Y=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2199,6 +2391,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-bom/2.25.1": {
+      "narHash": "sha256-WuhQuFiAtRkxY3zDyJOYVoPVv9Jv3b3T8DhXry5dfto=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2209,6 +2402,7 @@
       }
     },
     "org/apache/logging/log4j/log4j-core/2.25.1": {
+      "narHash": "sha256-k9Wu/MVjGWsqPss2P14M0iewkoojanJhO7bViqgMgF4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2221,6 +2415,7 @@
       }
     },
     "org/apache/logging/log4j/log4j/2.25.1": {
+      "narHash": "sha256-LfDhguyrNoDhsW+d//n1PGrx+3CHdZMv8PxbQOnBiqY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2231,6 +2426,7 @@
       }
     },
     "org/apache/tika/tika-core/3.2.3": {
+      "narHash": "sha256-4m68NftTJlaaX6Cm7KB460AZKBSMzYMi1cOzLW5KtLA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2243,6 +2439,7 @@
       }
     },
     "org/apache/tika/tika-parent/3.2.3": {
+      "narHash": "sha256-4nJXW5RUUEL+ebaLPbbh64o1N1mppZLITlRAyQ2JTGQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2253,6 +2450,7 @@
       }
     },
     "org/apache/xbean/xbean-reflect/3.7": {
+      "narHash": "sha256-KDCfNSN/4lfWIt7lnb/etPu3UbviMK6O5LkuUc1k8dY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2265,6 +2463,7 @@
       }
     },
     "org/apache/xbean/xbean/3.7": {
+      "narHash": "sha256-hQ6BKMV103yvpc04Dqoa6+xu2BKxQcO5UqNKngv3Hnc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2275,6 +2474,7 @@
       }
     },
     "org/checkerframework/checker-qual/3.5.0": {
+      "narHash": "sha256-pmDCPARSYcGncoFv8dMJYHJSUQo6xqHusvTuSyX+aWk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2287,6 +2487,7 @@
       }
     },
     "org/codehaus/plexus/plexus-archiver/4.10.1": {
+      "narHash": "sha256-V78TEbISDyOT2q3cGzklO0CZIbRlR56IonMmP4ZSXRs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2299,6 +2500,7 @@
       }
     },
     "org/codehaus/plexus/plexus-classworlds/2.6.0": {
+      "narHash": "sha256-XASW2MjUrG0xb6LQUAxW+wrAlfdLmfd6uWOfIX9lG7Y=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2311,6 +2513,7 @@
       }
     },
     "org/codehaus/plexus/plexus-container-default/2.1.1": {
+      "narHash": "sha256-DK+ZrlOIQSrf9ag7xK5V8hsl1tdPKrZRXx37hBks4VY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2323,6 +2526,7 @@
       }
     },
     "org/codehaus/plexus/plexus-containers/2.1.1": {
+      "narHash": "sha256-afcnIR7Mw3Sm+5OePirFq6ZGzRbiDdBCJ8rZfljph4s=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2333,6 +2537,7 @@
       }
     },
     "org/codehaus/plexus/plexus-io/3.5.1": {
+      "narHash": "sha256-vkD6MyZJVBgzCsuc5XuFGy+8EH5dMMmj78c1P5vKE+I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2345,6 +2550,7 @@
       }
     },
     "org/codehaus/plexus/plexus-utils/4.0.2": {
+      "narHash": "sha256-hclcJrJ5oXBltuxyHskIjmRV8Mz9Pxp8TplXxgB4m/4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2357,6 +2563,7 @@
       }
     },
     "org/codehaus/plexus/plexus/18": {
+      "narHash": "sha256-f2hAcXSAUEhPF81cdgaj0xRsbDleUMWv+c3l9TvjSP8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2367,6 +2574,7 @@
       }
     },
     "org/codehaus/plexus/plexus/23": {
+      "narHash": "sha256-akFxmP1IXKzrjuU/JOW+kWgOuLwvqhN5CB82rJwLdJg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2377,6 +2585,7 @@
       }
     },
     "org/codehaus/plexus/plexus/5.1": {
+      "narHash": "sha256-nRLuEdJgPVbznR6pacHpqqHEFFw8+soqa7Q902ozoz4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2387,6 +2596,7 @@
       }
     },
     "org/codehaus/plexus/plexus/6.5": {
+      "narHash": "sha256-RfB5TMTwKFoq0uOnpU+Xs+fOLIDEddabf7WV9y0spz8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2397,6 +2607,7 @@
       }
     },
     "org/eclipse/ee4j/project/1.0.7": {
+      "narHash": "sha256-DsMqamX0Nws0CZH0/Lt9ia44XK1cYMozf/dr5RLegZM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2407,6 +2618,7 @@
       }
     },
     "org/eclipse/jetty/jetty-bom/11.0.26": {
+      "narHash": "sha256-bdmdM0NKG3YQO9jFlK9+75zfmgDqFxB9YzxqFt3LC5U=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2417,6 +2629,7 @@
       }
     },
     "org/eclipse/jgit/org.eclipse.jgit-parent/6.10.1.202505221210-r": {
+      "narHash": "sha256-9B0sZIdbB0WCn+o9I4pCrTTGrmn+jrUmJxbaRNdftQk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2427,6 +2640,7 @@
       }
     },
     "org/eclipse/jgit/org.eclipse.jgit/6.10.1.202505221210-r": {
+      "narHash": "sha256-qqHffUYtpWRZATJHDvtQ6wQD00wxyOT5eY0mj38Tu3o=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2439,6 +2653,7 @@
       }
     },
     "org/eclipse/lsp4j/org.eclipse.lsp4j.generator/0.20.1": {
+      "narHash": "sha256-crpw5WA/1fe14d2Oer86Y8uDLQ8NDP3K+53OIr1Sj64=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2451,6 +2666,7 @@
       }
     },
     "org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.20.1": {
+      "narHash": "sha256-0yaQeS10hpPTLf5EcUAF+cC+szxJkZ9jIbnOMGdO0WY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2463,6 +2679,7 @@
       }
     },
     "org/eclipse/xtend/org.eclipse.xtend.lib.macro/2.28.0": {
+      "narHash": "sha256-ahRfcQy3OaedJwTNQNW7HRzrGdTOo3cwPJafeahB4bg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2475,6 +2692,7 @@
       }
     },
     "org/eclipse/xtend/org.eclipse.xtend.lib/2.28.0": {
+      "narHash": "sha256-xghLEmi2uOqBdYSqULKxmy6/PVFRpDnHzf5koGauWBE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2487,6 +2705,7 @@
       }
     },
     "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.28.0": {
+      "narHash": "sha256-f3ofynWSpJn7zfGhosED8cjuv/0Edg3got26l0ZpRGg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2499,6 +2718,7 @@
       }
     },
     "org/eclipse/xtext/xtext-dev-bom/2.28.0": {
+      "narHash": "sha256-mRoiSdQRKZienVjYnlLCxvaNAL0/LhkpL+CYoREFwbA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2509,6 +2729,7 @@
       }
     },
     "org/fusesource/fusesource-pom/1.12": {
+      "narHash": "sha256-bP6V8bPeozOobgbUzIgMC90iL28usSlmI9X36UTHZws=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2519,6 +2740,7 @@
       }
     },
     "org/fusesource/jansi/jansi/2.4.1": {
+      "narHash": "sha256-ctFo1PFnISeFNxWzWp1DRwuw2/u0gVUEudpRboPzJaY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2531,6 +2753,7 @@
       }
     },
     "org/java-websocket/Java-WebSocket/1.5.3": {
+      "narHash": "sha256-dE+6z1xkJZgUvXbtmdBUV3AVaCfHf71mD9A4BF9/mCM=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2542,6 +2765,7 @@
       }
     },
     "org/jboss/jboss-parent/23": {
+      "narHash": "sha256-oDmvCEToXeEUzAR2QgufBrMXIi1yiPqayHxnPj5i834=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2551,6 +2775,7 @@
       }
     },
     "org/jboss/jboss-parent/35": {
+      "narHash": "sha256-R9v4UgZ4MzAkJp5S4yKvjoP5n8kXXZFMnUOcAsqhv4Y=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2560,6 +2785,7 @@
       }
     },
     "org/jboss/jboss-parent/36": {
+      "narHash": "sha256-melNYwNbfffRzYPRJwYbBjBE9l6S3Fr/di06PhsiG8k=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2569,6 +2795,7 @@
       }
     },
     "org/jboss/jboss-parent/39": {
+      "narHash": "sha256-BK47fRx/cXMU3zii7ZvvkZL+aKFSIpRTCla63OmioIU=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2578,6 +2805,7 @@
       }
     },
     "org/jboss/jboss-parent/43": {
+      "narHash": "sha256-bmO7r/tUNR6DQG7/59/ZGsmuPkZR5TU38VypX37roc0=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2587,6 +2815,7 @@
       }
     },
     "org/jboss/logging/jboss-logging/3.4.3.Final": {
+      "narHash": "sha256-f9JrZTFWYRtxm1hpJCY2F5juipD/LL6jUu+Iqzs8FwY=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2598,6 +2827,7 @@
       }
     },
     "org/jboss/threads/jboss-threads/3.5.0.Final": {
+      "narHash": "sha256-LTAMI+WAyUGUQVVc0IjZzB21xMXrLqKh9UbTthOxcrM=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2609,6 +2839,7 @@
       }
     },
     "org/jboss/xnio/xnio-all/3.8.16.Final": {
+      "narHash": "sha256-sLpBlUi3fT1G3Ty4HbtJiV08lD7hMdx0rLYV4AvyGw8=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2618,6 +2849,7 @@
       }
     },
     "org/jboss/xnio/xnio-api/3.8.16.Final": {
+      "narHash": "sha256-estdK34Za9OSj9xBv2RaExNvKNOC8PK037aykoraURE=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2629,6 +2861,7 @@
       }
     },
     "org/jboss/xnio/xnio-nio/3.8.16.Final": {
+      "narHash": "sha256-I1NCeEi5Dyhk6gqL+Ap18hELP5fWiai//kf1icMy1ns=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2640,6 +2873,7 @@
       }
     },
     "org/jgrapht/jgrapht-core/1.4.0": {
+      "narHash": "sha256-krB+8bXnW0in6tNW3XQ4At1tqltpQA31C8vwAD5sUzQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2652,6 +2886,7 @@
       }
     },
     "org/jgrapht/jgrapht/1.4.0": {
+      "narHash": "sha256-znqGWOYTYvodYhftTSIpbZnRmocuF2yUpR6/8zqeioI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2662,6 +2897,7 @@
       }
     },
     "org/jheaps/jheaps/0.11": {
+      "narHash": "sha256-8WxKa+gzaA/WcQ7E3l1rr52Svi4KtOrCK5enMial86E=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2674,6 +2910,7 @@
       }
     },
     "org/jline/jline-native/3.27.1": {
+      "narHash": "sha256-L+v7a1SjHf+ZqYMLCk6Eoc51UbOOwBpnEZs8IbFj/f8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2686,6 +2923,7 @@
       }
     },
     "org/jline/jline-native/3.29.0": {
+      "narHash": "sha256-KgKU0EJ5eY6uiDbaDMm2EbP0oAtrvinmkWlxuqw/3WQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2698,6 +2936,7 @@
       }
     },
     "org/jline/jline-parent/3.27.1": {
+      "narHash": "sha256-UoyWFOH/VlcCzHSmAfKpGKDK8T3QotEFMj7TDnAFKnI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2708,6 +2947,7 @@
       }
     },
     "org/jline/jline-parent/3.29.0": {
+      "narHash": "sha256-AXy28dmu0l2MfcCNNxJIXZ+fJgXsrqsNWtGjmUlPUYw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2718,6 +2958,7 @@
       }
     },
     "org/jline/jline-reader/3.27.1": {
+      "narHash": "sha256-7CKYMWiBTm/NrhRmJaC5LODOqz8fffLGB9jm+ghzxVw=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -2729,6 +2970,7 @@
       }
     },
     "org/jline/jline-reader/3.29.0": {
+      "narHash": "sha256-m3TQyVpghuJTaHIKSbS0V8ZJAL1QVV0uJHf4p8586uM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2741,6 +2983,7 @@
       }
     },
     "org/jline/jline-terminal-jni/3.27.1": {
+      "narHash": "sha256-QoyZpKyEmPqaez2iv/KJ68Bl/fZlKXF4cMrjvCaWTLU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2753,6 +2996,7 @@
       }
     },
     "org/jline/jline-terminal-jni/3.29.0": {
+      "narHash": "sha256-UZEi5HYNwGSdUpWTZWo+4JXVXkkRvnfMdoR6L1Dr9/8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2765,6 +3009,7 @@
       }
     },
     "org/jline/jline-terminal/3.27.1": {
+      "narHash": "sha256-tv4BBKyLUHj/04srhmn+FC4QtEWwkoQHKL93i5fwj8w=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2777,6 +3022,7 @@
       }
     },
     "org/jline/jline-terminal/3.29.0": {
+      "narHash": "sha256-YBoMP+awP9aQQIaM3RDVRG0iCU65DvIOYw2UsmMVQhg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2789,6 +3035,7 @@
       }
     },
     "org/jline/jline/3.30.6": {
+      "narHash": "sha256-QP+ke0mCN+/m4/64Q8Q4yY7hIIgoqWemuDOvOSVENLE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2801,6 +3048,7 @@
       }
     },
     "org/junit/junit-bom/5.10.2": {
+      "narHash": "sha256-B+PJk8v+wHuhDStnRc4EJjhmXjHoEBVPe+XFRBcBnFs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2811,6 +3059,7 @@
       }
     },
     "org/junit/junit-bom/5.13.1": {
+      "narHash": "sha256-FB7QZInKyvY3albCyuunUc64zWhvL3OP0MhZed6QQPU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2821,6 +3070,7 @@
       }
     },
     "org/junit/junit-bom/5.13.2": {
+      "narHash": "sha256-4G97sHarSS/uF9F0zqcHTMFcToEpIM967acAb6YgC+Q=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2831,6 +3081,7 @@
       }
     },
     "org/junit/junit-bom/5.13.4": {
+      "narHash": "sha256-fLwHSpSF6swDb2zrYGgeJrTHUrVgJhPJxBPqUCsLcoE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2841,6 +3092,7 @@
       }
     },
     "org/junit/junit-bom/5.14.2": {
+      "narHash": "sha256-CsHLiGsnCgXiYfjNsh/ySzLHegzdFqXuIbbQ7GwDTaQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2851,6 +3103,7 @@
       }
     },
     "org/junit/junit-bom/5.8.0-M1": {
+      "narHash": "sha256-eldjBYUR0v52PvwjLQ4YzcWmRR6s5WCWjWnxa5jnvqc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2861,6 +3114,7 @@
       }
     },
     "org/junit/junit-bom/5.8.2": {
+      "narHash": "sha256-QBoV+BDyC5t08U/M8iEfG1stzCT23fYh61FLYVfBvu0=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2870,6 +3124,7 @@
       }
     },
     "org/mockito/mockito-bom/4.11.0": {
+      "narHash": "sha256-T6mltJmfhoi0tQnauEwjxgKg9MKi/UweZ5MnJtKptxI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2880,6 +3135,7 @@
       }
     },
     "org/ow2/asm/asm-commons/9.8": {
+      "narHash": "sha256-xEVsG5Tfm7PfUQ1AiQX+hflk9hKa9hS1b+pYwTz+St8=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2891,6 +3147,7 @@
       }
     },
     "org/ow2/asm/asm-tree/9.8": {
+      "narHash": "sha256-RAXYjGc3bzDHffxblvqo4MpHcvn6qzUxALMgsypL1oc=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2902,6 +3159,7 @@
       }
     },
     "org/ow2/asm/asm-tree/9.9.1": {
+      "narHash": "sha256-bpW7/rDmlBZ/HJ6hJslK1mRoNJHWIHxyzqRDg757mVc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2914,6 +3172,7 @@
       }
     },
     "org/ow2/asm/asm/9.8": {
+      "narHash": "sha256-jJ4HtBQQAkpJ8ohTzn3vveUR20k/wWKL6gXZ4buWelI=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -2925,6 +3184,7 @@
       }
     },
     "org/ow2/asm/asm/9.9.1": {
+      "narHash": "sha256-QwoFUayo0lC3kYVhNmoD40G99yuB1dyLadsXf3FJxsQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2937,6 +3197,7 @@
       }
     },
     "org/ow2/ow2/1.5.1": {
+      "narHash": "sha256-/r2DFKgqLJGqIN9ygOdD/rjXRC5mrSI3ObkkPmY99uw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2947,6 +3208,7 @@
       }
     },
     "org/scala-lang/modules/scala-asm/9.7.1-scala-1": {
+      "narHash": "sha256-4UN5odlO7pjWNN7zD5R4/Lm8AD7vXhUqajS/nQr22Zg=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -2958,6 +3220,7 @@
       }
     },
     "org/scala-lang/modules/scala-asm/9.9.0-scala-1": {
+      "narHash": "sha256-eQrBrknk3x8fv5bsuYTFlAYDdYDF/O73s4YF+EgK/vs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2970,6 +3233,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_2.13/2.13.0": {
+      "narHash": "sha256-8MJilZ4MSyAIPTV4NXY8MqoXKcAQacdCElbDKgHNp6E=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2982,6 +3246,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_3/2.12.0": {
+      "narHash": "sha256-7Au54pBxOqfKN0FC7rReGntTXjSItkHo6lXkvMfri6A=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -2994,6 +3259,7 @@
       }
     },
     "org/scala-lang/modules/scala-collection-compat_3/2.8.1": {
+      "narHash": "sha256-m2xg1l2fUAiSQvdIlEO0q6K+haD2ecd2LZBdx/wz6Ow=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3005,6 +3271,7 @@
       }
     },
     "org/scala-lang/modules/scala-parallel-collections_3/1.2.0": {
+      "narHash": "sha256-b3c+8vBjvNQ2PetaZ1DL7Mi7b1tLVVcJGH8Ufok9ZLQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3017,6 +3284,7 @@
       }
     },
     "org/scala-lang/modules/scala-parser-combinators_3/2.1.0": {
+      "narHash": "sha256-ZRku7/GCUu8Mi3M1HfyBfj/3cfr4h5yuxEUP0dAm24s=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3029,6 +3297,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_2.13/2.4.0": {
+      "narHash": "sha256-BLvjUdvcFtQGxpKdg7D+TOa06Chipiqk9kOc8bt+Se4=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3041,6 +3310,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_3/2.0.1": {
+      "narHash": "sha256-Jeyeq0WavLCUszVtSved7egkBjoFibOjps/aMVz0SGU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3053,6 +3323,7 @@
       }
     },
     "org/scala-lang/modules/scala-xml_3/2.4.0": {
+      "narHash": "sha256-MRFpTbQduSCHCUFrc/K8I/HnZJyyoXmpER+FbjEY+lQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3065,6 +3336,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.15": {
+      "narHash": "sha256-usVVeWfMUINWSWlTxoOI6cvgfK7yGTLCClQdAC/ggrM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3077,6 +3349,7 @@
       }
     },
     "org/scala-lang/scala-library/2.13.16": {
+      "narHash": "sha256-5RdV0lVjCsQh6hQ2+jwjTLB3/2b/euPVAfIzIIqIFaA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3089,6 +3362,7 @@
       }
     },
     "org/scala-lang/scala-library/3.8.1": {
+      "narHash": "sha256-WHIVyIRmRBhxZaYKODHQ6THv2zAMksL/Xjjb7YrYwOk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3101,6 +3375,7 @@
       }
     },
     "org/scala-lang/scala-reflect/2.13.18": {
+      "narHash": "sha256-WmVnyDrFEPK/RuKG4Gd45CwC8ASQhONB0rR/YlaL8Pw=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3113,6 +3388,7 @@
       }
     },
     "org/scala-lang/scala3-compiler_3/3.6.4": {
+      "narHash": "sha256-+VQ9PZ/WNb6iZqhuyJP9cicCQ5kW1CDbRfmZKfNIcQc=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -3124,6 +3400,7 @@
       }
     },
     "org/scala-lang/scala3-compiler_3/3.8.1": {
+      "narHash": "sha256-Ytl7sA2ijKrfbSJ6LCOJv2ha1c2UX8p/Y6lUIf/A1Kk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3136,6 +3413,7 @@
       }
     },
     "org/scala-lang/scala3-interfaces/3.6.4": {
+      "narHash": "sha256-eoanVPrQc6KgK7g1tFdtrXp29FYhpShm6/dkYeYGIYQ=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -3147,6 +3425,7 @@
       }
     },
     "org/scala-lang/scala3-interfaces/3.8.1": {
+      "narHash": "sha256-Tf9B0E3dZj9XXLALSQYd9WaIiEj1vA7V97ZOzaE9T0c=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3159,6 +3438,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.3.3": {
+      "narHash": "sha256-+xuWViiZfGaq42zE9smS7hR3kclne+jawbieim67lEc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3169,6 +3449,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.6.4": {
+      "narHash": "sha256-tZgdBj3yWVR6K5gdc1vK/PYvPNTRnbQOxgDm8M8a2Lg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3181,6 +3462,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.7.4": {
+      "narHash": "sha256-Z88HdEBC/j+9VgMWXZnd4PxA7s8MSHbdZ20e1X/sVJU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3193,6 +3475,7 @@
       }
     },
     "org/scala-lang/scala3-library_3/3.8.1": {
+      "narHash": "sha256-eJ/OvrECwmgQ4IdHjs9SWiGQDSvwz9O8KaJtJvUC6Do=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3205,6 +3488,7 @@
       }
     },
     "org/scala-lang/scala3-repl_3/3.8.1": {
+      "narHash": "sha256-WI6Iatal2/VHaaiaLJ6KJyyNsM3c9JYR14sjPBR6NhU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3217,6 +3501,7 @@
       }
     },
     "org/scala-lang/scala3-sbt-bridge/3.6.4": {
+      "narHash": "sha256-VtLnG3kguAQtzgznX+QTCBzfHjrl+6s4of1M0coKvtw=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3228,6 +3513,7 @@
       }
     },
     "org/scala-lang/scala3-sbt-bridge/3.8.1": {
+      "narHash": "sha256-uvOgmvpF4DPK+ii6GjbqX8+bZHgIexYzjWZFIREUrU0=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3240,6 +3526,7 @@
       }
     },
     "org/scala-lang/tasty-core_3/3.6.4": {
+      "narHash": "sha256-a7zEardUzMxt5yGwigaEKXU5+jna9uj7WofUgXDL0bA=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -3251,6 +3538,7 @@
       }
     },
     "org/scala-lang/tasty-core_3/3.8.1": {
+      "narHash": "sha256-DwkLZkHfZasJpt2f3ngUWP6aES9x+RAHbVe+W588PfI=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3263,6 +3551,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.4": {
+      "narHash": "sha256-Crk4NQFWxUnO435kCvjLZaRiTA6p1qpT8EEt+aJGOh4=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -3274,6 +3563,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/1.10.7": {
+      "narHash": "sha256-UkzhJOBwgDdz//SJKjICT94MaV+V1J8esBtWb3ySepM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3286,6 +3576,7 @@
       }
     },
     "org/scala-sbt/compiler-interface/2.0.0-M13": {
+      "narHash": "sha256-m19BFAZR3bfoEc4ZcN/z6zPDRpIpWw3cNhCbu1sbbMQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3298,6 +3589,7 @@
       }
     },
     "org/scala-sbt/io_3/1.10.5": {
+      "narHash": "sha256-vggMUrcbxuksvoxFO+PyiVWfy7TK3gaANeLy7S4NxMc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3310,6 +3602,7 @@
       }
     },
     "org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18": {
+      "narHash": "sha256-6TDTztSMioLAVO1G6oweJwI1q4Uoc3WF5iiBSd+74No=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3322,6 +3615,7 @@
       }
     },
     "org/scala-sbt/launcher-interface/1.5.2": {
+      "narHash": "sha256-TuMJJCOCXNJhp8+zseST5FbRPs8mXZSvK49DzyLA2io=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3334,6 +3628,7 @@
       }
     },
     "org/scala-sbt/sbinary_3/0.5.1": {
+      "narHash": "sha256-ZuK0klxDWGRMWduT0Hfa4Un6dZbLhMQ0bJ2cnqsVTQE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3346,6 +3641,7 @@
       }
     },
     "org/scala-sbt/test-interface/1.0": {
+      "narHash": "sha256-JfoybnLVYiewk1eDDLTgKkba155f2tqDeNHglFlzjyc=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3358,6 +3654,7 @@
       }
     },
     "org/scala-sbt/util-control_3/2.0.0-RC8": {
+      "narHash": "sha256-cdJTXsKoFjCv1n9rsQqI1B4yAx1tsq2ejJdEzNOh1sE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3370,6 +3667,7 @@
       }
     },
     "org/scala-sbt/util-core_3/2.0.0-RC8": {
+      "narHash": "sha256-KSsBtrDp3CKtL72vueuvLIOJ25ZTM3s+6anWqKO/A9c=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3382,6 +3680,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.4": {
+      "narHash": "sha256-edYMvD1EiuSgjImEmTXW04XvsNi4pEntKFtyTDaIgWQ=",
       "runs": [
         "d81ebcaa333f"
       ],
@@ -3393,6 +3692,7 @@
       }
     },
     "org/scala-sbt/util-interface/1.10.7": {
+      "narHash": "sha256-YRTgPzQUROVG0SpFyxjRxC8cQMKtLVi42pGgnzRJH94=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3405,6 +3705,7 @@
       }
     },
     "org/scala-sbt/util-interface/2.0.0-RC8": {
+      "narHash": "sha256-Tocl1rj+SSd5UMzQCzfPBIS1NpSMTnvZvgF+u1HbL40=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3417,6 +3718,7 @@
       }
     },
     "org/scala-sbt/util-logging_3/2.0.0-RC8": {
+      "narHash": "sha256-MLXlFcG5zWxhL9gd3wjgTsACKet3eYefgLE1Sgj5bjg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3429,6 +3731,7 @@
       }
     },
     "org/scala-sbt/util-relation_3/2.0.0-RC8": {
+      "narHash": "sha256-3se9PDEGfne6k35yliXuvqUBLdJYiYv/+i7JrDr/N6k=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3441,6 +3744,7 @@
       }
     },
     "org/scala-sbt/zinc-apiinfo_3/2.0.0-M13": {
+      "narHash": "sha256-F9Kx5W+PhSeGOVm6Y4EV0g3rFOBc8y4q0e1ykxl88eU=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3453,6 +3757,7 @@
       }
     },
     "org/scala-sbt/zinc-classfile_3/2.0.0-M13": {
+      "narHash": "sha256-Vy8f/Ch2qUl4xGj07uJAhT5LNovJTwwW7Ewc1GBaUZs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3465,6 +3770,7 @@
       }
     },
     "org/scala-sbt/zinc-classpath_3/2.0.0-M13": {
+      "narHash": "sha256-IQp10GDTnl/xtGGJdOBsxh6I57HUCSjeDLwfzDqHYTQ=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3477,6 +3783,7 @@
       }
     },
     "org/scala-sbt/zinc-compile-core_3/2.0.0-M13": {
+      "narHash": "sha256-XdBGPKHbZ3bBIUkXEh3Hq3zKFb7hfGwFaj6Ecw7ds7o=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3489,6 +3796,7 @@
       }
     },
     "org/scala-sbt/zinc-core_3/2.0.0-M13": {
+      "narHash": "sha256-FKa12RrLCosOpxN18rRcxyduParY6eTSDJAqtzwBz0I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3501,6 +3809,7 @@
       }
     },
     "org/scala-sbt/zinc-persist_3/2.0.0-M13": {
+      "narHash": "sha256-uJPt9e7966ntAm0VVFIF9AXidk/C3Uvzr3Ap4dbQJ64=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3513,6 +3822,7 @@
       }
     },
     "org/scala-sbt/zinc_3/2.0.0-M13": {
+      "narHash": "sha256-U+7EWaJtjh6mAm+wpqUiOJnYM5jfrLmg4bU9vOIPo0w=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3525,6 +3835,7 @@
       }
     },
     "org/slf4j/jcl-over-slf4j/1.7.30": {
+      "narHash": "sha256-pgUH+SySv5n8WpPCn+fegWnYPT0oayL/d97V7kngf+8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3537,6 +3848,7 @@
       }
     },
     "org/slf4j/jul-to-slf4j/1.7.30": {
+      "narHash": "sha256-iDTgHtSLZ0V5faJlfeVUX6dskfsPk8MnC2HFVGOjSm8=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3549,6 +3861,7 @@
       }
     },
     "org/slf4j/slf4j-api/2.0.13": {
+      "narHash": "sha256-zJvg4rbP8OWxjS6zuD04mdNxBI8Rl9c2HhRqQu1DcJU=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3560,6 +3873,7 @@
       }
     },
     "org/slf4j/slf4j-api/2.0.17": {
+      "narHash": "sha256-nAfMqycj+sgYHBLR6kQq2HRZQ9hs9keK7oIa1IVslls=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3572,6 +3886,7 @@
       }
     },
     "org/slf4j/slf4j-bom/2.0.13": {
+      "narHash": "sha256-SeSZxd+8FyohZ6kbqo0gapEeruKNnYpZtpxLhwxeVOE=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3581,6 +3896,7 @@
       }
     },
     "org/slf4j/slf4j-bom/2.0.17": {
+      "narHash": "sha256-bz/LEZ+MqjeCAHkg7DS29TiziWydHoFlrtU5wBRk1Xk=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3591,6 +3907,7 @@
       }
     },
     "org/slf4j/slf4j-nop/2.0.13": {
+      "narHash": "sha256-bvQTs7FFxPRw03/m+55DUerZ52WxYd2xvhp9M9awToI=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3602,6 +3919,7 @@
       }
     },
     "org/slf4j/slf4j-parent/1.7.30": {
+      "narHash": "sha256-nmncTonxk94tmAg8ULUcFpcaVyW6MR3TFwCbl/tdSsM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3612,6 +3930,7 @@
       }
     },
     "org/slf4j/slf4j-parent/2.0.13": {
+      "narHash": "sha256-XDNFhK4q7q43o1QGo2vUiiiqzlJS599mhN99dg0jkg4=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3621,6 +3940,7 @@
       }
     },
     "org/slf4j/slf4j-parent/2.0.17": {
+      "narHash": "sha256-1zHw/E9kAnw4t/AVodwbOyt3399uViG7tEV5d36ffoY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3631,6 +3951,7 @@
       }
     },
     "org/snakeyaml/snakeyaml-engine/3.0.1": {
+      "narHash": "sha256-tVO0+Sw+SDj4a0flX0JEDO0rhzx7fiEUqWi2tWthVys=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3643,6 +3964,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/5": {
+      "narHash": "sha256-5Z/lnIYrD82dPJXIja7vNYyE/q2zlq/hlUa+MGmF8ZE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3653,6 +3975,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/7": {
+      "narHash": "sha256-RjCCOnJGtuxZ8M5BtNSNtCpYYB04xxG5kt2xwcoHxSg=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3663,6 +3986,7 @@
       }
     },
     "org/sonatype/oss/oss-parent/9": {
+      "narHash": "sha256-xfUYO2N60QaaJ49IUjqK5GwD9jNi4+pcF1RH1eO0qUY=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3673,6 +3997,7 @@
       }
     },
     "org/springframework/spring-framework-bom/5.3.39": {
+      "narHash": "sha256-R6p3ezBeu31MiTd6CgNe6wSlQt8eScR2fZbbI4IfdUs=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3683,6 +4008,7 @@
       }
     },
     "org/testcontainers/testcontainers-bom/1.21.3": {
+      "narHash": "sha256-Hh7H54U3NOp5CAsPI2/SoKhPdj1JyZ/ELGiLRWI+3PE=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3693,6 +4019,7 @@
       }
     },
     "org/tukaani/xz/1.10": {
+      "narHash": "sha256-FgMhwpVQZWNySQWh5uKxl0l5ekOSIHsbL1tPVEj7+wo=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3705,6 +4032,7 @@
       }
     },
     "org/virtuslab/scala-cli/config_3/1.9.1": {
+      "narHash": "sha256-KeJbln0kmCGtrw1nD+N/56g0BTswntHOLhZ0o9QRSvA=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3717,6 +4045,7 @@
       }
     },
     "org/virtuslab/scala-cli/specification-level_3/1.9.1": {
+      "narHash": "sha256-Yr2gMfsi7CKUGQQzkY5QHV2V7zMVpZgLzrkb+8oyVoM=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3729,6 +4058,7 @@
       }
     },
     "org/wildfly/client/wildfly-client-config/1.0.1.Final": {
+      "narHash": "sha256-mRFb3hKLVUJZhp/PX0E/R0TAlKf4Mt1P58e8gmSpRQU=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3740,6 +4070,7 @@
       }
     },
     "org/wildfly/common/wildfly-common/1.6.0.Final": {
+      "narHash": "sha256-xLZZiZTPuKSB5ci+7oG1X9cEaR+x2JYzlDPyij/+yVA=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3751,6 +4082,7 @@
       }
     },
     "org/xerial/sqlite-jdbc/3.46.1.0": {
+      "narHash": "sha256-b7a22IabPx5LlnEPdE56Zhhcl7rcSjhhkGG68IBAn/Q=",
       "runs": [
         "419d5ecb25d4"
       ],
@@ -3762,6 +4094,7 @@
       }
     },
     "software/amazon/awssdk/aws-sdk-java-pom/2.33.4": {
+      "narHash": "sha256-SGeKNpJwovuATeTVpYVf4k5/q4NSGtZUMEmA3RKEA98=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"
@@ -3772,6 +4105,7 @@
       }
     },
     "software/amazon/awssdk/bom/2.33.4": {
+      "narHash": "sha256-vFTUCIYZsEbggVdG2xPKWKTBcaYsnUIFyR4Ua1MT5+I=",
       "runs": [
         "419d5ecb25d4",
         "d81ebcaa333f"

--- a/mif/src/Archive.scala
+++ b/mif/src/Archive.scala
@@ -33,6 +33,7 @@ object ArchiveRunner:
 
   def run(params: ArchiveParams): Either[String, LockUpdateSummary] =
     for
+      _ <- validateExistingLock(params.lockPath, params.fresh)
       tool <- BuildTools.detect(params.command)
       _ = tool
         .preflightWarnings(params.projectDir, params.command)
@@ -54,6 +55,16 @@ object ArchiveRunner:
         fresh = params.fresh
       )
     yield summary
+
+  /** Rejects an unreadable or obsolete lock before starting the potentially
+    * expensive sandboxed build. A fresh run deliberately replaces that lock.
+    */
+  private[mif] def validateExistingLock(
+      lockPath: os.Path,
+      fresh: Boolean
+  ): Either[String, Unit] =
+    if fresh then Right(())
+    else Lock.read(lockPath).map(_ => ())
 
   private def runBuildThroughRelay(
       params: ArchiveParams,

--- a/mif/src/Archive.scala
+++ b/mif/src/Archive.scala
@@ -47,6 +47,7 @@ object ArchiveRunner:
           )
       summary <- updateLock(
         lockPath = params.lockPath,
+        repoDir = params.repoDir,
         runFiles = accessed,
         upstream = params.upstream,
         command = params.command,
@@ -225,16 +226,21 @@ object ArchiveRunner:
       runFiles: Seq[MavenRepositoryFile],
       upstream: String,
       command: Seq[String],
-      fresh: Boolean
+      fresh: Boolean,
+      repoDir: os.Path,
+      hashArtifacts: (os.Path, MifLock) => Either[String, Map[String, String]] =
+        ArtifactNarHash.hashMissing
   ): Either[String, LockUpdateSummary] =
     for
       repository <- Lock.repositoryFor(upstream)
       existing <- if fresh then Right(None) else Lock.read(lockPath)
       base = existing.getOrElse(Lock.empty)
       merged <- Lock.merge(base, repository, runFiles, command)
-      _ <- Lock.write(lockPath, merged)
+      narHashes <- hashArtifacts(repoDir, merged)
+      finalized <- Lock.withArtifactNarHashes(merged, narHashes)
+      _ <- Lock.write(lockPath, finalized)
     yield LockUpdateSummary(
-      totalFiles = merged.files.size,
-      newFiles = merged.files.size - base.files.size,
-      runs = merged.runs.size
+      totalFiles = finalized.files.size,
+      newFiles = finalized.files.size - base.files.size,
+      runs = finalized.runs.size
     )

--- a/mif/src/ArtifactNarHash.scala
+++ b/mif/src/ArtifactNarHash.scala
@@ -1,7 +1,5 @@
 package in.avimit.dev.mif
 
-import java.nio.file.Files
-
 import scala.util.control.NonFatal
 
 /** Computes the recursive NAR hashes used by artifact-level fixed-output
@@ -95,8 +93,19 @@ object ArtifactNarHash:
     else {
       try {
         os.makeDir.all(destination / os.up)
-        linkOrCopy(source, destination)
-        Right(())
+        os.copy(source, destination)
+        Sha256
+          .sriFile(destination)
+          .left
+          .map(reason =>
+            s"failed to hash staged file ${file.mavenPath}: ${reason}"
+          )
+          .flatMap: actual =>
+            if actual == file.sha256 then Right(())
+            else
+              Left(
+                s"cannot compute artifact narHash: cached file ${file.mavenPath} has sha256 ${actual}, but the lock expects ${file.sha256}"
+              )
       } catch {
         case NonFatal(e) =>
           Left(
@@ -104,10 +113,6 @@ object ArtifactNarHash:
           )
       }
     }
-
-  private def linkOrCopy(source: os.Path, destination: os.Path): Unit =
-    try Files.createLink(destination.toNIO, source.toNIO)
-    catch case NonFatal(_) => os.copy(source, destination)
 
   private def nixHashPaths(
       paths: Vector[os.Path]

--- a/mif/src/ArtifactNarHash.scala
+++ b/mif/src/ArtifactNarHash.scala
@@ -1,0 +1,158 @@
+package in.avimit.dev.mif
+
+import java.nio.file.Files
+
+import scala.util.control.NonFatal
+
+/** Computes the recursive NAR hashes used by artifact-level fixed-output
+  * derivations. Each staging root has exactly the Maven subtree that the Nix
+  * builder will produce, so `nix hash path` remains the source of truth for NAR
+  * serialization.
+  */
+object ArtifactNarHash:
+  def hashMissing(
+      repoDir: os.Path,
+      lock: MifLock
+  ): Either[String, Map[String, String]] =
+    val artifactDirs = Lock.missingArtifactNarHashes(lock)
+    if artifactDirs.isEmpty then Right(Map.empty)
+    else stageAndHash(repoDir, lock.files, artifactDirs)
+
+  private def stageAndHash(
+      repoDir: os.Path,
+      files: Vector[LockedFile],
+      artifactDirs: Vector[String]
+  ): Either[String, Map[String, String]] =
+    createStagingDirectory(repoDir).flatMap: stagingDir =>
+      try
+        for
+          roots <- stageArtifacts(repoDir, stagingDir, files, artifactDirs)
+          hashes <- nixHashPaths(roots)
+        yield artifactDirs.zip(hashes).toMap
+      finally bestEffortDelete(stagingDir)
+
+  private def createStagingDirectory(
+      repoDir: os.Path
+  ): Either[String, os.Path] =
+    try
+      val metadataDir = repoDir / MavenRepositoryStore.MetadataDirectoryName
+      os.makeDir.all(metadataDir)
+      Right(
+        os.temp.dir(
+          dir = metadataDir,
+          prefix = ".nar-hash-",
+          deleteOnExit = false
+        )
+      )
+    catch
+      case NonFatal(e) =>
+        Left(s"failed to create NAR hash staging directory: ${message(e)}")
+
+  private def stageArtifacts(
+      repoDir: os.Path,
+      stagingDir: os.Path,
+      files: Vector[LockedFile],
+      artifactDirs: Vector[String]
+  ): Either[String, Vector[os.Path]] =
+    val filesByArtifact =
+      files.groupBy(file => Lock.splitMavenPath(file.mavenPath)._1)
+    artifactDirs.zipWithIndex.foldLeft[Either[String, Vector[os.Path]]](
+      Right(Vector.empty)
+    ): (acc, entry) =>
+      val (artifactDir, index) = entry
+      for
+        roots <- acc
+        root = stagingDir / f"artifact-${index}%06d"
+        _ <- stageArtifact(
+          repoDir,
+          root,
+          filesByArtifact.getOrElse(artifactDir, Vector.empty)
+        )
+      yield roots :+ root
+
+  private def stageArtifact(
+      repoDir: os.Path,
+      root: os.Path,
+      files: Seq[LockedFile]
+  ): Either[String, Unit] =
+    files.foldLeft[Either[String, Unit]](Right(())) { (acc, file) =>
+      acc.flatMap(_ => stageFile(repoDir, root, file))
+    }
+
+  private def stageFile(
+      repoDir: os.Path,
+      root: os.Path,
+      file: LockedFile
+  ): Either[String, Unit] =
+    val relative = os.RelPath(file.mavenPath)
+    val source = repoDir / relative
+    val destination = root / relative
+    if !os.isFile(source) then
+      Left(
+        s"cannot compute artifact narHash: locked file ${file.mavenPath} is missing from ${repoDir}"
+      )
+    else {
+      try {
+        os.makeDir.all(destination / os.up)
+        linkOrCopy(source, destination)
+        Right(())
+      } catch {
+        case NonFatal(e) =>
+          Left(
+            s"failed to stage ${file.mavenPath} for NAR hashing: ${message(e)}"
+          )
+      }
+    }
+
+  private def linkOrCopy(source: os.Path, destination: os.Path): Unit =
+    try Files.createLink(destination.toNIO, source.toNIO)
+    catch case NonFatal(_) => os.copy(source, destination)
+
+  private def nixHashPaths(
+      paths: Vector[os.Path]
+  ): Either[String, Vector[String]] =
+    val command =
+      Seq(
+        "nix",
+        "hash",
+        "path",
+        "--mode",
+        "nar",
+        "--algo",
+        "sha256",
+        "--format",
+        "sri"
+      ) ++ paths.map(_.toString)
+
+    try
+      val result = os
+        .proc(command)
+        .call(
+          cwd = os.pwd,
+          stdout = os.Pipe,
+          stderr = os.Pipe,
+          check = false
+        )
+      if result.exitCode != 0 then
+        val reason = result.err.trim()
+        Left(
+          if reason.nonEmpty then s"nix hash path failed: ${reason}"
+          else s"nix hash path failed with exit code ${result.exitCode}"
+        )
+      else
+        val hashes = result.out.trim().linesIterator.filter(_.nonEmpty).toVector
+        if hashes.size != paths.size then
+          Left(
+            s"nix hash path returned ${hashes.size} hashes for ${paths.size} artifact paths"
+          )
+        else Right(hashes)
+    catch
+      case NonFatal(e) =>
+        Left(s"failed to run nix hash path: ${message(e)}")
+
+  private def bestEffortDelete(path: os.Path): Unit =
+    try if os.exists(path) then os.remove.all(path)
+    catch case NonFatal(_) => ()
+
+  private def message(e: Throwable): String =
+    Option(e.getMessage).getOrElse(e.getClass.getSimpleName)

--- a/mif/src/ArtifactNarHash.scala
+++ b/mif/src/ArtifactNarHash.scala
@@ -7,7 +7,8 @@ import scala.util.control.NonFatal
 /** Computes the recursive NAR hashes used by artifact-level fixed-output
   * derivations. Each staging root has exactly the Maven subtree that the Nix
   * builder will produce, so `nix hash path` remains the source of truth for NAR
-  * serialization.
+  * serialization. This runs after the build and relay have stopped: until then,
+  * another file for the same Maven coordinate may still be requested.
   */
 object ArtifactNarHash:
   def hashMissing(

--- a/mif/src/Lock.scala
+++ b/mif/src/Lock.scala
@@ -54,11 +54,12 @@ case class MifLock(
     kind: String,
     repositories: Vector[LockRepository],
     runs: Vector[LockRun],
-    files: Vector[LockedFile]
+    files: Vector[LockedFile],
+    artifactNarHashes: Map[String, String] = Map.empty
 )
 
 object Lock:
-  val Version = 2
+  val Version = 3
   val Kind = "mif-maven-lock"
   val DefaultFileName = "mif.lock.json"
 
@@ -79,6 +80,7 @@ object Lock:
   ) derives ReadWriter
 
   private case class LockJsonArtifact(
+      narHash: String,
       runs: Vector[String],
       files: Map[String, String]
   ) derives ReadWriter
@@ -89,7 +91,8 @@ object Lock:
       kind = Kind,
       repositories = Vector.empty,
       runs = Vector.empty,
-      files = Vector.empty
+      files = Vector.empty,
+      artifactNarHashes = Map.empty
     )
 
   private def errorMessage(e: Throwable): String =
@@ -147,7 +150,10 @@ object Lock:
             runs = artifact.runs
           )
         }
-      }
+      },
+      artifactNarHashes = document.artifacts.view
+        .mapValues(_.narHash)
+        .toMap
     )
 
   private def repositoryForRuns(
@@ -165,6 +171,7 @@ object Lock:
       _ <- validateRepositories(lock.repositories)
       _ <- validateRuns(lock.runs)
       _ <- validateFiles(lock)
+      _ <- validateArtifactNarHashes(lock)
     yield lock
 
   private def validateHeader(lock: MifLock): Either[String, Unit] =
@@ -240,6 +247,24 @@ object Lock:
       case Some(path) => Left(s"duplicate lock entry for maven path '${path}'")
       case None       => invalid.orElse(invalidRunRepository).toLeft(())
 
+  private def validateArtifactNarHashes(lock: MifLock): Either[String, Unit] =
+    val expected = artifactDirectories(lock.files).toSet
+    val actual = lock.artifactNarHashes.keySet
+    val missing = (expected -- actual).toVector.sorted
+    val unexpected = (actual -- expected).toVector.sorted
+    val invalid = lock.artifactNarHashes.toVector.sortBy(_._1).collectFirst {
+      case (dir, hash) if sriPattern.findFirstIn(hash).isEmpty =>
+        s"artifact ${dir} has invalid narHash '${hash}'; expected SRI sha256-<base64>"
+    }
+
+    if missing.nonEmpty then
+      Left(s"artifacts missing narHash: ${missing.mkString(", ")}")
+    else if unexpected.nonEmpty then
+      Left(
+        s"narHash entries reference unknown artifacts: ${unexpected.mkString(", ")}"
+      )
+    else invalid.toLeft(())
+
   /** Deterministic form: entry order never depends on sqlite collation or
     * insertion order, so appends produce minimal diffs.
     */
@@ -249,7 +274,9 @@ object Lock:
       runs = lock.runs.sortBy(_.command.mkString("\n")),
       files = lock.files
         .map(file => file.copy(runs = file.runs.distinct.sorted))
-        .sortBy(_.mavenPath)
+        .sortBy(_.mavenPath),
+      artifactNarHashes =
+        VectorMap.from(lock.artifactNarHashes.toVector.sortBy(_._1))
     )
 
   def render(lock: MifLock): String =
@@ -274,16 +301,17 @@ object Lock:
             )
           )
       ),
-      artifacts = artifacts(lock.files)
+      artifacts = artifacts(lock.files, lock.artifactNarHashes)
     )
 
-  private def splitMavenPath(path: String): (String, String) =
+  private[mif] def splitMavenPath(path: String): (String, String) =
     val index = path.lastIndexOf('/')
     if index < 0 then ("", path)
     else (path.take(index), path.drop(index + 1))
 
   private def artifacts(
-      files: Vector[LockedFile]
+      files: Vector[LockedFile],
+      artifactNarHashes: Map[String, String]
   ): Map[String, LockJsonArtifact] =
     VectorMap.from(
       files
@@ -301,9 +329,40 @@ object Lock:
                 name -> file.sha256
               }
           )
-          dir -> LockJsonArtifact(runs = artifactRuns, files = entries)
+          val narHash = artifactNarHashes.getOrElse(
+            dir,
+            throw new IllegalArgumentException(
+              s"artifact ${dir} is missing its narHash"
+            )
+          )
+          dir -> LockJsonArtifact(
+            narHash = narHash,
+            runs = artifactRuns,
+            files = entries
+          )
         }
     )
+
+  private[mif] def artifactDirectories(
+      files: Seq[LockedFile]
+  ): Vector[String] =
+    files.iterator
+      .map(file => splitMavenPath(file.mavenPath)._1)
+      .toVector
+      .distinct
+      .sorted
+
+  private[mif] def missingArtifactNarHashes(lock: MifLock): Vector[String] =
+    artifactDirectories(lock.files).filterNot(lock.artifactNarHashes.contains)
+
+  private[mif] def withArtifactNarHashes(
+      lock: MifLock,
+      hashes: Map[String, String]
+  ): Either[String, MifLock] =
+    val updated = canonicalize(
+      lock.copy(artifactNarHashes = lock.artifactNarHashes ++ hashes)
+    )
+    validateArtifactNarHashes(updated).map(_ => updated)
 
   private def runsForArtifact(files: Vector[LockedFile]): Vector[String] =
     files.flatMap(_.runs).distinct.sorted
@@ -323,11 +382,12 @@ object Lock:
         .map(reason => s"${file}: ${reason}")
 
   def write(file: os.Path, lock: MifLock): Either[String, Unit] =
-    val rendered = render(lock)
-    createTempFile(file).flatMap { tmp =>
-      try writeAndMove(tmp, file, rendered)
-      finally bestEffortDelete(tmp)
-    }
+    validate(lock).flatMap: validated =>
+      val rendered = render(validated)
+      createTempFile(file).flatMap { tmp =>
+        try writeAndMove(tmp, file, rendered)
+        finally bestEffortDelete(tmp)
+      }
 
   private def createTempFile(file: os.Path): Either[String, os.Path] =
     try
@@ -410,6 +470,14 @@ object Lock:
         if existing.runs.exists(_.id == run.id) then existing.runs
         else existing.runs :+ run
 
+      val mergedFileVector = mergedFiles.values.toVector
+      val previousContents = artifactContents(existing.files)
+      val mergedContents = artifactContents(mergedFileVector)
+      val reusableNarHashes = existing.artifactNarHashes.filter {
+        case (dir, _) =>
+          previousContents.get(dir) == mergedContents.get(dir)
+      }
+
       Right(
         canonicalize(
           MifLock(
@@ -417,10 +485,25 @@ object Lock:
             kind = Kind,
             repositories = repositories,
             runs = runs,
-            files = mergedFiles.values.toVector
+            files = mergedFileVector,
+            artifactNarHashes = reusableNarHashes
           )
         )
       )
+
+  private def artifactContents(
+      files: Vector[LockedFile]
+  ): Map[String, Map[String, String]] =
+    files
+      .groupBy(file => splitMavenPath(file.mavenPath)._1)
+      .view
+      .mapValues: dirFiles =>
+        dirFiles
+          .map: file =>
+            val (_, name) = splitMavenPath(file.mavenPath)
+            name -> file.sha256
+          .toMap
+      .toMap
 
   private def assignRepository(
       existing: Vector[LockRepository],

--- a/mif/src/Lock.scala
+++ b/mif/src/Lock.scala
@@ -49,6 +49,13 @@ case class LockedFile(
     runs: Vector[String]
 )
 
+/** The relay observes independent Maven file requests, so the in-memory lock
+  * remains file-oriented during capture. Only after the build command finishes
+  * can archive treat the requested files under one Maven coordinate directory
+  * as a complete artifact output. `artifactNarHashes` is the resulting
+  * coordinate-directory-to-NAR-hash index; keeping it separate avoids repeating
+  * the same hash on every `LockedFile`.
+  */
 case class MifLock(
     version: Int,
     kind: String,

--- a/mif/src/Lock.scala
+++ b/mif/src/Lock.scala
@@ -81,6 +81,8 @@ object Lock:
       artifacts: Map[String, LockJsonArtifact]
   ) derives ReadWriter
 
+  private case class LockJsonVersion(version: Int) derives ReadWriter
+
   private case class LockJsonRun(
       repository: String,
       command: Vector[String]
@@ -131,7 +133,16 @@ object Lock:
     if slug.isEmpty then "repository" else slug
 
   def parse(text: String): Either[String, MifLock] =
-    decode(text).flatMap(validate)
+    for
+      version <- decodeVersion(text)
+      _ <- validateVersion(version)
+      lock <- decode(text)
+      validated <- validate(lock)
+    yield validated
+
+  private def decodeVersion(text: String): Either[String, Int] =
+    try Right(upickle.default.read[LockJsonVersion](text).version)
+    catch case NonFatal(e) => Left(s"invalid lock JSON: ${errorMessage(e)}")
 
   private def decode(text: String): Either[String, MifLock] =
     try Right(fromJson(upickle.default.read[LockJson](text)))
@@ -182,12 +193,20 @@ object Lock:
     yield lock
 
   private def validateHeader(lock: MifLock): Either[String, Unit] =
-    if lock.version != Version then
+    validateVersion(lock.version).flatMap: _ =>
+      if lock.kind != Kind then
+        Left(s"unsupported lock kind '${lock.kind}'; expected '${Kind}'")
+      else Right(())
+
+  private def validateVersion(version: Int): Either[String, Unit] =
+    if version < Version then
       Left(
-        s"unsupported lock version ${lock.version}; this mif understands version ${Version}, upgrade mif or regenerate the lock"
+        s"unsupported lock version ${version}; this mif understands version ${Version}. Regenerate the lock by rerunning the complete archive command sequence, using --fresh on the first command only"
       )
-    else if lock.kind != Kind then
-      Left(s"unsupported lock kind '${lock.kind}'; expected '${Kind}'")
+    else if version > Version then
+      Left(
+        s"unsupported lock version ${version}; this mif understands version ${Version}, upgrade mif to read this lock"
+      )
     else Right(())
 
   private def validateRepositories(

--- a/mif/test/src/ArchiveTests.scala
+++ b/mif/test/src/ArchiveTests.scala
@@ -25,6 +25,36 @@ object ArchiveTests extends TestSuite:
       case Right(value) => value
       case Left(reason) => throw new java.lang.AssertionError(reason)
 
+  private def hashArtifacts(
+      repoDir: os.Path,
+      lock: MifLock
+  ): Either[String, Map[String, String]] =
+    val _ = repoDir
+    Right(
+      Lock
+        .missingArtifactNarHashes(lock)
+        .map: dir =>
+          dir -> Sha256.sri(dir.getBytes("UTF-8"))
+        .toMap
+    )
+
+  private def updateLock(
+      lockPath: os.Path,
+      runFiles: Seq[MavenRepositoryFile],
+      upstream: String,
+      command: Seq[String],
+      fresh: Boolean
+  ): Either[String, LockUpdateSummary] =
+    ArchiveRunner.updateLock(
+      lockPath = lockPath,
+      runFiles = runFiles,
+      upstream = upstream,
+      command = command,
+      fresh = fresh,
+      repoDir = lockPath / os.up / "repository",
+      hashArtifacts = hashArtifacts
+    )
+
   val tests = Tests {
     test("updateLock creates a lock from one run") {
       val tempDir = os.temp.dir(prefix = "mif-archive-test_")
@@ -35,7 +65,7 @@ object ArchiveTests extends TestSuite:
       )
 
       val summary = unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath = lockPath,
           runFiles = files,
           upstream = upstream,
@@ -57,7 +87,7 @@ object ArchiveTests extends TestSuite:
       val shared = repoFile("com/example/shared/1.0.0/shared-1.0.0.jar")
 
       val first = unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"), shared),
           upstream,
@@ -68,7 +98,7 @@ object ArchiveTests extends TestSuite:
       assert(first == LockUpdateSummary(2, 2, 1))
 
       val second = unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom"), shared),
           upstream,
@@ -92,7 +122,7 @@ object ArchiveTests extends TestSuite:
       val files = Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"))
 
       unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           files,
           upstream,
@@ -101,7 +131,7 @@ object ArchiveTests extends TestSuite:
         )
       )
       val summary = unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           files,
           upstream,
@@ -128,7 +158,7 @@ object ArchiveTests extends TestSuite:
       val file = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
 
       unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           Seq(file),
           upstream,
@@ -139,7 +169,7 @@ object ArchiveTests extends TestSuite:
       val before = os.read(lockPath)
 
       val mutated = file.copy(sha256 = Sha256.sri("other".getBytes("UTF-8")))
-      val result = ArchiveRunner.updateLock(
+      val result = updateLock(
         lockPath,
         Seq(mutated),
         upstream,
@@ -155,7 +185,7 @@ object ArchiveTests extends TestSuite:
       val lockPath = tempDir / "mif.lock.json"
 
       unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
           upstream,
@@ -164,7 +194,7 @@ object ArchiveTests extends TestSuite:
         )
       )
       val summary = unwrap(
-        ArchiveRunner.updateLock(
+        updateLock(
           lockPath,
           Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom")),
           upstream,

--- a/mif/test/src/ArchiveTests.scala
+++ b/mif/test/src/ArchiveTests.scala
@@ -211,6 +211,28 @@ object ArchiveTests extends TestSuite:
       assert(lock.runs == Vector(assemblyRun))
     }
 
+    test("archive rejects an old lock before building unless fresh") {
+      val tempDir = os.temp.dir(prefix = "mif-archive-test_")
+      val lockPath = tempDir / "mif.lock.json"
+      os.write(
+        lockPath,
+        """{
+          |  "version": 2,
+          |  "kind": "mif-maven-lock",
+          |  "repositories": {},
+          |  "runs": {},
+          |  "artifacts": {}
+          |}
+          |""".stripMargin
+      )
+
+      val rejected = ArchiveRunner.validateExistingLock(lockPath, fresh = false)
+      assert(rejected.left.exists(_.contains("unsupported lock version 2")))
+      assert(
+        ArchiveRunner.validateExistingLock(lockPath, fresh = true) == Right(())
+      )
+    }
+
     test("lookupFiles resolves accessed paths through the repository store") {
       val tempDir = os.temp.dir(prefix = "mif-archive-test_")
       val repoDir = tempDir / "repository"

--- a/mif/test/src/ArtifactNarHashTests.scala
+++ b/mif/test/src/ArtifactNarHashTests.scala
@@ -8,11 +8,11 @@ object ArtifactNarHashTests extends TestSuite:
     "central"
   )
 
-  private def lockedFile(path: String): LockedFile =
+  private def lockedFile(path: String, content: String): LockedFile =
     LockedFile(
       repository = "central",
       mavenPath = path,
-      sha256 = Sha256.sri(path.getBytes("UTF-8")),
+      sha256 = Sha256.sri(content.getBytes("UTF-8")),
       runs = Vector(run.id)
     )
 
@@ -77,9 +77,9 @@ object ArtifactNarHashTests extends TestSuite:
           repoDir,
           lock(
             Vector(
-              lockedFile(jarPath),
-              lockedFile(pomPath),
-              lockedFile(otherPath)
+              lockedFile(jarPath, "jar"),
+              lockedFile(pomPath, "pom"),
+              lockedFile(otherPath, "other")
             )
           )
         )
@@ -103,7 +103,7 @@ object ArtifactNarHashTests extends TestSuite:
       val tempDir = os.temp.dir(prefix = "mif-nar-hash-test_")
       val repoDir = tempDir / "repository"
       val path = "com/example/a/1.0.0/a-1.0.0.pom"
-      val pending = lock(Vector(lockedFile(path)))
+      val pending = lock(Vector(lockedFile(path, "pom")))
       val finalized = unwrap(
         Lock.withArtifactNarHashes(
           pending,
@@ -123,9 +123,24 @@ object ArtifactNarHashTests extends TestSuite:
 
       val result = ArtifactNarHash.hashMissing(
         repoDir,
-        lock(Vector(lockedFile(path)))
+        lock(Vector(lockedFile(path, "missing")))
       )
       assert(result.left.exists(_.contains(path)))
       assert(result.left.exists(_.contains("missing")))
+    }
+
+    test("hashMissing rejects cache content that differs from the lock") {
+      val tempDir = os.temp.dir(prefix = "mif-nar-hash-test_")
+      val repoDir = tempDir / "repository"
+      val path = "com/example/a/1.0.0/a-1.0.0.pom"
+      writeRepositoryFile(repoDir, path, "mutated")
+
+      val result = ArtifactNarHash.hashMissing(
+        repoDir,
+        lock(Vector(lockedFile(path, "expected")))
+      )
+
+      assert(result.left.exists(_.contains(path)))
+      assert(result.left.exists(_.contains("lock expects")))
     }
   }

--- a/mif/test/src/ArtifactNarHashTests.scala
+++ b/mif/test/src/ArtifactNarHashTests.scala
@@ -1,0 +1,131 @@
+package in.avimit.dev.mif
+
+import utest._
+
+object ArtifactNarHashTests extends TestSuite:
+  private val run = LockRun.fromCommand(
+    Seq("mill", "--no-daemon", "__.prepareOffline"),
+    "central"
+  )
+
+  private def lockedFile(path: String): LockedFile =
+    LockedFile(
+      repository = "central",
+      mavenPath = path,
+      sha256 = Sha256.sri(path.getBytes("UTF-8")),
+      runs = Vector(run.id)
+    )
+
+  private def lock(files: Vector[LockedFile]): MifLock =
+    MifLock(
+      version = Lock.Version,
+      kind = Lock.Kind,
+      repositories = Vector(
+        LockRepository(
+          "central",
+          "maven",
+          MavenRelayServer.DefaultUpstream
+        )
+      ),
+      runs = Vector(run),
+      files = files
+    )
+
+  private def unwrap[T](result: Either[String, T]): T =
+    result match
+      case Right(value) => value
+      case Left(reason) => throw new java.lang.AssertionError(reason)
+
+  private def writeRepositoryFile(
+      repoDir: os.Path,
+      path: String,
+      content: String
+  ): Unit =
+    val destination = repoDir / os.RelPath(path)
+    os.makeDir.all(destination / os.up)
+    os.write(destination, content)
+
+  private def nixHash(path: os.Path): String =
+    os.proc(
+      "nix",
+      "hash",
+      "path",
+      "--mode",
+      "nar",
+      "--algo",
+      "sha256",
+      "--format",
+      "sri",
+      path
+    ).call()
+      .out
+      .trim()
+
+  val tests = Tests {
+    test("hashMissing produces the NAR of each exact Maven subtree") {
+      val tempDir = os.temp.dir(prefix = "mif-nar-hash-test_")
+      val repoDir = tempDir / "repository"
+      val jarPath = "com/example/a/1.0.0/a-1.0.0.jar"
+      val pomPath = "com/example/a/1.0.0/a-1.0.0.pom"
+      val otherPath = "com/example/b/2.0.0/b-2.0.0.pom"
+      writeRepositoryFile(repoDir, jarPath, "jar")
+      writeRepositoryFile(repoDir, pomPath, "pom")
+      writeRepositoryFile(repoDir, otherPath, "other")
+
+      val hashes = unwrap(
+        ArtifactNarHash.hashMissing(
+          repoDir,
+          lock(
+            Vector(
+              lockedFile(jarPath),
+              lockedFile(pomPath),
+              lockedFile(otherPath)
+            )
+          )
+        )
+      )
+
+      val expectedA = tempDir / "expected-a"
+      writeRepositoryFile(expectedA, jarPath, "jar")
+      writeRepositoryFile(expectedA, pomPath, "pom")
+      val expectedB = tempDir / "expected-b"
+      writeRepositoryFile(expectedB, otherPath, "other")
+
+      assert(hashes("com/example/a/1.0.0") == nixHash(expectedA))
+      assert(hashes("com/example/b/2.0.0") == nixHash(expectedB))
+      assert(
+        os.list(repoDir / MavenRepositoryStore.MetadataDirectoryName)
+          .forall(!_.last.startsWith(".nar-hash-"))
+      )
+    }
+
+    test("hashMissing skips finalized artifacts") {
+      val tempDir = os.temp.dir(prefix = "mif-nar-hash-test_")
+      val repoDir = tempDir / "repository"
+      val path = "com/example/a/1.0.0/a-1.0.0.pom"
+      val pending = lock(Vector(lockedFile(path)))
+      val finalized = unwrap(
+        Lock.withArtifactNarHashes(
+          pending,
+          Map("com/example/a/1.0.0" -> Sha256.sri("nar".getBytes("UTF-8")))
+        )
+      )
+
+      assert(
+        ArtifactNarHash.hashMissing(repoDir, finalized) == Right(Map.empty)
+      )
+    }
+
+    test("hashMissing reports a locked file absent from the relay cache") {
+      val tempDir = os.temp.dir(prefix = "mif-nar-hash-test_")
+      val repoDir = tempDir / "repository"
+      val path = "com/example/a/1.0.0/a-1.0.0.pom"
+
+      val result = ArtifactNarHash.hashMissing(
+        repoDir,
+        lock(Vector(lockedFile(path)))
+      )
+      assert(result.left.exists(_.contains(path)))
+      assert(result.left.exists(_.contains("missing")))
+    }
+  }

--- a/mif/test/src/LockTests.scala
+++ b/mif/test/src/LockTests.scala
@@ -222,6 +222,42 @@ object LockTests extends TestSuite:
       assert(parsed.files.head.runs == Vector(mirrorRun.id))
     }
 
+    test("parse reports how to migrate a version 2 lock") {
+      val sha = repoFile("com/example/a/1.0.0/a-1.0.0.pom").sha256
+      val json =
+        s"""{
+           |  "version": 2,
+           |  "kind": "mif-maven-lock",
+           |  "repositories": {
+           |    "central": "https://repo1.maven.org/maven2"
+           |  },
+           |  "runs": {
+           |    "${prepareRun.id}": {
+           |      "repository": "central",
+           |      "command": ["mill", "-i", "__.prepareOffline"]
+           |    }
+           |  },
+           |  "artifacts": {
+           |    "com/example/a/1.0.0": {
+           |      "runs": ["${prepareRun.id}"],
+           |      "files": {
+           |        "a-1.0.0.pom": "${sha}"
+           |      }
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+
+      val result = Lock.parse(json)
+      assert(result.left.exists(_.contains("unsupported lock version 2")))
+      assert(
+        result.left.exists(_.contains("complete archive command sequence"))
+      )
+      assert(
+        result.left.exists(_.contains("--fresh on the first command only"))
+      )
+    }
+
     test("parse rejects malformed JSON and schema violations") {
       val base = unwrap(
         merge(

--- a/mif/test/src/LockTests.scala
+++ b/mif/test/src/LockTests.scala
@@ -29,6 +29,27 @@ object LockTests extends TestSuite:
       case Right(value) => value
       case Left(reason) => throw new java.lang.AssertionError(reason)
 
+  private def artifactHash(dir: String): String =
+    Sha256.sri(dir.getBytes("UTF-8"))
+
+  private def merge(
+      existing: MifLock,
+      upstream: LockRepository,
+      runFiles: Seq[MavenRepositoryFile],
+      command: Seq[String]
+  ): Either[String, MifLock] =
+    Lock
+      .merge(existing, upstream, runFiles, command)
+      .flatMap: lock =>
+        Lock.withArtifactNarHashes(
+          lock,
+          Lock
+            .missingArtifactNarHashes(lock)
+            .map: dir =>
+              dir -> artifactHash(dir)
+            .toMap
+        )
+
   val tests = Tests {
     test("run ids are stable across machines and dedupe identical commands") {
       assert(prepareRun.id == LockRun.idFor(prepareCommand, "central"))
@@ -74,11 +95,11 @@ object LockTests extends TestSuite:
       val jar = repoFile("com/example/foo/1.0.0/foo-1.0.0.jar")
       val pom = repoFile("com/example/foo/1.0.0/foo-1.0.0.pom")
       val lock =
-        unwrap(Lock.merge(Lock.empty, central, Seq(jar, pom), prepareCommand))
+        unwrap(merge(Lock.empty, central, Seq(jar, pom), prepareCommand))
 
       val golden =
         s"""{
-           |  "version": 2,
+           |  "version": 3,
            |  "kind": "mif-maven-lock",
            |  "repositories": {
            |    "central": "https://repo1.maven.org/maven2"
@@ -95,6 +116,7 @@ object LockTests extends TestSuite:
            |  },
            |  "artifacts": {
            |    "com/example/foo/1.0.0": {
+           |      "narHash": "${artifactHash("com/example/foo/1.0.0")}",
            |      "runs": [
            |        "${prepareRun.id}"
            |      ],
@@ -116,11 +138,11 @@ object LockTests extends TestSuite:
       val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
       val forward =
         unwrap(
-          Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
+          merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
         )
       val backward =
         unwrap(
-          Lock.merge(Lock.empty, central, Seq(fileB, fileA), prepareCommand)
+          merge(Lock.empty, central, Seq(fileB, fileA), prepareCommand)
         )
       assert(Lock.render(forward) == Lock.render(backward))
     }
@@ -129,8 +151,8 @@ object LockTests extends TestSuite:
       val pom = repoFile("com/example/foo/1.0.0/foo-1.0.0.pom")
       val jar = repoFile("com/example/foo/1.0.0/foo-1.0.0.jar")
       val first =
-        unwrap(Lock.merge(Lock.empty, central, Seq(pom), prepareCommand))
-      val second = unwrap(Lock.merge(first, central, Seq(jar), assemblyCommand))
+        unwrap(merge(Lock.empty, central, Seq(pom), prepareCommand))
+      val second = unwrap(merge(first, central, Seq(jar), assemblyCommand))
       val parsed = unwrap(Lock.parse(Lock.render(second)))
       val expectedRuns = Vector(prepareRun.id, assemblyRun.id).sorted
 
@@ -149,7 +171,7 @@ object LockTests extends TestSuite:
       )
       val run = LockRun.fromCommand(command, "central")
       val lock = unwrap(
-        Lock.merge(
+        merge(
           Lock.empty,
           central,
           Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
@@ -166,7 +188,7 @@ object LockTests extends TestSuite:
       val mirrorRun = LockRun.fromCommand(prepareCommand, "mirror")
       val json =
         s"""{
-           |  "version": 2,
+           |  "version": 3,
            |  "kind": "mif-maven-lock",
            |  "repositories": {
            |    "central": "https://repo1.maven.org/maven2",
@@ -184,6 +206,7 @@ object LockTests extends TestSuite:
            |  },
            |  "artifacts": {
            |    "com/example/a/1.0.0": {
+           |      "narHash": "${artifactHash("com/example/a/1.0.0")}",
            |      "runs": ["${mirrorRun.id}"],
            |      "files": {
            |        "a-1.0.0.pom": "${sha}"
@@ -201,7 +224,7 @@ object LockTests extends TestSuite:
 
     test("parse rejects malformed JSON and schema violations") {
       val base = unwrap(
-        Lock.merge(
+        merge(
           Lock.empty,
           central,
           Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
@@ -228,9 +251,21 @@ object LockTests extends TestSuite:
       )
       assert(badSha.left.exists(_.contains("invalid sha256")))
 
+      val badNarHash = Lock.parse(
+        renderWith(lock =>
+          lock.copy(artifactNarHashes =
+            lock.artifactNarHashes.view.mapValues(_ => "abc123").toMap
+          )
+        )
+      )
+      assert(badNarHash.left.exists(_.contains("invalid narHash")))
+
       val badPath = Lock.parse(
         renderWith(lock =>
-          lock.copy(files = lock.files.map(_.copy(mavenPath = "com/../a.pom")))
+          lock.copy(
+            files = lock.files.map(_.copy(mavenPath = "com/../a.pom")),
+            artifactNarHashes = Map("com/.." -> artifactHash("com/.."))
+          )
         )
       )
       assert(badPath.left.exists(_.contains("invalid maven path")))
@@ -268,7 +303,7 @@ object LockTests extends TestSuite:
       val tempDir = os.temp.dir(prefix = "mif-lock-test_")
       val lockPath = tempDir / "nested" / "mif.lock.json"
       val lock = unwrap(
-        Lock.merge(
+        merge(
           Lock.empty,
           central,
           Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom")),
@@ -280,7 +315,7 @@ object LockTests extends TestSuite:
       assert(Lock.read(lockPath) == Right(Some(lock)))
 
       val updated = unwrap(
-        Lock.merge(
+        merge(
           lock,
           central,
           Seq(repoFile("com/example/b/1.0.0/b-1.0.0.pom")),
@@ -303,10 +338,10 @@ object LockTests extends TestSuite:
 
       val first =
         unwrap(
-          Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
+          merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
         )
       val second =
-        unwrap(Lock.merge(first, central, Seq(fileB, fileC), assemblyCommand))
+        unwrap(merge(first, central, Seq(fileB, fileC), assemblyCommand))
 
       assert(
         second.files.map(_.mavenPath) == Vector(
@@ -328,9 +363,28 @@ object LockTests extends TestSuite:
 
     test("merge of the same run twice is a no-op") {
       val files = Seq(repoFile("com/example/a/1.0.0/a-1.0.0.pom"))
-      val once = unwrap(Lock.merge(Lock.empty, central, files, prepareCommand))
-      val twice = unwrap(Lock.merge(once, central, files, prepareCommand))
+      val once = unwrap(merge(Lock.empty, central, files, prepareCommand))
+      val twice = unwrap(merge(once, central, files, prepareCommand))
       assert(Lock.render(once) == Lock.render(twice))
+    }
+
+    test("merge reuses narHash until an artifact's contents change") {
+      val pom = repoFile("com/example/a/1.0.0/a-1.0.0.pom")
+      val jar = repoFile("com/example/a/1.0.0/a-1.0.0.jar")
+      val artifactDir = "com/example/a/1.0.0"
+      val first = unwrap(merge(Lock.empty, central, Seq(pom), prepareCommand))
+
+      val metadataOnly = unwrap(
+        Lock.merge(first, central, Seq(pom), assemblyCommand)
+      )
+      assert(metadataOnly.artifactNarHashes == first.artifactNarHashes)
+      assert(Lock.missingArtifactNarHashes(metadataOnly).isEmpty)
+
+      val expanded = unwrap(
+        Lock.merge(first, central, Seq(pom, jar), assemblyCommand)
+      )
+      assert(!expanded.artifactNarHashes.contains(artifactDir))
+      assert(Lock.missingArtifactNarHashes(expanded) == Vector(artifactDir))
     }
 
     test("merge reports every content conflict and keeps the lock untouched") {
@@ -338,7 +392,7 @@ object LockTests extends TestSuite:
       val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
       val existing =
         unwrap(
-          Lock.merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
+          merge(Lock.empty, central, Seq(fileA, fileB), prepareCommand)
         )
 
       val mutatedA = fileA.copy(sha256 = Sha256.sri("other".getBytes("UTF-8")))
@@ -346,7 +400,7 @@ object LockTests extends TestSuite:
         fileB.copy(sha256 = Sha256.sri("other-b".getBytes("UTF-8")))
 
       val result =
-        Lock.merge(existing, central, Seq(mutatedA, mutatedB), assemblyCommand)
+        merge(existing, central, Seq(mutatedA, mutatedB), assemblyCommand)
       result match
         case Right(_) => assert(false)
         case Left(reason) =>
@@ -363,15 +417,15 @@ object LockTests extends TestSuite:
       val fileB = repoFile("com/example/b/1.0.0/b-1.0.0.pom")
 
       val first =
-        unwrap(Lock.merge(Lock.empty, central, Seq(fileA), prepareCommand))
+        unwrap(merge(Lock.empty, central, Seq(fileA), prepareCommand))
       // Same url: entry reused, no duplicate repository.
       val reused =
-        unwrap(Lock.merge(first, central, Seq(fileB), assemblyCommand))
+        unwrap(merge(first, central, Seq(fileB), assemblyCommand))
       assert(reused.repositories == first.repositories)
 
       // Different url wanting the same id: suffixed instead of clobbered.
       val suffixed =
-        unwrap(Lock.merge(first, mirror, Seq(fileB), assemblyCommand))
+        unwrap(merge(first, mirror, Seq(fileB), assemblyCommand))
       assert(
         suffixed.repositories.map(_.id) == Vector("central", "central-2")
       )

--- a/nix/mill-ivy-fetcher/maven-repository.nix
+++ b/nix/mill-ivy-fetcher/maven-repository.nix
@@ -78,7 +78,7 @@ let
         runCommand "mif-maven-artifact-${lib.strings.sanitizeDerivationName dir}"
           {
             nativeBuildInputs = [ curl ];
-            SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+            impureEnvVars = lib.fetchers.proxyImpureEnvVars;
             outputHash = narHash;
             outputHashAlgo = "sha256";
             outputHashMode = "recursive";
@@ -86,6 +86,7 @@ let
             passthru.mavenPath = dir;
           }
           ''
+            export SSL_CERT_FILE="''${NIX_SSL_CERT_FILE:-${cacert}/etc/ssl/certs/ca-bundle.crt}"
             mavenDir=${lib.escapeShellArg dir}
             install -d -m755 "$out/$mavenDir"
             ${downloadFiles}

--- a/nix/mill-ivy-fetcher/maven-repository.nix
+++ b/nix/mill-ivy-fetcher/maven-repository.nix
@@ -1,5 +1,6 @@
 {
-  fetchurl,
+  cacert,
+  curl,
   lib,
   runCommand,
   symlinkJoin,
@@ -19,7 +20,7 @@ let
         "name"
       ];
 
-      hasSchema = (lock.version or null) == 2 && (lock.kind or null) == "mif-maven-lock";
+      hasSchema = (lock.version or null) == 3 && (lock.kind or null) == "mif-maven-lock";
 
       trimTrailingSlash = url: lib.removeSuffix "/" url;
 
@@ -44,43 +45,56 @@ let
         in
         lock.repositories.${repository} or (throw "unknown MIF repository id '${repository}'");
 
-      fetchArtifact =
-        dir: repositoryUrl: fileName: sha256:
-        let
-          mavenPath = "${dir}/${fileName}";
-        in
-        runCommand "mif-artifact-${lib.strings.sanitizeDerivationName mavenPath}"
-          {
-            artifact = fetchurl {
-              name = baseNameOf mavenPath;
-              url = "${trimTrailingSlash repositoryUrl}/${mavenPath}";
-              hash = sha256;
-            };
-            inherit mavenPath;
-            preferLocalBuild = true;
-          }
-          ''
-            install -Dm444 "$artifact" "$out/$mavenPath"
-          '';
-
-      mkMavenArtifact =
+      fetchMavenArtifact =
         dir: artifact:
         let
           repositoryUrl = artifactRepositoryUrl artifact;
           files = artifact.files or (throw "MIF artifact '${dir}' does not define files");
+          narHash = artifact.narHash or (throw "MIF artifact '${dir}' does not define narHash");
+          downloadFiles = lib.concatMapStringsSep "\n" (
+            fileName:
+            let
+              mavenPath = "${dir}/${fileName}";
+              url = "${trimTrailingSlash repositoryUrl}/${mavenPath}";
+            in
+            ''
+              fileName=${lib.escapeShellArg fileName}
+              curl \
+                --fail \
+                --location \
+                --retry 3 \
+                --retry-all-errors \
+                --silent \
+                --show-error \
+                --output "$out/$mavenDir/$fileName" \
+                ${lib.escapeShellArg url}
+              chmod 0444 "$out/$mavenDir/$fileName"
+            ''
+          ) (builtins.attrNames files);
         in
-        symlinkJoin {
-          name = "mif-maven-artifact-${lib.strings.sanitizeDerivationName dir}";
-          paths = lib.mapAttrsToList (fetchArtifact dir repositoryUrl) files;
-          passthru = {
-            mavenPath = dir;
-          };
-        };
+        # Download the whole Maven coordinate in one fixed-output derivation.
+        # Nix verifies the recursive NAR hash; the per-file hashes remain in the
+        # lock for review and diagnostics.
+        runCommand "mif-maven-artifact-${lib.strings.sanitizeDerivationName dir}"
+          {
+            nativeBuildInputs = [ curl ];
+            SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+            outputHash = narHash;
+            outputHashAlgo = "sha256";
+            outputHashMode = "recursive";
+            preferLocalBuild = false;
+            passthru.mavenPath = dir;
+          }
+          ''
+            mavenDir=${lib.escapeShellArg dir}
+            install -d -m755 "$out/$mavenDir"
+            ${downloadFiles}
+          '';
 
-      defaultArtifacts = lib.mapAttrs mkMavenArtifact lock.artifacts;
+      defaultArtifacts = lib.mapAttrs fetchMavenArtifact lock.artifacts;
       artifacts = defaultArtifacts // artifactOverrides;
     in
-    assert lib.assertMsg hasSchema "${toString lockFile} is not a version 2 mif-maven-lock file";
+    assert lib.assertMsg hasSchema "${toString lockFile} is not a version 3 mif-maven-lock file";
     symlinkJoin {
       inherit name;
       paths = builtins.attrValues artifacts;

--- a/package.nix
+++ b/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   mkMavenRepository,
   millVersions,
+  nix,
   stdenvNoCC,
   zulu,
 }:
@@ -15,11 +16,12 @@ let
   # dependency from here, fully offline.
   m2 = mkMavenRepository { lockFile = ./mif.lock.json; };
 
-  wrapperPathArgs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+  runtimePath = [ nix ] ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ bubblewrap ];
+  wrapperPathArgs = [
     "--prefix"
     "PATH"
     ":"
-    (lib.makeBinPath [ bubblewrap ])
+    (lib.makeBinPath runtimePath)
   ];
 in
 stdenvNoCC.mkDerivation (finalAttrs: {

--- a/readme.md
+++ b/readme.md
@@ -121,9 +121,11 @@ and keep dependency repositories within the configured MIF upstream.
 
 ## Using a lock from Nix
 
-The overlay exposes `mkMavenRepository`, which reads `mif.lock.json`, fetches all
-locked files with fixed-output `fetchurl` derivations, and joins them into a
-standard Maven repository layout.
+The overlay exposes `mkMavenRepository`, which reads `mif.lock.json`, fetches each
+locked Maven artifact as one recursive fixed-output derivation, and joins them
+into a standard Maven repository layout. This keeps the cache reusable at Maven
+dependency granularity without creating a separate Nix derivation for every
+JAR, POM, and checksum file.
 
 ```nix
 { pkgs, ... }:
@@ -231,7 +233,7 @@ A lock has this shape:
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "kind": "mif-maven-lock",
   "repositories": {
     "central": "https://repo1.maven.org/maven2"
@@ -244,6 +246,7 @@ A lock has this shape:
   },
   "artifacts": {
     "com/example/foo/1.0.0": {
+      "narHash": "sha256-9kgpv3fh7yGNCmQlq8WZ7noBDsiUt2TuwTQa8i3pYpA=",
       "runs": ["ee52a000ca94"],
       "files": {
         "foo-1.0.0.jar": "sha256-DAOEyJEjhkDsWJUAJ4xVSFcQqai/38MDdTuIovpi6MA="
@@ -254,11 +257,15 @@ A lock has this shape:
 ```
 
 Archive runs append: run `mif archive` once per target and the lock unions the
-results. Entries are sorted, re-running a command against the same repository is
-a no-op, and each artifact records the run ids that requested it. If an already
-locked path comes back with different content, archive refuses to update the lock
-and reports the mismatched paths; investigate the upstream mutation or rebuild
-deliberately with `--fresh` into a clean `--repo-dir`.
+results. MIF uses `nix hash path` to record the recursive NAR hash of every
+artifact directory. Entries are sorted, re-running a command against the same
+repository is a no-op, and each artifact records the run ids that requested it.
+If an already locked path comes back with different content, archive refuses to
+update the lock and reports the mismatched paths; investigate the upstream
+mutation or rebuild deliberately with `--fresh` into a clean `--repo-dir`.
+
+Schema version 3 introduced artifact NAR hashes. Regenerate older locks with
+`mif archive --fresh` before using them with the current `mkMavenRepository`.
 
 ### `mif relay`
 

--- a/readme.md
+++ b/readme.md
@@ -264,8 +264,10 @@ If an already locked path comes back with different content, archive refuses to
 update the lock and reports the mismatched paths; investigate the upstream
 mutation or rebuild deliberately with `--fresh` into a clean `--repo-dir`.
 
-Schema version 3 introduced artifact NAR hashes. Regenerate older locks with
-`mif archive --fresh` before using them with the current `mkMavenRepository`.
+Schema version 3 introduced artifact NAR hashes. Regenerate older locks by
+rerunning the complete archive command sequence. Use `--fresh` on the first
+invocation only, then append every subsequent target without it before using
+the lock with the current `mkMavenRepository`.
 
 The relay still captures files individually. Maven clients request a JAR, POM,
 checksum, parent POM, or BOM as independent HTTP paths, and while the build is

--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,15 @@ mutation or rebuild deliberately with `--fresh` into a clean `--repo-dir`.
 Schema version 3 introduced artifact NAR hashes. Regenerate older locks with
 `mif archive --fresh` before using them with the current `mkMavenRepository`.
 
+The relay still captures files individually. Maven clients request a JAR, POM,
+checksum, parent POM, or BOM as independent HTTP paths, and while the build is
+running the relay cannot know whether another file for the same coordinate will
+be requested. After the command and relay stop, MIF groups the captured files by
+their containing Maven coordinate directory and computes that directory's NAR
+hash. In this context, an “artifact” is the fixed-output fetch unit represented
+by one Maven repository directory; it does not imply that the relay observed a
+single dependency-resolution event.
+
 ### `mif relay`
 
 `mif relay` starts the Maven-compatible relay manually. This is mainly useful for


### PR DESCRIPTION
## Summary

- group all files in a Maven coordinate into one recursive fixed-output derivation
- calculate artifact NAR hashes with nix hash path after relay capture completes
- preserve the file-oriented relay model while storing one NAR hash per artifact directory
- migrate the repository and Chisel integration locks to schema version 3
- document why grouping happens only after the relay stops

## Review follow-ups

- preserve proxy variables and NIX_SSL_CERT_FILE for sandboxed artifact downloads
- reject obsolete locks before starting an expensive archive build and provide multi-run migration instructions
- snapshot cached files and verify their SHA-256 before computing the directory NAR hash
- add regression coverage for lock migration, cache mutation, and the Nix fetch environment

## Performance

The grouped layout reduces recursive derivations from 2,838 to 785 for this repository and from 5,350 to 1,085 for the Chisel integration lock.

## Validation

- mill --no-daemon mif.test
- nix flake check --no-build
- nix build .#mif --no-link
- nix build .#mif-maven-repository --no-link
- nix build .#checks.x86_64-linux.maven-fetch-environment --no-link